### PR TITLE
Fix log4j2 being unable to find appender because of missing directory entries

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/tasks/SignJar.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/SignJar.java
@@ -107,7 +107,16 @@ public class SignJar extends DefaultTask implements PatternFilterable
             @Override
             public void visitDir(FileVisitDetails details)
             {
-                // nothing
+                try
+                {
+                    String path = details.getPath();
+                    ZipEntry entry = new ZipEntry(path.endsWith("/") ? path : path + "/");
+                    outs.putNextEntry(entry);
+                }
+                catch (IOException e)
+                {
+                    e.printStackTrace();
+                }
             }
 
             @Override


### PR DESCRIPTION
Basically same story as #309, the sign jar task removes the directory entries but log4j needs them in order to find the appenders in a package.

Related issues: MinecraftForge/MinecraftForge#2263 (older issue where the same issue happened before in the dev environment, was fixed with #309), MinecraftForge/Installer#28 (current issue)

tl;dr The missing directory entries caused log4j2 to be unable to find the appender, caused weird errors. This should fix it.