### PR TITLE
Scan the exceptor configuration for unknown classes before applying

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/tasks/DeobfuscateJar.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/DeobfuscateJar.java
@@ -13,8 +13,10 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import java.util.zip.ZipFile;
 
 import net.md_5.specialsource.AccessMap;
 import net.md_5.specialsource.Jar;
@@ -291,6 +293,10 @@ public class DeobfuscateJar extends CachedTask
                     }
                 });
             }
+
+            // Remove unknown classes from configuration
+            removeUnknownClasses(inJar, struct);
+
             File jsonTmp = new File(this.getTemporaryDir(), "transformed.json");
             json = jsonTmp.getCanonicalPath();
             Files.write(JsonFactory.GSON.toJson(struct).getBytes(), jsonTmp);
@@ -312,6 +318,49 @@ public class DeobfuscateJar extends CachedTask
                 json,
                 isApplyMarkers(),
                 true);
+    }
+
+    private void removeUnknownClasses(File inJar, Map<String, MCInjectorStruct> config) throws IOException
+    {
+        ZipFile zip = new ZipFile(inJar);
+        try
+        {
+            Iterator<Map.Entry<String, MCInjectorStruct>> entries = config.entrySet().iterator();
+            while (entries.hasNext())
+            {
+                Map.Entry<String, MCInjectorStruct> entry = entries.next();
+                String className = entry.getKey();
+
+                // Verify the configuration contains only classes we actually have
+                if (zip.getEntry(className + ".class") == null)
+                {
+                    getLogger().info("Removing unknown class {}", className);
+                    entries.remove();
+                    continue;
+                }
+
+                MCInjectorStruct struct = entry.getValue();
+
+                // Verify the inner classes in the configuration actually exist in our deobfuscated JAR file
+                if (struct.innerClasses != null)
+                {
+                    Iterator<InnerClass> innerClasses = struct.innerClasses.iterator();
+                    while (innerClasses.hasNext())
+                    {
+                        InnerClass innerClass = innerClasses.next();
+                        if (zip.getEntry(innerClass.inner_class + ".class") == null)
+                        {
+                            getLogger().info("Removing unknown inner class {} from {}", innerClass.inner_class, className);
+                            innerClasses.remove();
+                        }
+                    }
+                }
+            }
+        }
+        finally
+        {
+            zip.close();
+        }
     }
 
     public File getExceptorCfg()


### PR DESCRIPTION
This fixes the problem reported in #244 by adding a new deobfuscation step that will scan the generated classes and remove any invalid inner class references it finds.