### PR TITLE
Fix incorrect coremod launch argument

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/patcherUser/forge/ForgePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/patcherUser/forge/ForgePlugin.java
@@ -245,8 +245,7 @@ public class ForgePlugin extends PatcherUserBasePlugin<ForgeExtension>
         List<String> out = ext.getResolvedClientJvmArgs();
         if (!Strings.isNullOrEmpty(ext.getCoreMod()))
         {
-            out.add("-Dfml.coreMods.load");
-            out.add(ext.getCoreMod());
+            out.add("-Dfml.coreMods.load=" + ext.getCoreMod());
         }
         return out;
     }
@@ -257,8 +256,7 @@ public class ForgePlugin extends PatcherUserBasePlugin<ForgeExtension>
         List<String> out = ext.getResolvedServerJvmArgs();
         if (!Strings.isNullOrEmpty(ext.getCoreMod()))
         {
-            out.add("-Dfml.coreMods.load");
-            out.add(ext.getCoreMod());
+            out.add("-Dfml.coreMods.load=" + ext.getCoreMod());
         }
         return out;
     }


### PR DESCRIPTION
There should be an equals sign not a space.

Note: I have not tested this change, I only modified it from the GitHub web interface.