### PR TITLE
Multiproject builds - org.gradle.api.InvalidUserDataException: Cannot add task ':subproj:decompile' as a task with that name already exists.

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
@@ -22,7 +22,7 @@ import org.gradle.testfixtures.ProjectBuilder;
 
 public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Project>
 {
-    public static Project project;
+    public Project project;
 
     @Override
     public final void apply(Project arg)

--- a/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ArtifactSpec.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ArtifactSpec.java
@@ -5,11 +5,10 @@ import groovy.lang.Closure;
 import java.io.File;
 
 import joptsimple.internal.Strings;
-import net.minecraftforge.gradle.common.BasePlugin;
 
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
-
+import org.gradle.api.Project;
 import com.google.common.io.Files;
 
 public class ArtifactSpec
@@ -22,34 +21,41 @@ public class ArtifactSpec
     private Object  archiveName;
     private Object  classpath;
 
+    private Project project;
+
     private boolean archiveSet = false;
 
-    public ArtifactSpec()
+    public ArtifactSpec(Project proj)
     {
+        project = proj;
     }
 
-    public ArtifactSpec(File file)
+    public ArtifactSpec(File file, Project proj)
     {
         archiveName = file.getName();
         extension = Files.getFileExtension(file.getName());
+        project = proj;
     }
 
-    public ArtifactSpec(String file)
+    public ArtifactSpec(String file, Project proj)
     {
         archiveName = file;
         extension = Files.getFileExtension(file);
+        project = proj;
     }
 
-    public ArtifactSpec(PublishArtifact artifact)
+    public ArtifactSpec(PublishArtifact artifact, Project proj)
     {
         baseName = artifact.getName();
         classifier = artifact.getClassifier();
         extension = artifact.getExtension();
+        project = proj;
     }
 
     @SuppressWarnings({ "serial", "rawtypes" })
     public ArtifactSpec(final AbstractArchiveTask task)
     {
+        project = task.getProject();
         baseName = new Closure(null) { public Object call() {return task.getBaseName();} };
         appendix = new Closure(null) { public Object call() {return task.getAppendix();} };
         version = new Closure(null) { public Object call() {return task.getVersion();} };
@@ -111,7 +117,7 @@ public class ArtifactSpec
     public Object getClasspath()
     {
         if (classpath == null)
-            classpath = BasePlugin.project.files((Object)new String[] {});
+            classpath = project.files((Object)new String[] {});
         return classpath;
     }
 
@@ -153,7 +159,7 @@ public class ArtifactSpec
 
         // resolve classpath
         if (classpath != null)
-            classpath = BasePlugin.project.files(classpath);
+            classpath = project.files(classpath);
 
         // skip if its already been set by the user.
         if (archiveSet)

--- a/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
@@ -77,7 +77,7 @@ public class ReobfTask extends DefaultTask
             }
 
             dependsOn((AbstractArchiveTask) task);
-            addArtifact(new ObfArtifact(new DelayedThingy(task), new ArtifactSpec(), this));
+            addArtifact(new ObfArtifact(new DelayedThingy(task), new ArtifactSpec(getProject()), this));
         }
     }
     
@@ -91,7 +91,7 @@ public class ReobfTask extends DefaultTask
      */
     public void reobf(PublishArtifact publishArtifact, Closure<Object> artifactSpec)
     {
-        ArtifactSpec spec = new ArtifactSpec(publishArtifact);
+        ArtifactSpec spec = new ArtifactSpec(publishArtifact, getProject());
         artifactSpec.call(spec);
 
         dependsOn(publishArtifact);
@@ -106,7 +106,7 @@ public class ReobfTask extends DefaultTask
         for (PublishArtifact publishArtifact : publishArtifacts)
         {
             dependsOn(publishArtifact);
-            addArtifact(new ObfArtifact(publishArtifact, new ArtifactSpec(publishArtifact), this));
+            addArtifact(new ObfArtifact(publishArtifact, new ArtifactSpec(publishArtifact, getProject()), this));
         }
     }
     
@@ -120,7 +120,7 @@ public class ReobfTask extends DefaultTask
      */
     public void reobf(File file, Closure<Object> artifactSpec)
     {
-        ArtifactSpec spec = new ArtifactSpec(file);
+        ArtifactSpec spec = new ArtifactSpec(file, getProject());
         artifactSpec.call(spec);
 
         addArtifact(new ObfArtifact(file, spec, this));
@@ -133,7 +133,7 @@ public class ReobfTask extends DefaultTask
     {
         for (File file : files)
         {
-            addArtifact(new ObfArtifact(file, new ArtifactSpec(file), this));
+            addArtifact(new ObfArtifact(file, new ArtifactSpec(file, getProject()), this));
         }
     }
 


### PR DESCRIPTION
Seems to be caused by BasePlugin.project being static and trying to create that all it's tasks in the same project multiple times.

I've tried changing it to a normal field and it seems to at least let the build run, currently testing if it broke anything, will send a PR once i'm sure.

Full error:

```
* Exception is:
org.gradle.api.ProjectConfigurationException: A problem occurred configuring root project 'gendustry2'.
    at org.gradle.configuration.project.LifecycleProjectEvaluator.addConfigurationFailure(LifecycleProjectEvaluator.java:79)
    at org.gradle.configuration.project.LifecycleProjectEvaluator.notifyAfterEvaluate(LifecycleProjectEvaluator.java:74)
    at org.gradle.configuration.project.LifecycleProjectEvaluator.evaluate(LifecycleProjectEvaluator.java:61)
    at org.gradle.api.internal.project.AbstractProject.evaluate(AbstractProject.java:507)
    at org.gradle.api.internal.project.AbstractProject.evaluate(AbstractProject.java:82)
    at org.gradle.configuration.DefaultBuildConfigurer.configure(DefaultBuildConfigurer.java:31)
    at org.gradle.initialization.DefaultGradleLauncher.doBuildStages(DefaultGradleLauncher.java:142)
    at org.gradle.initialization.DefaultGradleLauncher.doBuild(DefaultGradleLauncher.java:113)
    at org.gradle.initialization.DefaultGradleLauncher.run(DefaultGradleLauncher.java:81)
    at org.gradle.launcher.exec.InProcessBuildActionExecuter$DefaultBuildController.run(InProcessBuildActionExecuter.java:64)
    at org.gradle.launcher.cli.ExecuteBuildAction.run(ExecuteBuildAction.java:33)
    at org.gradle.launcher.cli.ExecuteBuildAction.run(ExecuteBuildAction.java:24)
    at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:35)
    at org.gradle.launcher.exec.InProcessBuildActionExecuter.execute(InProcessBuildActionExecuter.java:26)
    at org.gradle.launcher.cli.RunBuildAction.run(RunBuildAction.java:50)
    at org.gradle.api.internal.Actions$RunnableActionAdapter.execute(Actions.java:171)
    at org.gradle.launcher.cli.CommandLineActionFactory$ParseAndBuildAction.execute(CommandLineActionFactory.java:201)
    at org.gradle.launcher.cli.CommandLineActionFactory$ParseAndBuildAction.execute(CommandLineActionFactory.java:174)
    at org.gradle.launcher.cli.CommandLineActionFactory$WithLogging.execute(CommandLineActionFactory.java:170)
    at org.gradle.launcher.cli.CommandLineActionFactory$WithLogging.execute(CommandLineActionFactory.java:139)
    at org.gradle.launcher.cli.ExceptionReportingAction.execute(ExceptionReportingAction.java:33)
    at org.gradle.launcher.cli.ExceptionReportingAction.execute(ExceptionReportingAction.java:22)
    at org.gradle.launcher.Main.doAction(Main.java:46)
    at org.gradle.launcher.bootstrap.EntryPoint.run(EntryPoint.java:45)
    at org.gradle.launcher.Main.main(Main.java:37)
    at org.gradle.launcher.bootstrap.ProcessBootstrap.runNoExit(ProcessBootstrap.java:50)
    at org.gradle.launcher.bootstrap.ProcessBootstrap.run(ProcessBootstrap.java:32)
    at org.gradle.launcher.GradleMain.main(GradleMain.java:23)
    at org.gradle.wrapper.BootstrapMainStarter.start(BootstrapMainStarter.java:30)
    at org.gradle.wrapper.WrapperExecutor.execute(WrapperExecutor.java:127)
    at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:58)
Caused by: org.gradle.api.InvalidUserDataException: Cannot add task ':bdlib:decompile' as a task with that name already exists.
    at org.gradle.api.internal.tasks.DefaultTaskContainer.create(DefaultTaskContainer.java:60)
    at org.gradle.api.internal.project.AbstractProject.task(AbstractProject.java:950)
    at net.minecraftforge.gradle.common.BasePlugin.makeTask(BasePlugin.java:153)
    at net.minecraftforge.gradle.common.BasePlugin.makeTask(BasePlugin.java:144)
    at net.minecraftforge.gradle.user.UserBasePlugin.delayedTasks(UserBasePlugin.java:204)
    at net.minecraftforge.gradle.user.UserBasePlugin.afterEvaluate(UserBasePlugin.java:667)
    at net.minecraftforge.gradle.user.ForgeUserPlugin.afterEvaluate(ForgeUserPlugin.java:45)
    at net.minecraftforge.gradle.common.BasePlugin$1.execute(BasePlugin.java:52)
    at net.minecraftforge.gradle.common.BasePlugin$1.execute(BasePlugin.java:48)
    at org.gradle.listener.BroadcastDispatch$ActionInvocationHandler.dispatch(BroadcastDispatch.java:105)
    at org.gradle.listener.BroadcastDispatch$ActionInvocationHandler.dispatch(BroadcastDispatch.java:94)
    at org.gradle.listener.BroadcastDispatch.dispatch(BroadcastDispatch.java:79)
    at org.gradle.listener.BroadcastDispatch.dispatch(BroadcastDispatch.java:31)
    at org.gradle.messaging.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
    at com.sun.proxy.$Proxy13.afterEvaluate(Unknown Source)
    at org.gradle.configuration.project.LifecycleProjectEvaluator.notifyAfterEvaluate(LifecycleProjectEvaluator.java:67)
    ... 29 more
```
