### PR TITLE
fixed can`t compile when using jdk7 or jdk8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,10 @@ dependencies {
 }
 
 compileJava {
+  if(System.env.JDK6_HOME != null) {
+    options.fork = true
+    options.bootClasspath = "$System.env.JDK6_HOME/jre/lib/rt.jar"
+  }
 	options.deprecation = true
 	options.compilerArgs += ["-Werror"]
 	//options.compilerArgs += ["-Werror", "-Xlint:unchecked"]


### PR DESCRIPTION
Must set bootclasspath when doing cross version compile. Otherwise you will get a warning. then -Werror will let warning be error.