### PR TITLE
Fix #334 invalid regex for methods/fields

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/tasks/RemapSources.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/RemapSources.java
@@ -60,8 +60,8 @@ public class RemapSources extends AbstractEditJarTask
     private final Map<String, String> params       = Maps.newHashMap();
 
     private static final Pattern      SRG_FINDER   = Pattern.compile("func_[0-9]+_[a-zA-Z_]+|field_[0-9]+_[a-zA-Z_]+|p_[\\w]+_\\d+_\\b");
-    private static final Pattern      METHOD       = Pattern.compile("^((?: {4})+|\\t+)(?:[\\w$.\\[\\]]+ )+(func_[0-9]+_[a-zA-Z_]+)\\(");
-    private static final Pattern      FIELD        = Pattern.compile("^((?: {4})+|\\t+)(?:[\\w$.\\[\\]]+ )+(field_[0-9]+_[a-zA-Z_]+) *(?:=|;)");
+    private static final Pattern      METHOD       = Pattern.compile("^((?: {4})+|\\t+)(?!return)(?:[\\w$.\\[\\]]+(?:<.+>)? )+(func_[0-9]+_[a-zA-Z_]+)\\(");
+    private static final Pattern      FIELD        = Pattern.compile("^((?: {4})+|\\t+)(?:[\\w$.\\[\\]]+(?:<.+>)? )+(field_[0-9]+_[a-zA-Z_]+) *(?:=|;)");
 
     @Override
     public void doStuffBefore() throws Exception


### PR DESCRIPTION
Explanation:

Added this regex to the pattern for "words" in the declaration: (?:<.+>)?

This is a noncapturing group which matches anything inside angle brackets (<>), or nothing (the ? character at the end assures it only captures 0-1 instances).

Also added this regex to pattern (method only) to avoid matching return statments use srg names: (?!return)

This is a negative lookahead to check that there is no return statement just after the whitespace.

See http://regexr.com/3cl58 for evidence of the fix.
