### PR TITLE
Improve the liteloader plugin

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteModJson.java
+++ b/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteModJson.java
@@ -19,16 +19,22 @@
  */
 package net.minecraftforge.gradle.user.liteloader;
 
-import com.google.common.base.Strings;
-import com.google.gson.GsonBuilder;
-import org.gradle.api.InvalidUserDataException;
-import org.gradle.api.Project;
-
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.gradle.api.InvalidUserDataException;
+import org.gradle.api.Project;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
 
 public class LiteModJson
 {
@@ -39,30 +45,44 @@ public class LiteModJson
     public List<String> dependsOn;
     public List<String> requiredAPIs;
     public List<String> mixinConfigs;
-    
+    public String description;
+    private transient Map<String, String> descriptionMap;
+
     private transient final Project project;
     private transient final String minecraftVersion;
-    
+
     LiteModJson(Project project, String minecraftVersion)
     {
         this.project = project;
         this.mcversion = this.minecraftVersion = minecraftVersion;
-        
+
         this.name = project.getName();
         this.displayName = project.hasProperty("displayName") ? project.property("displayName").toString() : project.getDescription();
         this.version = project.getVersion().toString();
     }
-    
+
     public void setMcversion(String version)
     {
         this.mcversion = version;
     }
-    
+
     public void setRevision(String revision)
     {
         this.revision = revision;
     }
-    
+
+    public void setDescription(String desc)
+    {
+        this.description = desc;
+    }
+
+    public Map<String, String> getDescription()
+    {
+        if (this.descriptionMap == null)
+            this.descriptionMap = Maps.newHashMap();
+        return this.descriptionMap;
+    }
+
     public List<String> getClassTransformerClasses()
     {
         if (this.classTransformerClasses == null)
@@ -71,7 +91,7 @@ public class LiteModJson
         }
         return this.classTransformerClasses;
     }
-    
+
     public List<String> getDependsOn()
     {
         if (this.dependsOn == null)
@@ -80,7 +100,7 @@ public class LiteModJson
         }
         return this.dependsOn;
     }
-    
+
     public List<String> getRequiredAPIs()
     {
         if (this.requiredAPIs == null)
@@ -89,7 +109,7 @@ public class LiteModJson
         }
         return this.requiredAPIs;
     }
-    
+
     public List<String> getMixinConfigs()
     {
         if (this.mixinConfigs == null)
@@ -102,9 +122,19 @@ public class LiteModJson
     public void toJsonFile(File outputFile) throws IOException
     {
         this.validate();
+
+        Gson gson = new Gson();
+        JsonObject json = gson.fromJson(gson.toJson(this), JsonObject.class);
+        if (this.descriptionMap != null)
+        {
+            for (Entry<String, String> desc : this.descriptionMap.entrySet())
+            {
+                json.addProperty("description." + desc.getKey(), desc.getValue());
+            }
+        }
         
         FileWriter writer = new FileWriter(outputFile);
-        new GsonBuilder().setPrettyPrinting().create().toJson(this, writer);
+        new GsonBuilder().setPrettyPrinting().create().toJson(json, writer);
         writer.flush();
         writer.close();
     }
@@ -113,16 +143,16 @@ public class LiteModJson
     {
         if (Strings.isNullOrEmpty(this.name))
             throw new InvalidUserDataException("litemod json is missing property [name]");
-        
+
         if (Strings.isNullOrEmpty(this.version))
             throw new InvalidUserDataException("litemod json is missing property [version]");
-        
+
         if (Strings.isNullOrEmpty(this.mcversion))
             throw new InvalidUserDataException("litemod json is missing property [mcversion]");
-        
+
         if (Strings.isNullOrEmpty(this.revision))
             throw new InvalidUserDataException("litemod json is missing property [revision]");
-        
+
         try
         {
             Float.parseFloat(this.revision);
@@ -131,11 +161,11 @@ public class LiteModJson
         {
             throw new InvalidUserDataException("invalid format for [revision] property in litemod.json, expected float");
         }
-        
-        if (!this.minecraftVersion.equals(this.mcversion)) {
+
+        if (!this.minecraftVersion.equals(this.mcversion))
+        {
             this.project.getLogger().warn("You are setting a different target version of minecraft to the build environment");
         }
 
     }
-    
 }

--- a/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteModJson.java
+++ b/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteModJson.java
@@ -43,11 +43,10 @@ public class LiteModJson
     private transient final Project project;
     private transient final String minecraftVersion;
     
-    LiteModJson(Project project, String minecraftVersion, String revision)
+    LiteModJson(Project project, String minecraftVersion)
     {
         this.project = project;
         this.mcversion = this.minecraftVersion = minecraftVersion;
-        this.revision = revision;
         
         this.name = project.getName();
         this.displayName = project.hasProperty("displayName") ? project.property("displayName").toString() : project.getDescription();

--- a/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteModTask.java
+++ b/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteModTask.java
@@ -27,7 +27,9 @@ import org.gradle.api.AntBuilder;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.file.SourceDirectorySet;
 import org.gradle.api.internal.ClosureBackedAction;
+import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
@@ -48,6 +50,23 @@ public class LiteModTask extends DefaultTask
     public LiteModTask()
     {
         this.setFileName("litemod.json");
+        // only do this if there isn't a litemod.json in main
+        // XXX: adding litemod.json later requires clean
+        this.onlyIf(new Spec<Task> () {
+            @Override
+            public boolean isSatisfiedBy(Task arg0)
+            {
+                JavaPluginConvention java = ((JavaPluginConvention)getProject().getConvention().getPlugins().get("java"));
+                SourceDirectorySet resources = java.getSourceSets().getByName("main").getResources();
+                return resources.filter(new Spec<File>() {
+                    @Override
+                    public boolean isSatisfiedBy(File arg0)
+                    {
+                        return arg0.getName().equals("litemod.json");
+                    }
+                }).isEmpty();
+            }
+        });
         this.getOutputs().upToDateWhen(new Spec<Task>()
         {
             @Override

--- a/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteloaderPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteloaderPlugin.java
@@ -151,40 +151,41 @@ public class LiteloaderPlugin extends UserVanillaBasePlugin<LiteloaderExtension>
     
     private void applyDependenciesFromJson()
     {
+        final RepoObject repo = this.getRepo();
+        if (repo == null)
+        {
+            return;
+        }
+        
         this.project.allprojects(new Action<Project>() {
             @Override
             public void execute(Project proj)
             {
-                RepoObject repo = LiteloaderPlugin.this.getRepo();
-                if (repo == null)
-                {
-                    return;
-                }
                 addMavenRepo(proj, MAVEN_REPO_NAME, repo.url);
-                
-                Artifact artifact = LiteloaderPlugin.this.getArtifact();
-                if (artifact == null)
-                {
-                    return;
-                }
-                addDependency(proj, CONFIG_LL_DEOBF_COMPILE, artifact.getDepString(repo));
-                
-                for (Map<String, String> library : artifact.getLibraries())
-                {
-                    String name = library.get("name");
-                    if (name != null && !name.isEmpty())
-                    {
-                        addDependency(proj, CONFIG_MC_DEPS, name);
-                    }
-                    
-                    String url = library.get("url");
-                    if (url != null && !url.isEmpty())
-                    {
-                        addMavenRepo(proj, url, url);
-                    }
-                }
             }
         });
+
+        Artifact artifact = this.getArtifact();
+        if (artifact == null)
+        {
+            return;
+        }
+        addDependency(this.project, CONFIG_LL_DEOBF_COMPILE, artifact.getDepString(repo));
+        
+        for (Map<String, String> library : artifact.getLibraries())
+        {
+            String name = library.get("name");
+            if (name != null && !name.isEmpty())
+            {
+                addDependency(this.project, CONFIG_MC_DEPS, name);
+            }
+            
+            String url = library.get("url");
+            if (url != null && !url.isEmpty())
+            {
+                addMavenRepo(this.project, url, url);
+            }
+        }
     }
 
     public VersionObject getVersion(String version)

--- a/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteloaderPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteloaderPlugin.java
@@ -34,6 +34,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.ConfigurationContainer;
 import org.gradle.api.java.archives.Attributes;
+import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.TaskContainer;
 import org.gradle.jvm.tasks.Jar;
 
@@ -88,7 +89,13 @@ public class LiteloaderPlugin extends UserVanillaBasePlugin<LiteloaderExtension>
         final Jar sourceJar = (Jar)tasks.getByName("sourceJar");
         sourceJar.setBaseName(baseName);
         
-        makeTask(TASK_LITEMOD, LiteModTask.class);
+        final LiteModTask litemod = makeTask(TASK_LITEMOD, LiteModTask.class);
+
+        // make sure litemod.json is generated and added to the jar
+        Copy processResources = (Copy) tasks.getByName("processResources");
+        processResources.dependsOn(litemod);
+        processResources.from(litemod.getOutput());
+
     }
 
     @Override


### PR DESCRIPTION
This includes Mumfrey's fix for #347 

It also fixes the build number being incremented every time gradle is run. Now it's only when the task gets ran.

Additionally, the litemod.json now runs by default and is added to the jar if there is no litemod.json in the resources main sourceset.