### PR TITLE
Liteloader Plugin

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteModJson.java
+++ b/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteModJson.java
@@ -1,0 +1,142 @@
+/*
+ * A Gradle plugin for the creation of Minecraft mods and MinecraftForge plugins.
+ * Copyright (C) 2013 Minecraft Forge
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package net.minecraftforge.gradle.user.liteloader;
+
+import com.google.common.base.Strings;
+import com.google.gson.GsonBuilder;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Project;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class LiteModJson
+{
+    public String name, displayName, version, author;
+    public String mcversion, revision;
+    public String injectAt, tweakClass;
+    public List<String> classTransformerClasses;
+    public List<String> dependsOn;
+    public List<String> requiredAPIs;
+    public List<String> mixinConfigs;
+    
+    private transient final Project project;
+    private transient final String minecraftVersion;
+    
+    LiteModJson(Project project, String minecraftVersion, String revision)
+    {
+        this.project = project;
+        this.mcversion = this.minecraftVersion = minecraftVersion;
+        this.revision = revision;
+        
+        this.name = project.getName();
+        this.displayName = project.hasProperty("displayName") ? project.property("displayName").toString() : project.getDescription();
+        this.version = project.getVersion().toString();
+    }
+    
+    public void setMcversion(String version)
+    {
+        this.mcversion = version;
+    }
+    
+    public void setRevision(String revision)
+    {
+        this.revision = revision;
+    }
+    
+    public List<String> getClassTransformerClasses()
+    {
+        if (this.classTransformerClasses == null)
+        {
+            this.classTransformerClasses = new ArrayList<String>();
+        }
+        return this.classTransformerClasses;
+    }
+    
+    public List<String> getDependsOn()
+    {
+        if (this.dependsOn == null)
+        {
+            this.dependsOn = new ArrayList<String>();
+        }
+        return this.dependsOn;
+    }
+    
+    public List<String> getRequiredAPIs()
+    {
+        if (this.requiredAPIs == null)
+        {
+            this.requiredAPIs = new ArrayList<String>();
+        }
+        return this.requiredAPIs;
+    }
+    
+    public List<String> getMixinConfigs()
+    {
+        if (this.mixinConfigs == null)
+        {
+            this.mixinConfigs = new ArrayList<String>();
+        }
+        return this.mixinConfigs;
+    }
+
+    public void toJsonFile(File outputFile) throws IOException
+    {
+        this.validate();
+        
+        FileWriter writer = new FileWriter(outputFile);
+        new GsonBuilder().setPrettyPrinting().create().toJson(this, writer);
+        writer.flush();
+        writer.close();
+    }
+
+    private void validate()
+    {
+        if (Strings.isNullOrEmpty(this.name))
+            throw new InvalidUserDataException("litemod json is missing property [name]");
+        
+        if (Strings.isNullOrEmpty(this.version))
+            throw new InvalidUserDataException("litemod json is missing property [version]");
+        
+        if (Strings.isNullOrEmpty(this.mcversion))
+            throw new InvalidUserDataException("litemod json is missing property [mcversion]");
+        
+        if (Strings.isNullOrEmpty(this.revision))
+            throw new InvalidUserDataException("litemod json is missing property [revision]");
+        
+        try
+        {
+            Float.parseFloat(this.revision);
+        }
+        catch (NumberFormatException ex)
+        {
+            throw new InvalidUserDataException("invalid format for [revision] property in litemod.json, expected float");
+        }
+        
+        if (!this.minecraftVersion.equals(this.mcversion)) {
+            this.project.getLogger().warn("You are setting a different target version of minecraft to the build environment");
+        }
+
+    }
+    
+}

--- a/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteModTask.java
+++ b/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteModTask.java
@@ -1,0 +1,126 @@
+/*
+ * A Gradle plugin for the creation of Minecraft mods and MinecraftForge plugins.
+ * Copyright (C) 2013 Minecraft Forge
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package net.minecraftforge.gradle.user.liteloader;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Files;
+import groovy.lang.Closure;
+import org.apache.tools.ant.taskdefs.BuildNumber;
+import org.gradle.api.AntBuilder;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.internal.ClosureBackedAction;
+import org.gradle.api.specs.Spec;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+public class LiteModTask extends DefaultTask
+{
+    private String buildNumber;
+    
+    private Object fileName;
+    
+    private LiteModJson json;
+    
+    @OutputFile
+    private File output;
+    
+    public LiteModTask()
+    {
+        this.setFileName("litemod.json");
+        this.getOutputs().upToDateWhen(new Spec<Task>()
+        {
+            @Override
+            public boolean isSatisfiedBy(Task arg0)
+            {
+                return false;
+            }
+        });
+    }
+
+    @TaskAction
+    public void doTask() throws IOException
+    {
+        File outputFile = this.getOutput();
+        outputFile.delete();
+        this.getJson().toJsonFile(outputFile);
+    }
+    
+    public Object getFileName()
+    {
+        return this.fileName;
+    }
+    
+    public void setFileName(Object fileName)
+    {
+        this.fileName = fileName;
+    }
+
+    public File getOutput()
+    {
+        if (this.output == null)
+        {
+            this.output = getProject().file(new File(this.getTemporaryDir(), this.getFileName().toString()));
+        }
+        return this.output;
+    }
+    
+    public LiteModJson getJson() throws IOException
+    {
+        if (this.json == null)
+        {
+            Project project = this.getProject();
+            String version = project.getExtensions().findByType(LiteloaderExtension.class).getVersion();
+            String revision = this.getBuildNumber();
+            this.json = new LiteModJson(project, version, revision);
+        }
+        
+        return this.json;
+    }
+    
+    public void json(Closure<?> configureClosure) throws IOException
+    {
+        ClosureBackedAction.execute(this.getJson(), configureClosure);
+    }
+
+    public String getBuildNumber() throws IOException
+    {
+        if (this.buildNumber == null)
+        {
+            AntBuilder ant = getProject().getAnt();
+
+            File buildNumberFile = new File(this.getTemporaryDir(), "build.number");  
+            BuildNumber buildNumber = (BuildNumber)ant.invokeMethod("buildnumber");
+            buildNumber.setFile(buildNumberFile);
+            buildNumber.execute();
+            
+            Properties props = new Properties();
+            props.load(Files.newReader(buildNumberFile, Charsets.ISO_8859_1));
+            this.buildNumber = props.getProperty("build.number");
+        }
+        
+        return this.buildNumber;
+    }
+}

--- a/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteloaderExtension.java
+++ b/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteloaderExtension.java
@@ -19,12 +19,38 @@
  */
 package net.minecraftforge.gradle.user.liteloader;
 
+import com.google.common.base.Strings;
 import net.minecraftforge.gradle.user.UserBaseExtension;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.jvm.tasks.Jar;
 
 public class LiteloaderExtension extends UserBaseExtension
 {
+    private final LiteloaderPlugin plugin;
+    
     public LiteloaderExtension(LiteloaderPlugin plugin)
     {
         super(plugin);
+        this.plugin = plugin;
+    }
+    
+    @Override
+    public void setVersion(String version)
+    {
+        super.setVersion(version);
+        this.checkVersion(version);
+        
+        Jar jar = (Jar)project.getTasks().getByName("jar");
+        if (Strings.isNullOrEmpty(jar.getClassifier())) {
+            jar.setClassifier("mc" + version);
+        }
+    }
+
+    private void checkVersion(String version)
+    {
+        if (this.plugin.getVersion(version) == null)
+        {
+            throw new InvalidUserDataException("No ForgeGradle-compatible LiteLoader version found for Minecraft" + version);
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteloaderPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteloaderPlugin.java
@@ -19,20 +19,200 @@
  */
 package net.minecraftforge.gradle.user.liteloader;
 
-import net.minecraftforge.gradle.common.Constants;
+import static net.minecraftforge.gradle.common.Constants.*;
+import static net.minecraftforge.gradle.user.UserConstants.*;
+
 import net.minecraftforge.gradle.user.UserVanillaBasePlugin;
+import net.minecraftforge.gradle.util.delayed.DelayedFile;
+import net.minecraftforge.gradle.util.json.JsonFactory;
+import net.minecraftforge.gradle.util.json.LiteLoaderJson;
+import net.minecraftforge.gradle.util.json.LiteLoaderJson.Artifact;
+import net.minecraftforge.gradle.util.json.LiteLoaderJson.RepoObject;
+import net.minecraftforge.gradle.util.json.LiteLoaderJson.VersionObject;
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.tasks.TaskContainer;
+import org.gradle.jvm.tasks.Jar;
 
 import java.util.List;
-
-import static net.minecraftforge.gradle.common.Constants.*;
+import java.util.Map;
 
 public class LiteloaderPlugin extends UserVanillaBasePlugin<LiteloaderExtension>
 {
+    public static final String CONFIG_LL_DEOBF_COMPILE = "liteloaderDeobfCompile";
+    public static final String CONFIG_LL_DC_RESOLVED = "liteloaderResolvedDeobfCompile";
+
+    public static final String MAVEN_REPO_NAME = "liteloaderRepo";
+
+    public static final String MODFILE_PREFIX = "mod-";
+    public static final String MODFILE_EXTENSION = "litemod";
+    
+    public static final String VERSION_JSON_URL = "http://dl.liteloader.com/versions/versions.json";
+    public static final String VERSION_JSON_FILENAME = "versions.json";
+    public static final String VERSION_JSON_FILE = REPLACE_CACHE_DIR + "/com/mumfrey/liteloader/" + VERSION_JSON_FILENAME;
+
+    public static final String TASK_LITEMOD = "litemod";
+    
+    public static final String MFATT_MODTYPE = "ModType";
+    public static final String MODSYSTEM = "LiteLoader";
+
+    private LiteLoaderJson json;
+
+    private RepoObject repo;
+
+    private Artifact artifact;
+
     @Override
     protected void applyVanillaUserPlugin()
     {
-        // liteloader requires this...
-        project.getDependencies().add(Constants.CONFIG_MC_DEPS, "net.minecraft:launchwrapper:1.11");
+        final ConfigurationContainer configs = this.project.getConfigurations();
+        configs.maybeCreate(CONFIG_LL_DEOBF_COMPILE);
+        configs.maybeCreate(CONFIG_LL_DC_RESOLVED);
+
+        configs.getByName(CONFIG_DC_RESOLVED).extendsFrom(configs.getByName(CONFIG_LL_DC_RESOLVED));
+        
+        final DelayedFile versionJson = delayedFile(VERSION_JSON_FILE);
+        final DelayedFile versionJsonEtag = delayedFile(VERSION_JSON_FILE + ".etag");
+        setJson(JsonFactory.loadLiteLoaderJson(getWithEtag(VERSION_JSON_URL, versionJson.call(), versionJsonEtag.call())));
+
+        String baseName = MODFILE_PREFIX + this.project.property("archivesBaseName").toString().toLowerCase();
+
+        TaskContainer tasks = this.project.getTasks();
+        final Jar jar = (Jar)tasks.getByName("jar");
+        jar.setExtension(MODFILE_EXTENSION);
+        jar.setBaseName(baseName);
+        
+        final Jar sourceJar = (Jar)tasks.getByName("sourceJar");
+        sourceJar.setBaseName(baseName);
+        
+        makeTask(TASK_LITEMOD, LiteModTask.class);
+    }
+
+    @Override
+    protected void afterEvaluate()
+    {
+        super.afterEvaluate();
+        this.applyJson();
+
+        // If user has changed extension back to .jar, write the ModType
+        // manifest attribute
+        final Jar jar = (Jar)this.project.getTasks().getByName("jar");
+        if ("jar".equals(jar.getExtension())) {
+            Attributes attributes = jar.getManifest().getAttributes();
+            if (attributes.get(MFATT_MODTYPE) == null) {
+                attributes.put(MFATT_MODTYPE, MODSYSTEM);
+            }
+        }
+    }
+    
+    @Override
+    protected void setupDevTimeDeobf(final Task compileDummy, final Task providedDummy)
+    {
+        super.setupDevTimeDeobf(compileDummy, providedDummy);
+        
+        // die with error if I find invalid types...
+        this.project.afterEvaluate(new Action<Project>() {
+            @Override
+            public void execute(Project project)
+            {
+                if (project.getState().getFailure() != null)
+                    return;
+                
+                remapDeps(project, project.getConfigurations().getByName(CONFIG_LL_DEOBF_COMPILE), CONFIG_LL_DC_RESOLVED, compileDummy);
+            }
+        });
+    }
+    
+    private void applyJson()
+    {
+        if (this.json == null)
+        {
+            return;
+        }
+        
+        VersionObject version = this.json.versions.get(this.getExtension().getVersion());
+        if (version != null)
+        {
+            this.setRepo(version.repo);
+            this.setArtifact(version.latest);
+            this.applyDependenciesFromJson();
+        }
+    }
+    
+    private void applyDependenciesFromJson()
+    {
+        this.project.allprojects(new Action<Project>() {
+            @Override
+            public void execute(Project proj)
+            {
+                RepoObject repo = LiteloaderPlugin.this.getRepo();
+                if (repo == null)
+                {
+                    return;
+                }
+                addMavenRepo(proj, MAVEN_REPO_NAME, repo.url);
+                
+                Artifact artifact = LiteloaderPlugin.this.getArtifact();
+                if (artifact == null)
+                {
+                    return;
+                }
+                addDependency(proj, CONFIG_LL_DEOBF_COMPILE, artifact.getDepString(repo));
+                
+                for (Map<String, String> library : artifact.getLibraries())
+                {
+                    String name = library.get("name");
+                    if (name != null && !name.isEmpty())
+                    {
+                        addDependency(proj, CONFIG_MC_DEPS, name);
+                    }
+                    
+                    String url = library.get("url");
+                    if (url != null && !url.isEmpty())
+                    {
+                        addMavenRepo(proj, url, url);
+                    }
+                }
+            }
+        });
+    }
+
+    public VersionObject getVersion(String version)
+    {
+        return this.json != null ? this.json.versions.get(version) : null;
+    }
+
+    public LiteLoaderJson getJson()
+    {
+        return this.json;
+    }
+    
+    public void setJson(LiteLoaderJson json)
+    {
+        this.json = json;
+    }
+    
+    public RepoObject getRepo()
+    {
+        return this.repo;
+    }
+    
+    public void setRepo(RepoObject repo)
+    {
+        this.repo = repo;
+    }
+    
+    public Artifact getArtifact()
+    {
+        return this.artifact;
+    }
+    
+    public void setArtifact(Artifact artifact)
+    {
+        this.artifact = artifact;
     }
 
     @Override
@@ -100,5 +280,10 @@ public class LiteloaderPlugin extends UserVanillaBasePlugin<LiteloaderExtension>
     protected List<String> getServerJvmArgs(LiteloaderExtension ext)
     {
         return ext.getResolvedServerJvmArgs();
+    }
+
+    protected void addDependency(Project proj, String configuration, String dependency)
+    {
+        proj.getDependencies().add(configuration, dependency);
     }
 }

--- a/src/main/java/net/minecraftforge/gradle/util/json/JsonFactory.java
+++ b/src/main/java/net/minecraftforge/gradle/util/json/JsonFactory.java
@@ -148,12 +148,9 @@ public class JsonFactory
         return a;
     }
 
-    public static LiteLoaderJson loadLiteLoaderJson(File json) throws JsonSyntaxException, JsonIOException, IOException
+    public static LiteLoaderJson loadLiteLoaderJson(String json) throws JsonSyntaxException, JsonIOException
     {
-        FileReader reader = new FileReader(json);
-        LiteLoaderJson a = GSON.fromJson(reader, LiteLoaderJson.class);
-        reader.close();
-        return a;
+        return GSON.fromJson(json, LiteLoaderJson.class).addDefaultArtifacts();
     }
 
     public static Map<String, MCInjectorStruct> loadMCIJson(File json) throws IOException

--- a/src/main/java/net/minecraftforge/gradle/util/json/LiteLoaderJson.java
+++ b/src/main/java/net/minecraftforge/gradle/util/json/LiteLoaderJson.java
@@ -20,6 +20,7 @@
 package net.minecraftforge.gradle.util.json;
 
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -41,25 +42,70 @@ public class LiteLoaderJson
         public String description, authors, url;
     }
     
+    public static final class RepoObject
+    {
+        public String stream, type, url, classifier;
+        
+        @Override
+        public String toString()
+        {
+            return String.format("Repository: %s:%s", type, url);
+        }
+        
+        String getClassifier()
+        {
+            return classifier == null || classifier.isEmpty() ? "" : ":" + classifier;
+        }
+    }
+    
+    public static final class SnapshotsObject
+    {
+        public List<Map<String, String>> libraries;
+    }
+
     public static final class VersionObject
     {
         public Artifact latest;
         public List<Artifact> artifacts;
+        public RepoObject repo;
+        public SnapshotsObject snapshots;
     }
     
     public static final class Artifact
     {
+        public static final String SNAPSHOT_STREAM = "SNAPSHOT";
+        public static final String DEFAULT_TWEAKER = "com.mumfrey.liteloader.launch.LiteLoaderTweaker";
+        public static final String DEFAULT_ARTEFACT = "com.mumfrey:liteloader";
+        
         public String group, md5, tweakClass, file, version, mcpJar, srcJar;
         public long timestamp;
+        public List<Map<String, String>> libraries;
+
+        public Artifact() {}
+        
+        Artifact(String version, RepoObject repo, SnapshotsObject snapshots)
+        {
+            String suffix = Artifact.SNAPSHOT_STREAM.equals(repo.stream) ? "-" + Artifact.SNAPSHOT_STREAM : "";
+
+            this.group = Artifact.DEFAULT_ARTEFACT;
+            this.tweakClass = Artifact.DEFAULT_TWEAKER;
+            this.version = version + suffix;
+            this.libraries = snapshots != null ? snapshots.libraries : null;
+        }
+        
+        public List<Map<String, String>> getLibraries()
+        {
+            return this.libraries != null ? this.libraries : Collections.<Map<String, String>>emptyList();
+        }
         
         public boolean hasMcp()
         {
             return mcpJar != null;
         }
         
-        public String getMcpDepString()
+        public String getDepString(RepoObject repo)
         {
-            return group + ":" + version + "-mcpnames"; 
+            return group + ":" + version + repo.getClassifier();
         }
     }
     
@@ -71,33 +117,64 @@ public class LiteLoaderJson
             VersionObject obj = new VersionObject();
             obj.artifacts = new LinkedList<Artifact>();
             
-            JsonObject groupLevel = json.getAsJsonObject().getAsJsonObject("artefacts");
-            
-            // itterate over the groups
-            for (Entry<String, JsonElement> groupE : groupLevel.entrySet())
+            JsonObject repoData = json.getAsJsonObject().getAsJsonObject("repo");
+            if (repoData != null)
             {
-                String group = groupE.getKey();
-                
-                // itterate over the artefacts in the groups
-                for (Entry<String, JsonElement> artifactE : groupE.getValue().getAsJsonObject().entrySet())
+                obj.repo = context.deserialize(repoData, RepoObject.class);
+            }
+
+            JsonObject snapshotsData = json.getAsJsonObject().getAsJsonObject("snapshots");
+            if (snapshotsData != null)
+            {
+                obj.snapshots = context.deserialize(snapshotsData, SnapshotsObject.class);
+            }
+            
+            JsonObject groupLevel = json.getAsJsonObject().getAsJsonObject("artefacts");
+            if (groupLevel != null)
+            {
+                // itterate over the groups
+                for (Entry<String, JsonElement> groupE : groupLevel.entrySet())
                 {
-                    Artifact artifact = context.deserialize(artifactE.getValue(), Artifact.class);
-                    artifact.group = group;
+                    String group = groupE.getKey();
                     
-                    if ("latest".equals(artifactE.getKey()))
+                    // itterate over the artefacts in the groups
+                    for (Entry<String, JsonElement> artifactE : groupE.getValue().getAsJsonObject().entrySet())
                     {
-                        obj.latest = artifact;
+                        Artifact artifact = context.deserialize(artifactE.getValue(), Artifact.class);
+                        artifact.group = group;
+                        
+                        if ("latest".equals(artifactE.getKey()))
+                        {
+                            obj.latest = artifact;
+                        }
+                        else
+                        {
+                            obj.artifacts.add(artifact);
+                        }
+                        
                     }
-                    else
-                    {
-                        obj.artifacts.add(artifact);
-                    }
-                    
                 }
             }
-                    
-            
+
             return obj;
         }
     }
+    
+    LiteLoaderJson addDefaultArtifacts()
+    {
+        for (Entry<String, VersionObject> versionEntry : this.versions.entrySet())
+        {
+            String version = versionEntry.getKey();
+            VersionObject data = versionEntry.getValue();
+            if (data.artifacts.size() == 0 && "SNAPSHOT".equals(data.repo.stream))
+            {
+                // Add snapshot artifact
+                data.latest = new Artifact(version, data.repo, data.snapshots);
+                data.artifacts.add(data.latest);
+            }
+        }
+        
+        return this;
+    }
+
 }

--- a/src/main/resources/META-INF/gradle-plugins/net.minecraftforge.gradle.liteloader.properties
+++ b/src/main/resources/META-INF/gradle-plugins/net.minecraftforge.gradle.liteloader.properties
@@ -1,0 +1,1 @@
+implementation-class=net.minecraftforge.gradle.user.liteloader.LiteloaderPlugin

--- a/src/test/java/net/minecraftforge/gradle/versions/ExtensionLiteLoaderVersionTest.java
+++ b/src/test/java/net/minecraftforge/gradle/versions/ExtensionLiteLoaderVersionTest.java
@@ -1,0 +1,65 @@
+/*
+ * A Gradle plugin for the creation of Minecraft mods and MinecraftForge plugins.
+ * Copyright (C) 2013 Minecraft Forge
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package net.minecraftforge.gradle.versions;
+
+import static org.junit.Assert.*;
+
+import com.google.common.collect.ImmutableMap;
+import net.minecraftforge.gradle.user.liteloader.LiteloaderExtension;
+import net.minecraftforge.gradle.user.liteloader.LiteloaderPlugin;
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+public class ExtensionLiteLoaderVersionTest
+{
+    private Project             testProject;
+    private LiteloaderExtension ext;
+
+    @Before
+    public void setupProject()
+    {
+        this.testProject = ProjectBuilder.builder().build();
+        assertNotNull(this.testProject);
+        this.testProject.apply(ImmutableMap.of("plugin", LiteloaderPlugin.class));
+
+        this.ext = this.testProject.getExtensions().findByType(LiteloaderExtension.class);   // unlike getByType(), does not throw exception
+        assertNotNull(this.ext);
+    }
+
+    // Invalid version notation! The following are valid notations. BuildNumber, version, version-branch, mcversion-version-branch, and pomotion (sic)
+
+    @Test
+    public void testValidVersion()
+    {
+        // version
+        this.ext.setVersion("1.8.9");
+        assertEquals(this.ext.getVersion(), "1.8.9");
+    }
+
+    @Test(expected = InvalidUserDataException.class)
+    public void testInvalidMcVersion()
+    {
+        // invalid MC version
+        this.ext.setVersion("1.2.3");
+    }
+}


### PR DESCRIPTION
This PR makes the liteloader plugin fully functional. In particular it:

* allows LiteLoader projects to be set up, fetches information on available versions from the json manifests on my main repository
* supports retromapping the liteloader dependency with the currently selected mappings
* adds a task to generate the liteloader mod descriptor file `litemod.json` via directives in the gradle build file
* brings over idiomatic behaviour from my previous recommended build scripts, such as automatically prepending `mod-` to jar and affixing `-mc<version>` (inhibited if the user sets a value for the artefact name)
* automatically adds the `ModType` manifest entry if building to `jar` rather than `litemod`
* supplies free cookies and beer to all

Changes made to other parts of FG for this to be supported:

* moves `UserBasePlugin::remapDeps` into `UserBasePlugin` itself so it can be called from the derived class
* addresses an issue with source remapping which causes duplicate entries to brick the generator