### PR TITLE
Append source set name for IntelliJ runs classpath module

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/UserBaseExtension.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBaseExtension.java
@@ -48,6 +48,7 @@ public class UserBaseExtension extends BaseExtension
     private List<Object>            clientRunArgs    = Lists.newArrayList();
     private List<Object>            serverJvmArgs    = Lists.newArrayList();
     private List<Object>            serverRunArgs    = Lists.newArrayList();
+    private Object                  runSourceSet     = "main";
 
     public UserBaseExtension(UserBasePlugin<? extends UserBaseExtension> plugin)
     {
@@ -373,6 +374,14 @@ public class UserBaseExtension extends BaseExtension
         return resolve(getServerRunArgs());
     }
 
+    public SourceSet getRunSourceSet() {
+        return resolveSourceSet(this.runSourceSet);
+    }
+
+    public void setRunSourceSet(Object runSourceSet) {
+        this.runSourceSet = runSourceSet;
+    }
+
     /**
      * Set the run arguments for the server run config
      *
@@ -391,6 +400,19 @@ public class UserBaseExtension extends BaseExtension
             out.add(Constants.resolveString(o));
         }
         return out;
+    }
+
+    private SourceSet resolveSourceSet(Object obj) {
+        while (obj instanceof Closure)
+            obj = ((Closure<?>) obj).call();
+
+        if (obj instanceof SourceSet)
+            return (SourceSet) obj;
+        else {
+            String name = obj.toString();
+            JavaPluginConvention javaConv = (JavaPluginConvention) project.getConvention().getPlugins().get("java");
+            return javaConv.getSourceSets().getByName(name);
+        }
     }
 
     private Object resolveFile(Object obj)

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -1286,7 +1286,7 @@ public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePl
             addXml(child, "option", ImmutableMap.of("name", "ENABLE_SWING_INSPECTOR", "value", "false"));
             addXml(child, "option", ImmutableMap.of("name", "ENV_VARIABLES"));
             addXml(child, "option", ImmutableMap.of("name", "PASS_PARENT_ENVS", "value", "true"));
-            addXml(child, "module", ImmutableMap.of("name", ((IdeaModel) project.getExtensions().getByName("idea")).getModule().getName()));
+            addXml(child, "module", ImmutableMap.of("name", ((IdeaModel) project.getExtensions().getByName("idea")).getModule().getName() + '_' + getExtension().getRunSourceSet().getName()));
             addXml(child, "RunnerSettings", ImmutableMap.of("RunnerId", "Run"));
             addXml(child, "ConfigurationWrapper", ImmutableMap.of("RunnerId", "Run"));
         }


### PR DESCRIPTION
With these changes ForgeGradle will automatically append the `main` source set name by default to the module name for the classpath. This is required for the run configurations to properly work in IntelliJ IDEA 2016.1 without additional manual changes.

I've also made the special source set configurable, because some project may use a different source set at runtime than the main one. As an example, SpongeForge has an additional `java6` source set which is used to print a proper error to the user to upgrade Java, therefore at runtime the `java6` source set is required (which then depends on the `main` source set). In that case, with this pull request it can be simply configured with:

``` gradle
minecraft {
    runSourceSet = 'java6'
}
```

**I'm still trying to come up with a way to support IntelliJ IDEA 15 at the same time but I haven't found anything simple yet to detect the version the currently created project is using.** I'm open for suggestions.
