### PR TITLE
Fix for #347 and add support for description keys in litemod.json

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteModJson.java
+++ b/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteModJson.java
@@ -54,17 +54,23 @@ public class LiteModJson
         {
             this.put(name, value);
         }
-        
+
         public Object propertyMissing(String name)
         {
             return this.get(name);
         }
-        
+
         static class JsonAdapter extends TypeAdapter<Description>
         {
             @Override
             public void write(JsonWriter out, Description value) throws IOException
             {
+                if (value == null)
+                {
+                    out.nullValue();
+                    return;
+                }
+
                 out.value(value.toString());
                 for (Entry<String, Object> entry : value.entrySet())
                 {
@@ -82,7 +88,7 @@ public class LiteModJson
             }
         }
     }
-    
+
     public String name, displayName, version, author;
     public String mcversion, revision;
     public String injectAt, tweakClass;
@@ -90,36 +96,36 @@ public class LiteModJson
     public List<String> dependsOn;
     public List<String> requiredAPIs;
     public List<String> mixinConfigs;
-    
+
     /**
-     * Handle base description and sub-descriptions dynamically 
+     * Handle base description and sub-descriptions dynamically
      */
     public Description description;
-    
+
     private transient final Project project;
     private transient final String minecraftVersion;
-    
+
     LiteModJson(Project project, String minecraftVersion, String revision)
     {
         this.project = project;
         this.mcversion = this.minecraftVersion = minecraftVersion;
         this.revision = revision;
-        
+
         this.name = project.getName();
         this.displayName = project.hasProperty("displayName") ? project.property("displayName").toString() : project.getDescription();
         this.version = project.getVersion().toString();
     }
-    
+
     public void setMcversion(String version)
     {
         this.mcversion = version;
     }
-    
+
     public void setRevision(String revision)
     {
         this.revision = revision;
     }
-    
+
     public List<String> getClassTransformerClasses()
     {
         if (this.classTransformerClasses == null)
@@ -128,7 +134,7 @@ public class LiteModJson
         }
         return this.classTransformerClasses;
     }
-    
+
     public List<String> getDependsOn()
     {
         if (this.dependsOn == null)
@@ -137,7 +143,7 @@ public class LiteModJson
         }
         return this.dependsOn;
     }
-    
+
     public List<String> getRequiredAPIs()
     {
         if (this.requiredAPIs == null)
@@ -146,7 +152,7 @@ public class LiteModJson
         }
         return this.requiredAPIs;
     }
-    
+
     public List<String> getMixinConfigs()
     {
         if (this.mixinConfigs == null)
@@ -155,7 +161,7 @@ public class LiteModJson
         }
         return this.mixinConfigs;
     }
-    
+
     public Description getDescription()
     {
         if (this.description == null)
@@ -164,7 +170,7 @@ public class LiteModJson
         }
         return this.description;
     }
-    
+
     public void setDescription(Object value)
     {
         this.getDescription().put(Description.BASE, value);
@@ -173,7 +179,7 @@ public class LiteModJson
     public void toJsonFile(File outputFile) throws IOException
     {
         this.validate();
-        
+
         FileWriter writer = new FileWriter(outputFile);
         new GsonBuilder().registerTypeAdapter(Description.class, new Description.JsonAdapter()).setPrettyPrinting().create().toJson(this, writer);
         writer.flush();
@@ -184,16 +190,16 @@ public class LiteModJson
     {
         if (Strings.isNullOrEmpty(this.name))
             throw new InvalidUserDataException("litemod json is missing property [name]");
-        
+
         if (Strings.isNullOrEmpty(this.version))
             throw new InvalidUserDataException("litemod json is missing property [version]");
-        
+
         if (Strings.isNullOrEmpty(this.mcversion))
             throw new InvalidUserDataException("litemod json is missing property [mcversion]");
-        
+
         if (Strings.isNullOrEmpty(this.revision))
             throw new InvalidUserDataException("litemod json is missing property [revision]");
-        
+
         try
         {
             Float.parseFloat(this.revision);
@@ -202,11 +208,11 @@ public class LiteModJson
         {
             throw new InvalidUserDataException("invalid format for [revision] property in litemod.json, expected float");
         }
-        
+
         if (!this.minecraftVersion.equals(this.mcversion)) {
             this.project.getLogger().warn("You are setting a different target version of minecraft to the build environment");
         }
 
     }
-    
+
 }

--- a/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteloaderPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/liteloader/LiteloaderPlugin.java
@@ -144,40 +144,41 @@ public class LiteloaderPlugin extends UserVanillaBasePlugin<LiteloaderExtension>
 
     private void applyDependenciesFromJson()
     {
+        final RepoObject repo = this.getRepo();
+        if (repo == null)
+        {
+            return;
+        }
+
         this.project.allprojects(new Action<Project>() {
             @Override
             public void execute(Project proj)
             {
-                RepoObject repo = LiteloaderPlugin.this.getRepo();
-                if (repo == null)
-                {
-                    return;
-                }
                 addMavenRepo(proj, MAVEN_REPO_NAME, repo.url);
-
-                Artifact artifact = LiteloaderPlugin.this.getArtifact();
-                if (artifact == null)
-                {
-                    return;
-                }
-                addDependency(proj, CONFIG_LL_DEOBF_COMPILE, artifact.getDepString(repo));
-
-                for (Map<String, String> library : artifact.getLibraries())
-                {
-                    String name = library.get("name");
-                    if (name != null && !name.isEmpty())
-                    {
-                        addDependency(proj, CONFIG_MC_DEPS, name);
-                    }
-
-                    String url = library.get("url");
-                    if (url != null && !url.isEmpty())
-                    {
-                        addMavenRepo(proj, url, url);
-                    }
-                }
             }
         });
+
+        Artifact artifact = this.getArtifact();
+        if (artifact == null)
+        {
+            return;
+        }
+        addDependency(this.project, CONFIG_LL_DEOBF_COMPILE, artifact.getDepString(repo));
+
+        for (Map<String, String> library : artifact.getLibraries())
+        {
+            String name = library.get("name");
+            if (name != null && !name.isEmpty())
+            {
+                addDependency(this.project, CONFIG_MC_DEPS, name);
+            }
+
+            String url = library.get("url");
+            if (url != null && !url.isEmpty())
+            {
+                addMavenRepo(this.project, url, url);
+            }
+        }
     }
 
     public VersionObject getVersion(String version)


### PR DESCRIPTION
Sorry it took a while, I've been super busy IRL for the last few weeks. This PR addresses the following:
- Provides the fix for issue #347, I have now had a chance to test this and verify that it does indeed solve the problem
- Adds support for `description` keys in the `litemod` task which were previously unsupported. It provides support for sub-mod descriptions by providing a custom `TypeAdapter` for the description map
