### PR TITLE
made methodsCsv and fieldsCsv consistent, ignored additional idea files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,5 +17,6 @@ bin
 out
 *.idea
 *.iml
-
+*.ipr
+*.iws
 /repo/

--- a/src/main/java/net/minecraftforge/gradle/tasks/GenSrgTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/GenSrgTask.java
@@ -84,18 +84,18 @@ public class GenSrgTask extends CachedTask
         
     }
     
-    private static void readCSVs(File methodCsv, File fieldCsv, Map<String, String> methodMap, Map<String, String> fieldMap) throws IOException
+    private static void readCSVs(File methodsCsv, File fieldsCsv, Map<String, String> methodMap, Map<String, String> fieldMap) throws IOException
     {
         
         // read methods
-        CSVReader csvReader = RemapSourcesTask.getReader(methodCsv);
+        CSVReader csvReader = RemapSourcesTask.getReader(methodsCsv);
         for (String[] s : csvReader.readAll())
         {
             methodMap.put(s[0], s[1]);
         }
 
         // read fields
-        csvReader = RemapSourcesTask.getReader(fieldCsv);
+        csvReader = RemapSourcesTask.getReader(fieldsCsv);
         for (String[] s : csvReader.readAll())
         {
             fieldMap.put(s[0], s[1]);

--- a/src/main/java/net/minecraftforge/gradle/tasks/ProcessJarTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/ProcessJarTask.java
@@ -63,10 +63,10 @@ public class ProcessJarTask extends CachedTask
 {
     @InputFile
     @Optional
-    private DelayedFile            fieldCsv;
+    private DelayedFile            fieldsCsv;
     @InputFile
     @Optional
-    private DelayedFile            methodCsv;
+    private DelayedFile            methodsCsv;
 
     @InputFile
     private DelayedFile            inJar;
@@ -168,7 +168,7 @@ public class ProcessJarTask extends CachedTask
         mapping.loadMappings(srg);
 
         final Map<String, String> renames = Maps.newHashMap();
-        for (File f : new File[]{ getFieldCsv(), getMethodCsv() })
+        for (File f : new File[]{ getFieldsCsv(), getMethodsCsv() })
         {
             if (f == null) continue;
             Files.readLines(f, Charsets.UTF_8, new LineProcessor<String>()
@@ -516,24 +516,24 @@ public class ProcessJarTask extends CachedTask
         return getProject().files(ats.toArray());
     }
 
-    public File getFieldCsv()
+    public File getFieldsCsv()
     {
-        return fieldCsv == null ? null : fieldCsv.call();
+        return fieldsCsv == null ? null : fieldsCsv.call();
     }
 
-    public void setFieldCsv(DelayedFile fieldCsv)
+    public void setFieldsCsv(DelayedFile fieldsCsv)
     {
-        this.fieldCsv = fieldCsv;
+        this.fieldsCsv = fieldsCsv;
     }
 
-    public File getMethodCsv()
+    public File getMethodsCsv()
     {
-        return methodCsv == null ? null : methodCsv.call();
+        return methodsCsv == null ? null : methodsCsv.call();
     }
 
-    public void setMethodCsv(DelayedFile methodCsv)
+    public void setMethodsCsv(DelayedFile methodsCsv)
     {
-        this.methodCsv = methodCsv;
+        this.methodsCsv = methodsCsv;
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
@@ -46,11 +46,11 @@ public class ReobfTask extends DefaultTask
 
     @Optional
     @InputFile
-    private DelayedFile                               fieldCsv;
+    private DelayedFile                               fieldsCsv;
 
     @Optional
     @InputFile
-    private DelayedFile                               methodCsv;
+    private DelayedFile                               methodsCsv;
 
     @Optional
     @InputFile
@@ -308,8 +308,8 @@ public class ReobfTask extends DefaultTask
         exc.deobfJar = getDeobfFile();
         exc.toReobfJar = getRecompFile();
         exc.excConfig = getExceptorCfg();
-        exc.fieldCSV = getFieldCsv();
-        exc.methodCSV = getMethodCsv();
+        exc.fieldCSV = getFieldsCsv();
+        exc.methodCSV = getMethodsCsv();
 
         exc.doFirstThings();
 
@@ -457,24 +457,24 @@ public class ReobfTask extends DefaultTask
         this.srg = new DelayedFile(getProject(), UserConstants.REOBF_NOTCH_SRG, ((UserExtension)getProject().getExtensions().getByName(Constants.EXT_NAME_MC)).plugin);
     }
 
-    public File getFieldCsv()
+    public File getFieldsCsv()
     {
-        return fieldCsv == null ? null : fieldCsv.call();
+        return fieldsCsv == null ? null : fieldsCsv.call();
     }
 
-    public void setFieldCsv(DelayedFile fieldCsv)
+    public void setFieldsCsv(DelayedFile fieldsCsv)
     {
-        this.fieldCsv = fieldCsv;
+        this.fieldsCsv = fieldsCsv;
     }
 
-    public File getMethodCsv()
+    public File getMethodsCsv()
     {
-        return methodCsv == null ? null : methodCsv.call();
+        return methodsCsv == null ? null : methodsCsv.call();
     }
 
-    public void setMethodCsv(DelayedFile methodCsv)
+    public void setMethodsCsv(DelayedFile methodsCsv)
     {
-        this.methodCsv = methodCsv;
+        this.methodsCsv = methodsCsv;
     }
 
     public DefaultDomainObjectSet<ObfArtifact> getObfOutput()

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -617,8 +617,8 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
             task.setSrg(delayedFile(DEOBF_MCP_SRG));
             task.setExceptorJson(delayedFile(EXC_JSON));
             task.setExceptorCfg(delayedFile(EXC_MCP));
-            task.setFieldCsv(delayedFile(FIELD_CSV));
-            task.setMethodCsv(delayedFile(METHOD_CSV));
+            task.setFieldsCsv(delayedFile(FIELD_CSV));
+            task.setMethodsCsv(delayedFile(METHOD_CSV));
             task.setInJar(delayedFile(JAR_MERGED));
             task.setOutCleanJar(delayedFile("{API_CACHE_DIR}/" + name));
             task.setOutDirtyJar(delayedFile(DIRTY_DIR + "/" + name));
@@ -648,8 +648,8 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
             task.dependsOn("genSrgs");
             task.setExceptorCfg(delayedFile(EXC_SRG));
             task.setSrg(delayedFile(REOBF_SRG));
-            task.setFieldCsv(delayedFile(FIELD_CSV));
-            task.setFieldCsv(delayedFile(METHOD_CSV));
+            task.setFieldsCsv(delayedFile(FIELD_CSV));
+            task.setFieldsCsv(delayedFile(METHOD_CSV));
             task.reobf(project.getTasks().getByName("jar"), new Action<ArtifactSpec>()
             {
                 @Override


### PR DESCRIPTION
Tiny change, but lays the ground for something I've been fiddling with lately. I've been able to use my own `methods.csv` and `fields.csv` files in the remapping srg names to mcp names, yielding a more understandable set of source code without having to wait on the files on [MCPTest](http://mcpold.ocean-labs.de/files/mcptest/) to be incorporated into userdev.
