### PR TITLE
Fixed "Task with name 'deobfuscateJar' not found in root project" in multi-project build

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -110,7 +110,7 @@ public abstract class UserBasePlugin extends BasePlugin<UserExtension>
                 p.afterEvaluate(new Action<Project>() {
                     public void execute(Project proj)
                     {
-                        ProcessJarTask deobf = (ProcessJarTask) proj.getRootProject().getTasks().getByName("deobfuscateJar");
+                        ProcessJarTask deobf = (ProcessJarTask) proj.getTasks().getByName("deobfuscateJar");
                         final String repoDir = delayedFile(deobf.isClean() ? getCacheDir() : DIRTY_DIR).call().getAbsolutePath();
                         addFlatRepo(proj, "forgeFlatRepo", repoDir);
                         proj.getLogger().info("Adding repo to " + proj.getPath() + " >> " +repoDir);


### PR DESCRIPTION
```
A problem occurred configuring project ':mod'.
> Task with name 'deobfuscateJar' not found in root project 'testProject'.
```

Stacktrace:

```
org.gradle.api.ProjectConfigurationException: A problem occurred configuring project ':mod'.
        at org.gradle.configuration.project.LifecycleProjectEvaluator.addConfigurationFailure(LifecycleProjectEvaluator.java:79)
...
Caused by: org.gradle.api.UnknownTaskException: Task with name 'deobfuscateJar' not found in root project 'testProject'.
        at org.gradle.api.internal.tasks.DefaultTaskCollection.createNotFoundException(DefaultTaskCollection.java:85)
        at org.gradle.api.internal.DefaultNamedDomainObjectCollection.getByName(DefaultNamedDomainObjectCollection.java:192)
        at org.gradle.api.internal.tasks.DefaultTaskCollection.getByName(DefaultTaskCollection.java:34)
        at net.minecraftforge.gradle.user.UserBasePlugin$1$1.execute(UserBasePlugin.java:113)
```
