### PR TITLE
Add tests for new supported version formats

### DIFF
--- a/src/test/java/net/minecraftforge/gradle/ExtensionVersionTest.java
+++ b/src/test/java/net/minecraftforge/gradle/ExtensionVersionTest.java
@@ -1,0 +1,155 @@
+package net.minecraftforge.gradle;
+
+import java.io.File;
+import java.util.Map;
+import java.util.HashMap;
+
+import net.minecraftforge.gradle.user.patch.ForgeUserPlugin;
+import net.minecraftforge.gradle.user.patch.UserPatchExtension;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+
+import static org.junit.Assert.*;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExtensionVersionTest
+{
+    private Project testProject;
+    private UserPatchExtension ext;
+
+    @Before
+    public void setupProject()
+    {
+        Map<String, Object> options = new HashMap<String, Object>();
+        options.put("plugin", ForgeUserPlugin.class);
+
+        this.testProject = ProjectBuilder.builder().build();
+        assertNotNull(this.testProject);
+        this.testProject.apply(options);
+
+        this.ext = this.testProject.getExtensions().findByType(UserPatchExtension.class);   // unlike getByType(), does not throw exception
+        assertNotNull(this.ext);
+    }
+
+    // Invalid version notation! The following are valid notations. Buildnumber, version, version-branch, mcversion-version-branch, and pomotion (sic)
+
+    @Test
+    public void testValidBuildNumber()
+    {
+        // buildnumber
+        this.ext.setVersion("965");
+        assertEquals(this.ext.getVersion(), "1.6.4");
+        assertEquals(this.ext.getApiVersion(), "1.6.4-9.11.1.965");
+    }
+
+    @Test
+    public void testValidPromotion()
+    {
+        // promotion
+        this.ext.setVersion("1.6.4-recommended");
+        assertEquals(this.ext.getVersion(), "1.6.4");
+        assertEquals(this.ext.getApiVersion(), "1.6.4-9.11.1.965");
+    }
+
+    @Test
+    public void testValidPromotionWithBranch()
+    {
+        // promotion (with branch)
+        this.ext.setVersion("1.7.10-latest-new");
+        assertEquals(this.ext.getVersion(), "1.7.10");
+        assertEquals(this.ext.getApiVersion(), "1.7.10-10.13.1.1216-new");
+    }
+
+    @Test
+    public void testValidBuildNumberNoBranch()
+    {
+        // buildnumber (no branch)
+        this.ext.setVersion("1256");
+        assertEquals(this.ext.getVersion(), "1.7.10");
+        assertEquals(this.ext.getApiVersion(), "1.7.10-10.13.2.1256");
+    }
+
+    @Test
+    public void testValidBuildNumberWithBranch()
+    {
+        // buildnumber (with branch)
+        this.ext.setVersion("1257");
+        assertEquals(this.ext.getVersion(), "1.8");
+        assertEquals(this.ext.getApiVersion(), "1.8-11.14.0.1257-1.8");
+    }
+
+    @Test
+    public void testValidVersion()
+    {
+        // version
+        this.ext.setVersion("10.13.2.1256");
+        assertEquals(this.ext.getVersion(), "1.7.10");
+        assertEquals(this.ext.getApiVersion(), "1.7.10-10.13.2.1256");
+    }
+
+    @Test
+    public void testValidMcVersionWithVersion()
+    {
+        // mcversion-version
+        this.ext.setVersion("1.7.10-10.13.2.1256");
+        assertEquals(this.ext.getVersion(), "1.7.10");
+        assertEquals(this.ext.getApiVersion(), "1.7.10-10.13.2.1256");
+    }
+
+    @Test
+    public void testValidVersionWithBranch()
+    {
+        // version-branch
+        this.ext.setVersion("11.14.0.1257-1.8");
+        assertEquals(this.ext.getVersion(), "1.8");
+        assertEquals(this.ext.getApiVersion(), "1.8-11.14.0.1257-1.8");
+    }
+
+    @Test
+    public void testValidMcVersionWithVersionAndBranch()
+    {
+        // mcversion-version-branch
+        this.ext.setVersion("1.8-11.14.0.1257-1.8");
+        assertEquals(this.ext.getVersion(), "1.8");
+        assertEquals(this.ext.getApiVersion(), "1.8-11.14.0.1257-1.8");
+    }
+
+    // Invalid formats
+
+    @Test(expected=RuntimeException.class)
+    public void testInvalidBuild()
+    {
+        // 1.8 build skipped due to 1.7.10
+        this.ext.setVersion("11.14.0.1256-1.8");
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void testInvalidBuildWithMcVersion()
+    {
+        // 1.8 build skipped due to 1.7.10 (with MC version)
+        this.ext.setVersion("1.8-11.14.0.1256-1.8");
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void testInvalidMcVersion()
+    {
+        // invalid MC version
+        this.ext.setVersion("1.7.10-9.11.1.965");
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void testInvalidMcVersionWithBranch()
+    {
+        // invalid MC version (with branch)
+        this.ext.setVersion("1.7.10-11.14.0.1257-1.8");
+    }
+
+    @Test(expected=RuntimeException.class)
+    public void testInvalidBranch()
+    {
+        // invalid branch
+        this.ext.setVersion("1.7.10-11.14.0.1256-1.8");
+    }
+}


### PR DESCRIPTION
~~To my understanding, integration tests differ from unit tests in that they depend on external state (databases, servers, etc.), I/O, and/or mockups to verify a test, whereas unit tests can be isolated as a POJO (plain-old Java object) and verified as if it were a 'pure' function.  Integration tests are therefore relatively slower than unit tests, and it is desirable to separate the two.~~

~~This plugin adds an integration sourceSet that is not called when running `build` but instead is manually executed by running `integrationTest`.~~

The included tests test various supported version formats that Abrar recently added support for in 400b0666e8c1f5a99f8bd35a7f29b0a38958b84a.  ~~They are classified as integration tests because they depend on external state from a web server, namely a JSON file from the forge maven.~~

edit:  integration plugin removed pending further review, and these tests aren't that slow on modern processors.
