### PR TITLE
Create zip entries for directories in the recompiled Minecraft JAR

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/TaskRecompileMc.java
+++ b/src/main/java/net/minecraftforge/gradle/user/TaskRecompileMc.java
@@ -149,8 +149,25 @@ public class TaskRecompileMc extends CachedTask
         }
 
         @Override
-        public void visitDir(FileVisitDetails dirDetails)
+        public void visitDir(FileVisitDetails dir)
         {
+            try
+            {
+                String name = dir.getRelativePath().toString().replace('\\', '/');
+                if (!name.endsWith("/"))
+                    name += "/";
+
+                if (entries.contains(name))
+                    return;
+
+                entries.add(name);
+                ZipEntry entry = new ZipEntry(name);
+                zout.putNextEntry(entry);
+            }
+            catch (IOException e)
+            {
+                Throwables.propagate(e);
+            }
         }
 
         @Override


### PR DESCRIPTION
Fixes MinecraftForge/MinecraftForge#2263

Climbing down into the deep caves of class loading the absence of ZIP entries for directories in the recompiled Minecraft decomp JAR causes log4j2 to be unable to find its plugins in the configured packages.

Forge 1.8.8 uses a [custom log4j2 appender](https://github.com/MinecraftForge/MinecraftForge/blob/1.8.8/src/main/java/net/minecraftforge/server/console/TerminalConsoleAppender.java) for the extended console implementation using jline on the server. In the user workspace (e.g. when making a Forge mod) the server will currently fail to display any console output because log4j2 is unable to find the custom appender class. (See MinecraftForge/MinecraftForge#2263)

Looking into the internals of log4j2 it uses the classloader's [getResources(String name) method](http://docs.oracle.com/javase/8/docs/api/java/lang/ClassLoader.html#getResources-java.lang.String-) to get the JAR(s) that contain the [specified packages that were configured for log4j2 to load plugins from](https://github.com/MinecraftForge/MinecraftForge/blob/1.8.8/src/main/resources/log4j2_server.xml#L2). For that to work, the JARs will need to contain directory entries for the packages it has, or otherwise Java will assume no JAR has the wanted package. (Which will cause our appender to fail to load.)

This changes the `recompileMc` task to add the entries for the directories to the created ZIP additionally instead of only the class files.