### PR TITLE
Fix tweaker plugin dependency resolution when access transformers are used

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/tweakers/TweakerPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/tweakers/TweakerPlugin.java
@@ -38,7 +38,7 @@ public abstract class TweakerPlugin extends UserBasePlugin<TweakerExtension>
         String dirtySuffix = "%s-" + REPLACE_MC_VERSION + "-PROJECT(" + project.getName() + ")";
         String jarName = getJarName();
 
-        createDecompTasks(CLEAN_ROOT + jarName + "/" + REPLACE_MC_VERSION + "/" + MCP_INSERT + "/" + jarName + cleanSuffix, DIR_LOCAL_CACHE + jarName + dirtySuffix);
+        createDecompTasks(CLEAN_ROOT + jarName + "/" + REPLACE_MC_VERSION + "/" + MCP_INSERT + "/" + jarName + cleanSuffix, DIR_LOCAL_CACHE + "/" + jarName + dirtySuffix);
 
         // remove the unused merge jars task
         project.getTasks().remove(project.getTasks().getByName(TASK_MERGE_JARS));


### PR DESCRIPTION
Currently, Gradle fails to resolve the decompiled Minecraft dependency properly if access transformers are used in a project using the tweaker plugin. This happens because ForgeGradle decompiles them in the wrong folder due to a missing slash in the path.

Instead of saving them in `.gradle/minecraft` where Gradle will search the dependencies later it saves them in `.gradle` directly:

![](https://i.imgur.com/cjwQUpn.png)