### PR TITLE
IDEA workspace configuration NPE on subprojects

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -454,24 +454,28 @@ public abstract class UserBasePlugin extends BasePlugin<UserExtension>
             }
         });
 
-        ideaConv.getWorkspace().getIws().withXml(new Closure<Object>(this, null)
-        {
-            public Object call(Object... obj)
+        if (ideaConv.getWorkspace().getIws() != null) {
+            ideaConv.getWorkspace().getIws().withXml(new Closure<Object>(this, null)
             {
-                Element root = ((XmlProvider) this.getDelegate()).asElement();
-                Document doc = root.getOwnerDocument();
-                try
+                public Object call(Object... obj)
                 {
-                    injectIntellijRuns(doc, project.getProjectDir().getCanonicalPath());
-                }
-                catch (Exception e)
-                {
-                    e.printStackTrace();
-                }
+                    Element root = ((XmlProvider) this.getDelegate()).asElement();
+                    Document doc = root.getOwnerDocument();
+                    try
+                    {
+                        injectIntellijRuns(doc, project.getProjectDir().getCanonicalPath());
+                    }
+                    catch (Exception e)
+                    {
+                        e.printStackTrace();
+                    }
 
-                return null;
-            }
-        });
+                    return null;
+                }
+            });
+        } else {
+            project.getLogger().warn(String.format("subproject %s has no IDEA workspace, skipping configuration",project.getName()));
+        }
     }
 
     public final void injectIntellijRuns(Document doc, String module) throws DOMException, IOException


### PR DESCRIPTION
Looks like IdeaWorkspace.getIws() returns null on subprojects, causing an NPE

```
22:21:58.456 [ERROR] [org.gradle.BuildExceptionReporter] Caused by: java.lang.NullPointerException
22:21:58.460 [ERROR] [org.gradle.BuildExceptionReporter]    at net.minecraftforge.gradle.user.UserBasePlugin.configureIntellij(UserBasePlugin.java:457)
22:21:58.464 [ERROR] [org.gradle.BuildExceptionReporter]    at net.minecraftforge.gradle.user.UserBasePlugin.applyPlugin(UserBasePlugin.java:92)
22:21:58.468 [ERROR] [org.gradle.BuildExceptionReporter]    at net.minecraftforge.gradle.user.ForgeUserPlugin.applyPlugin(ForgeUserPlugin.java:21)
22:21:58.471 [ERROR] [org.gradle.BuildExceptionReporter]    at net.minecraftforge.gradle.common.BasePlugin.apply(BasePlugin.java:89)
22:21:58.475 [ERROR] [org.gradle.BuildExceptionReporter]    at net.minecraftforge.gradle.common.BasePlugin.apply(BasePlugin.java:34)
22:21:58.479 [ERROR] [org.gradle.BuildExceptionReporter]    at org.gradle.api.internal.plugins.DefaultPluginContainer.providePlugin(DefaultPluginContainer.java:104)
22:21:58.483 [ERROR] [org.gradle.BuildExceptionReporter]    at org.gradle.api.internal.plugins.DefaultPluginContainer.addPluginInternal(DefaultPluginContainer.java:68)
22:21:58.487 [ERROR] [org.gradle.BuildExceptionReporter]    at org.gradle.api.internal.plugins.DefaultPluginContainer.apply(DefaultPluginContainer.java:34)
22:21:58.491 [ERROR] [org.gradle.BuildExceptionReporter]    at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.applyPlugin(DefaultObjectConfigurationAction.java:101)
22:21:58.494 [ERROR] [org.gradle.BuildExceptionReporter]    at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.access$200(DefaultObjectConfigurationAction.java:32)
22:21:58.503 [ERROR] [org.gradle.BuildExceptionReporter]    at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction$3.run(DefaultObjectConfigurationAction.java:72)
22:21:58.507 [ERROR] [org.gradle.BuildExceptionReporter]    at org.gradle.api.internal.plugins.DefaultObjectConfigurationAction.execute(DefaultObjectConfigurationAction.java:114)
22:21:58.511 [ERROR] [org.gradle.BuildExceptionReporter]    at org.gradle.api.internal.project.AbstractPluginAware.apply(AbstractPluginAware.java:39)
22:21:58.515 [ERROR] [org.gradle.BuildExceptionReporter]    at org.gradle.api.Project$apply.call(Unknown Source)
22:21:58.519 [ERROR] [org.gradle.BuildExceptionReporter]    at org.gradle.api.internal.project.ProjectScript.apply(ProjectScript.groovy:34)
22:21:58.523 [ERROR] [org.gradle.BuildExceptionReporter]    at org.gradle.api.Script$apply.callCurrent(Unknown Source)
22:21:58.527 [ERROR] [org.gradle.BuildExceptionReporter]    at build_1gomvr57rgu2r8v9689gne7abe.run(D:\mcmodding\gradle\gendustry\deps\build.gradle:17)
22:21:58.530 [ERROR] [org.gradle.BuildExceptionReporter]    at org.gradle.groovy.scripts.internal.DefaultScriptRunnerFactory$ScriptRunnerImpl.run(DefaultScriptRunnerFactory.java:52)
22:21:58.534 [ERROR] [org.gradle.BuildExceptionReporter]    ... 78 more
```
