### PR TITLE
Fix sources for dependencies in the deobfCompile and deobfProvided configurations not getting downloaded and remapped

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -611,12 +611,19 @@ public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePl
 
                 int taskId = 0;
 
+                // FOR SOURCES!
+
+                HashMap<ComponentIdentifier, ModuleVersionIdentifier> idMap = Maps.newHashMap();
+                
                 // FOR BINARIES
 
                 for (ResolvedArtifact artifact : config.getResolvedConfiguration().getResolvedArtifacts())
                 {
                     ModuleVersionIdentifier module = artifact.getModuleVersion().getId();
                     String group = "deobf." + module.getGroup();
+                    
+                    // Add artifacts that will be remapped to get their sources
+                    idMap.put(artifact.getId().getComponentIdentifier(), module);
 
                     TaskSingleDeobfBin deobf = makeTask(config.getName() + "DeobfDepTask" + (taskId++), TaskSingleDeobfBin.class);
                     deobf.setInJar(artifact.getFile());
@@ -628,10 +635,6 @@ public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePl
 
                     project.getDependencies().add(resolvedConfig, group + ":" + module.getName() + ":" + module.getVersion());
                 }
-
-                // FOR SOURCES!
-
-                HashMap<ComponentIdentifier, ModuleVersionIdentifier> idMap = Maps.newHashMap();
 
                 for (DependencyResult depResult : config.getIncoming().getResolutionResult().getAllDependencies())
                 {


### PR DESCRIPTION
While I was playing with the new dependency remapping in FG2, I noticed that the sources were not downloading, getting remapped, or getting attached to the jars in an eclipse project. This fixes it.