### PR TITLE
Store DIR_MCP_MAPPINGS path as a system property when mappings are set

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/common/BaseExtension.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BaseExtension.java
@@ -39,6 +39,7 @@ public abstract class BaseExtension
 
     public final String forgeGradleVersion;
 
+    protected transient BasePlugin<? extends BaseExtension> plugin;
     protected transient Project             project;
     protected transient ReplacementProvider replacer;
     protected String                        version;
@@ -54,6 +55,7 @@ public abstract class BaseExtension
 
     public BaseExtension(BasePlugin<? extends BaseExtension> plugin)
     {
+        this.plugin = plugin;
         this.project = plugin.project;
         this.replacer = plugin.replacer;
 
@@ -200,8 +202,7 @@ public abstract class BaseExtension
             mappingsChannel = null;
             mappingsVersion = -1;
 
-            replacer.putReplacement(Constants.REPLACE_MCP_CHANNEL, mappingsChannel);
-            replacer.putReplacement(Constants.REPLACE_MCP_VERSION, getMappingsVersion());
+            this.setMappingEnvironment();
 
             return;
         }
@@ -231,12 +232,19 @@ public abstract class BaseExtension
         }
 
         mappingsSet = true;
-
-        replacer.putReplacement(Constants.REPLACE_MCP_CHANNEL, mappingsChannel);
-        replacer.putReplacement(Constants.REPLACE_MCP_VERSION, getMappingsVersion());
+        this.setMappingEnvironment();
 
         // check
         checkMappings();
+    }
+
+    protected void setMappingEnvironment()
+    {
+        this.replacer.putReplacement(Constants.REPLACE_MCP_CHANNEL, this.mappingsChannel);
+        this.replacer.putReplacement(Constants.REPLACE_MCP_VERSION, this.getMappingsVersion());
+
+        // Store the MCP mappings path in properties so that it can be accessed during builds.
+        System.setProperty("net.minecraftforge.gradle.mcp.mappings", this.plugin.delayedFile(Constants.DIR_MCP_MAPPINGS).call().getAbsolutePath());
     }
 
     /**


### PR DESCRIPTION
This allows the use of the MCP mappings path without having to call `delayedFile`.

https://github.com/MinecraftForge/ForgeGradle/pull/302