### PR TITLE
Add support for uploading additional artifacts to CurseForge

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/json/curse/CurseMetadataChild.java
+++ b/src/main/java/net/minecraftforge/gradle/json/curse/CurseMetadataChild.java
@@ -1,0 +1,7 @@
+package net.minecraftforge.gradle.json.curse;
+
+public class CurseMetadataChild
+{
+    public String changelog, releaseType, displayName;
+    public int parentFileID;
+}


### PR DESCRIPTION
## This change adds the ability to upload multiple artifacts to CurseForge per build.
### Backwards compatibility

The main artifact can still be changed via:

``` groovy
curse {
    artifact = myOtherJarTask
}
```

As well, the default artifact is still the obfuscated jar.
This keeps compatibility with existing gradle scripts.
### An example of the new configuration:

``` groovy
curse {
    apiKey = project.curseForgeAPIKey
    projectId = 12345
    changelog = 'I made a change!'
    releaseType = 'release'

    additionalArtifact sourceJar, javadocJar, deobfJar
    additionalArtifact file("$project.buildDir/libs/A-Custom-File.txt")
}
```
### Some Notes:
- Additional artifacts are uploaded with the main artifact being their `parentFile`. This means that these additional artifacts will never be the "Primary Download" on the CurseForge website.
- Additional artifacts are intended to be files that are related to the current build, but not the main obfuscated jar. (Source jars, deobfuscated jars, javadoc jars, changelog files, etc)
