### PR TITLE
BSD support

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/common/Constants.java
+++ b/src/main/java/net/minecraftforge/gradle/common/Constants.java
@@ -137,7 +137,7 @@ public class Constants
         {
             return OperatingSystem.OSX;
         }
-        else if (name.contains("linux") || name.contains("unix"))
+        else if (name.contains("linux") || name.contains("unix") || name.contains("bsd"))
         {
             return OperatingSystem.LINUX;
         }

--- a/src/main/java/net/minecraftforge/gradle/common/version/OS.java
+++ b/src/main/java/net/minecraftforge/gradle/common/version/OS.java
@@ -4,7 +4,7 @@ import java.util.Locale;
 
 public enum OS
 {
-    LINUX("linux", "linux", "unix"), 
+    LINUX("linux", "unix", "bsd"),
     WINDOWS("windows", "win" ), 
     OSX("osx", "mac" ), 
     UNKNOWN("unknown");


### PR DESCRIPTION
This has been tested on FreeBSD 9.1.

If you try to build on FreeBSD without these changes you will get the error [`You must set the Minecraft Version!`](http://pastebin.com/raw.php?i=KxuFgb9M)
