### PR TITLE
SourceCopyTask should respect includes/excludes on the sources

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/tasks/user/SourceCopyTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/user/SourceCopyTask.java
@@ -20,6 +20,7 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
+import org.gradle.api.tasks.util.PatternSet;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
@@ -44,7 +45,12 @@ public class SourceCopyTask extends DefaultTask
         getLogger().info("INPUTS >> " + source );
         getLogger().info("OUTPUTS >> " + getOutput() );
         getLogger().info("REPLACE >> " + replacements );
-        
+
+        // get the include/exclude patterns from the source (this is different than what's returned by getFilter)
+        PatternSet patterns = new PatternSet();
+        patterns.setIncludes(source.getIncludes());
+        patterns.setExcludes(source.getExcludes());
+
         // get output
         File out = getOutput();
         if (out.exists())
@@ -64,9 +70,11 @@ public class SourceCopyTask extends DefaultTask
                 continue;
             else
                 dir = dir.getCanonicalFile();
-            
-            FileTree tree = getProject().fileTree(dir).matching(source.getFilter());
-            
+
+            // this could be written as .matching(source), but it doesn't actually work
+            // because later on gradle casts it directly to PatternSet and crashes
+            FileTree tree = getProject().fileTree(dir).matching(source.getFilter()).matching(patterns);
+
             for (File file : tree)
             {
                 if (!isIncluded(file))


### PR DESCRIPTION
I probably didn't explain too well what's going on...

SourceDirectorySet has 2 PatternSet's, filter and patterns.

Filter contains some default filter added by the language plugin (so for java it's something like "*_/_.java" by default), that's the one you apply in current code.

Patterns is empty by default, when you add includes/excludes in sourceSets, they go there. That's what my patch adds to SourceCopyTask.

In my patch i'm constructing a new PatternSet from those patterns because the field that holds them is private and not exposed via the gradle API. Looking at gradle source it looks like it's meant to use the SourceDirectorySet object itself which implements the PatternFilterable interface (using that second PatternSet) but it doesn't work with FileTree.matching() because later gradle tries to cast it directly to PatternSet instead of using the interface and crashes.
