### PR TITLE
Gradle 2.14 + 3.0 Fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -91,6 +91,8 @@ dependencies {
     //Stuff used in the GradleStart classes
     compileOnly 'com.mojang:authlib:1.5.16'
     compileOnly "net.minecraft:launchwrapper:1.11"
+
+    testCompile 'junit:junit:4.12'
 }
 
 sourceSets {

--- a/src/main/java/edu/sc/seis/launch4j/Launch4jPlugin.java
+++ b/src/main/java/edu/sc/seis/launch4j/Launch4jPlugin.java
@@ -137,7 +137,7 @@ public class Launch4jPlugin implements Plugin<Project>
         task.setGroup(LAUNCH4J_GROUP);
         // more stuff with the java plugin
         //task.with(configureDistSpec(project));
-        task.into(new Closure<File>(null)
+        task.into(new Closure<File>(Launch4jPlugin.class)
         {
             @Override
             public File call(Object... obj)
@@ -180,7 +180,7 @@ public class Launch4jPlugin implements Plugin<Project>
     @SuppressWarnings({ "serial", "unused" })
     private static CopySpec configureDistSpec(Project project)
     {
-        CopySpec distSpec = project.copySpec(new Closure<Object>(null) {});
+        CopySpec distSpec = project.copySpec(new Closure<Object>(Launch4jPlugin.class) {});
         Jar jar = (Jar) project.getTasks().getByName(JavaPlugin.JAR_TASK_NAME);
 
         distSpec.from(jar);

--- a/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
@@ -354,7 +354,7 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
     {
         EtagDownloadTask getVersionJson = makeTask(TASK_DL_VERSION_JSON, EtagDownloadTask.class);
         {
-            getVersionJson.setUrl(new Closure<String>(null, null) {
+            getVersionJson.setUrl(new Closure<String>(BasePlugin.class) {
                 @Override
                 public String call()
                 {
@@ -363,7 +363,7 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
             });
             getVersionJson.setFile(delayedFile(JSON_VERSION));
             getVersionJson.setDieWithError(false);
-            getVersionJson.doLast(new Closure<Boolean>(project) // normalizes to linux endings
+            getVersionJson.doLast(new Closure<Boolean>(BasePlugin.class) // normalizes to linux endings
             {
                 @Override
                 public Boolean call()
@@ -416,7 +416,7 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
 
         EtagDownloadTask getAssetsIndex = makeTask(TASK_DL_ASSET_INDEX, EtagDownloadTask.class);
         {
-            getAssetsIndex.setUrl(new Closure<String>(null, null) {
+            getAssetsIndex.setUrl(new Closure<String>(BasePlugin.class) {
                 @Override
                 public String call()
                 {
@@ -438,7 +438,7 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
         Download dlClient = makeTask(TASK_DL_CLIENT, Download.class);
         {
             dlClient.setOutput(delayedFile(JAR_CLIENT_FRESH));
-            dlClient.setUrl(new Closure<String>(null, null) {
+            dlClient.setUrl(new Closure<String>(BasePlugin.class) {
                 @Override
                 public String call()
                 {
@@ -452,7 +452,7 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
         Download dlServer = makeTask(TASK_DL_SERVER, Download.class);
         {
             dlServer.setOutput(delayedFile(JAR_SERVER_FRESH));
-            dlServer.setUrl(new Closure<String>(null, null) {
+            dlServer.setUrl(new Closure<String>(BasePlugin.class) {
                 @Override
                 public String call()
                 {
@@ -813,7 +813,7 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
                     new CacheLoader<String, DelayedString>() {
                         public DelayedString load(String key)
                         {
-                            return new DelayedString(replacerCache.getUnchecked(key));
+                            return new DelayedString(CacheLoader.class, replacerCache.getUnchecked(key));
                         }
                     });
     private LoadingCache<String, DelayedFile> fileCache = CacheBuilder.newBuilder()
@@ -822,7 +822,7 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
                     new CacheLoader<String, DelayedFile>() {
                         public DelayedFile load(String key)
                         {
-                            return new DelayedFile(project, replacerCache.getUnchecked(key));
+                            return new DelayedFile(CacheLoader.class, project, replacerCache.getUnchecked(key));
                         }
                     });
 
@@ -838,7 +838,7 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
 
     public DelayedFileTree delayedTree(String path)
     {
-        return new DelayedFileTree(project, replacerCache.getUnchecked(path));
+        return new DelayedFileTree(BasePlugin.class, project, replacerCache.getUnchecked(path));
     }
 
     protected File cacheFile(String path)

--- a/src/main/java/net/minecraftforge/gradle/common/Constants.java
+++ b/src/main/java/net/minecraftforge/gradle/common/Constants.java
@@ -87,7 +87,7 @@ public class Constants
     public static final String GROUP_FG = "ForgeGradle";
 
     @SuppressWarnings("serial")
-    public static final Closure<Boolean> CALL_FALSE = new Closure<Boolean>(null) {
+    public static final Closure<Boolean> CALL_FALSE = new Closure<Boolean>(Constants.class) {
         public Boolean call(Object o)
         {
             return false;

--- a/src/main/java/net/minecraftforge/gradle/patcher/PatcherExtension.java
+++ b/src/main/java/net/minecraftforge/gradle/patcher/PatcherExtension.java
@@ -124,7 +124,7 @@ public class PatcherExtension extends BaseExtension
     @SuppressWarnings("serial")
     protected Closure<File> getDelayedWorkspaceDir()
     {
-        return new Closure<File>(null) {
+        return new Closure<File>(PatcherExtension.class) {
             public File call()
             {
                 return getWorkspaceDir();
@@ -135,7 +135,7 @@ public class PatcherExtension extends BaseExtension
     @SuppressWarnings("serial")
     protected Closure<File> getDelayedSubWorkspaceDir(final String path)
     {
-        return new Closure<File>(null) {
+        return new Closure<File>(PatcherExtension.class) {
             public File call()
             {
                 return new File(getWorkspaceDir(), path);
@@ -146,7 +146,7 @@ public class PatcherExtension extends BaseExtension
     @SuppressWarnings("serial")
     protected Closure<File> getDelayedVersionJson()
     {
-        return new Closure<File>(null) {
+        return new Closure<File>(PatcherExtension.class) {
             public File call()
             {
                 return getVersionJson();

--- a/src/main/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
@@ -239,7 +239,7 @@ public class PatcherPlugin extends BasePlugin<PatcherExtension>
         Zip installer = makeTask(TASK_BUILD_INSTALLER, Zip.class);
         {
             installer.from(outputJar);
-            installer.from(delayedTree(JAR_INSTALLER), new CopyInto("", "!*.json", "!*.png"));
+            installer.from(delayedTree(JAR_INSTALLER), new CopyInto(PatcherPlugin.class, "", "!*.json", "!*.png"));
             installer.from(delayedTree(JSON_INSTALLER));
             installer.setBaseName(project.getName());
             installer.setClassifier("installer");

--- a/src/main/java/net/minecraftforge/gradle/patcher/PatcherProject.java
+++ b/src/main/java/net/minecraftforge/gradle/patcher/PatcherProject.java
@@ -554,7 +554,7 @@ public class PatcherProject implements Serializable
     @SuppressWarnings("serial")
     protected Closure<String> getDelayedMainClassClient()
     {
-        return new Closure<String>(project, this) {
+        return new Closure<String>(PatcherProject.class) {
             public String call()
             {
                 return getMainClassClient();
@@ -565,7 +565,7 @@ public class PatcherProject implements Serializable
     @SuppressWarnings("serial")
     protected Closure<String> getDelayedTweakClassClient()
     {
-        return new Closure<String>(project, this) {
+        return new Closure<String>(PatcherProject.class) {
             public String call()
             {
                 return getTweakClassClient();
@@ -576,7 +576,7 @@ public class PatcherProject implements Serializable
     @SuppressWarnings("serial")
     protected Closure<String> getDelayedRunArgsClient()
     {
-        return new Closure<String>(project, this) {
+        return new Closure<String>(PatcherProject.class) {
             public String call()
             {
                 return getRunArgsClient();
@@ -587,7 +587,7 @@ public class PatcherProject implements Serializable
     @SuppressWarnings("serial")
     protected Closure<String> getDelayedMainClassServer()
     {
-        return new Closure<String>(project, this) {
+        return new Closure<String>(PatcherProject.class) {
             public String call()
             {
                 return getMainClassServer();
@@ -598,7 +598,7 @@ public class PatcherProject implements Serializable
     @SuppressWarnings("serial")
     protected Closure<String> getDelayedTweakClassServer()
     {
-        return new Closure<String>(project, this) {
+        return new Closure<String>(PatcherProject.class) {
             public String call()
             {
                 return getTweakClassServer();
@@ -609,7 +609,7 @@ public class PatcherProject implements Serializable
     @SuppressWarnings("serial")
     protected Closure<String> getDelayedRunArgsServer()
     {
-        return new Closure<String>(project, this) {
+        return new Closure<String>(PatcherProject.class) {
             public String call()
             {
                 return getRunArgsServer();
@@ -620,7 +620,7 @@ public class PatcherProject implements Serializable
     @SuppressWarnings("serial")
     protected Closure<File> getDelayedSourcesDir()
     {
-        return new Closure<File>(project, this) {
+        return new Closure<File>(PatcherProject.class) {
             public File call()
             {
                 return getSourcesDir();
@@ -631,7 +631,7 @@ public class PatcherProject implements Serializable
     @SuppressWarnings("serial")
     protected Closure<File> getDelayedResourcesDir()
     {
-        return new Closure<File>(project, this) {
+        return new Closure<File>(PatcherProject.class) {
             public File call()
             {
                 return getResourcesDir();
@@ -642,7 +642,7 @@ public class PatcherProject implements Serializable
     @SuppressWarnings("serial")
     protected Closure<File> getDelayedTestSourcesDir()
     {
-        return new Closure<File>(project, this) {
+        return new Closure<File>(PatcherProject.class) {
             public File call()
             {
                 return getTestSourcesDir();
@@ -653,7 +653,7 @@ public class PatcherProject implements Serializable
     @SuppressWarnings("serial")
     protected Closure<File> getDelayedTestResourcesDir()
     {
-        return new Closure<File>(project, this) {
+        return new Closure<File>(PatcherProject.class) {
             public File call()
             {
                 return getTestResourcesDir();
@@ -664,7 +664,7 @@ public class PatcherProject implements Serializable
     @SuppressWarnings("serial")
     protected Closure<File> getDelayedPatchDir()
     {
-        return new Closure<File>(project, this) {
+        return new Closure<File>(PatcherProject.class) {
             public File call()
             {
                 return getPatchDir();

--- a/src/main/java/net/minecraftforge/gradle/tasks/CreateStartTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/CreateStartTask.java
@@ -33,10 +33,11 @@ import net.minecraftforge.gradle.common.Constants;
 import net.minecraftforge.gradle.util.caching.Cached;
 import net.minecraftforge.gradle.util.caching.CachedTask;
 
+import org.gradle.api.AntBuilder;
+import org.gradle.api.AntBuilder.AntMessagePriority;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
-import org.gradle.api.logging.LoggingManager;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputDirectory;
@@ -124,14 +125,14 @@ public class CreateStartTask extends CachedTask
                     col = col.plus(config);
             }
 
+            AntBuilder ant = this.getAnt();
             // Remove errors on normal runs
-            LoggingManager log = getLogging();
             LogLevel startLevel = getProject().getGradle().getStartParameter().getLogLevel();
             if (startLevel.compareTo(LogLevel.LIFECYCLE) >= 0) {
-                log.setLevel(LogLevel.ERROR);
+                ant.setLifecycleLogLevel(AntMessagePriority.ERROR);
             }
             // INVOKE!
-            this.getAnt().invokeMethod("javac", ImmutableMap.builder()
+            ant.invokeMethod("javac", ImmutableMap.builder()
                     .put("srcDir", resourceDir.getCanonicalPath())
                     .put("destDir", compiled.getCanonicalPath())
                     .put("failonerror", true)

--- a/src/main/java/net/minecraftforge/gradle/tasks/DeobfuscateJar.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/DeobfuscateJar.java
@@ -439,7 +439,7 @@ public class DeobfuscateJar extends CachedTask
     @SuppressWarnings("serial")
     public Closure<File> getDelayedOutput()
     {
-        return new Closure<File>(getProject(), this) {
+        return new Closure<File>(DeobfuscateJar.class) {
             public File call()
             {
                 return getOutJar();

--- a/src/main/java/net/minecraftforge/gradle/user/ReobfTaskFactory.java
+++ b/src/main/java/net/minecraftforge/gradle/user/ReobfTaskFactory.java
@@ -55,7 +55,7 @@ public class ReobfTaskFactory implements NamedDomainObjectFactory<IReobfuscator>
         task.dependsOn(Constants.TASK_GENERATE_SRGS, jarName);
         task.mustRunAfter("test");
 
-        task.setJar(new Closure<File>(null) {
+        task.setJar(new Closure<File>(ReobfTaskFactory.class) {
             public File call()
             {
                 return ((Jar) plugin.project.getTasks().getByName(jarName)).getArchivePath();

--- a/src/main/java/net/minecraftforge/gradle/user/TaskRecompileMc.java
+++ b/src/main/java/net/minecraftforge/gradle/user/TaskRecompileMc.java
@@ -102,7 +102,7 @@ public class TaskRecompileMc extends CachedTask
                 .put("target", "1.6")
                 .put("debug", "true")
                 .build(),
-            new Closure<Object>(this, this) {
+            new Closure<Object>(TaskRecompileMc.class) {
                 protected Object doCall(Object arguments) {
                     String currentExtDirs = System.getProperty("java.ext.dirs");
                     String newExtDirs = "";

--- a/src/main/java/net/minecraftforge/gradle/user/TaskRecompileMc.java
+++ b/src/main/java/net/minecraftforge/gradle/user/TaskRecompileMc.java
@@ -32,9 +32,10 @@ import java.util.zip.ZipOutputStream;
 import net.minecraftforge.gradle.util.caching.Cached;
 import net.minecraftforge.gradle.util.caching.CachedTask;
 
+import org.gradle.api.AntBuilder;
+import org.gradle.api.AntBuilder.AntMessagePriority;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
-import org.gradle.api.logging.LoggingManager;
 import org.gradle.api.logging.LogLevel;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
@@ -82,15 +83,14 @@ public class TaskRecompileMc extends CachedTask
         // extract sources
         extractSources(tempSrc, inJar);
 
+        AntBuilder ant = this.getAnt();
         // Remove errors on normal runs
-        LoggingManager log = getLogging();
         LogLevel startLevel = getProject().getGradle().getStartParameter().getLogLevel();
         if (startLevel.compareTo(LogLevel.LIFECYCLE) >= 0) {
-            log.setLevel(LogLevel.ERROR);
+            ant.setLifecycleLogLevel(AntMessagePriority.ERROR);
         }
-
         // recompile
-        this.getAnt().invokeMethod("javac", new Object[] {
+        ant.invokeMethod("javac", new Object[] {
             ImmutableMap.builder()
                 .put("srcDir", tempSrc.getCanonicalPath())
                 .put("destDir", tempCls.getCanonicalPath())

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -37,7 +37,6 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
-import com.beust.jcommander.internal.Lists;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.NamedDomainObjectContainer;

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -104,7 +104,7 @@ import net.minecraftforge.gradle.util.delayed.DelayedFile;
 public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePlugin<T>
 {
     private boolean madeDecompTasks = false; // to gaurd against stupid programmers
-    private final Closure<Object> makeRunDir = new Closure<Object>(null, null) {
+    private final Closure<Object> makeRunDir = new Closure<Object>(UserBasePlugin.class) {
         public Object call()
         {
             delayedFile(REPLACE_RUN_DIR).call().mkdirs();
@@ -446,7 +446,7 @@ public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePl
     @SuppressWarnings("serial")
     protected final Object chooseDeobfOutput(final String globalPattern, final String localPattern, final String appendage, final String classifier)
     {
-        return new Closure<DelayedFile>(project, this) {
+        return new Closure<DelayedFile>(UserBasePlugin.class) {
             public DelayedFile call()
             {
                 String classAdd = Strings.isNullOrEmpty(classifier) ? "" : "-" + classifier;
@@ -825,7 +825,7 @@ public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePl
         sourceJar.setClassifier("sources");
         sourceJar.dependsOn(main.getCompileJavaTaskName(), main.getProcessResourcesTaskName(), getSourceSetFormatted(main, TMPL_TASK_RETROMAP_RPL));
 
-        sourceJar.from(new Closure<Object>(this, this) {
+        sourceJar.from(new Closure<Object>(UserBasePlugin.class) {
             public Object call() {
                 File file = delayedFile(retromappedSrc).call();
                 if (file.exists())
@@ -1193,7 +1193,7 @@ public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePl
         if (ideaConv.getWorkspace().getIws() == null)
             return;
 
-        ideaConv.getWorkspace().getIws().withXml(new Closure<Object>(this, null)
+        ideaConv.getWorkspace().getIws().withXml(new Closure<Object>(UserBasePlugin.class)
         {
             public Object call(Object... obj)
             {

--- a/src/main/java/net/minecraftforge/gradle/user/patcherUser/PatcherUserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/patcherUser/PatcherUserBasePlugin.java
@@ -77,7 +77,7 @@ public abstract class PatcherUserBasePlugin<T extends UserBaseExtension> extends
             extractUserdev.exclude("META-INF/**", "META-INF/**");
             extractUserdev.dependsOn(TASK_DL_VERSION_JSON);
 
-            extractUserdev.doLast(new Closure<Boolean>(project) // normalizes to linux endings
+            extractUserdev.doLast(new Closure<Boolean>(PatcherUserBasePlugin.class) // normalizes to linux endings
             {
                 @Override
                 public Boolean call()

--- a/src/main/java/net/minecraftforge/gradle/util/CopyInto.java
+++ b/src/main/java/net/minecraftforge/gradle/util/CopyInto.java
@@ -35,16 +35,16 @@ public class CopyInto extends Closure<Object>
     private String[] filters;
     private HashMap<String, Object> expands = new HashMap<String, Object>();
     
-    public CopyInto(String dir)
+    public CopyInto(Class<?> owner, String dir)
     {
-        super(null);
+        super(owner);
         this.dir = dir;
         this.filters = new String[] {};
     }
 
-    public CopyInto(String dir, String... filters)
+    public CopyInto(Class<?> owner, String dir, String... filters)
     {
-        super(null);
+        super(owner);
         this.dir = dir;
         this.filters = filters;
     }

--- a/src/main/java/net/minecraftforge/gradle/util/SourceDirSetSupplier.java
+++ b/src/main/java/net/minecraftforge/gradle/util/SourceDirSetSupplier.java
@@ -19,13 +19,13 @@
  */
 package net.minecraftforge.gradle.util;
 
-import com.beust.jcommander.internal.Lists;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import net.minecraftforge.srg2source.util.io.InputSupplier;
 import net.minecraftforge.srg2source.util.io.OutputSupplier;
 import org.gradle.api.file.FileVisitDetails;
 import org.gradle.api.file.FileVisitor;
 import org.gradle.api.file.SourceDirectorySet;
-import org.testng.collections.Maps;
 
 import java.io.*;
 import java.util.List;

--- a/src/main/java/net/minecraftforge/gradle/util/delayed/DelayedBase.java
+++ b/src/main/java/net/minecraftforge/gradle/util/delayed/DelayedBase.java
@@ -26,15 +26,15 @@ public abstract class DelayedBase<V> extends Closure<V>
 {
     protected TokenReplacer replacer;
 
-    public DelayedBase(ReplacementProvider provider, String pattern)
+    public DelayedBase(Class<?> owner, ReplacementProvider provider, String pattern)
     {
-        super(null);
+        super(owner);
         replacer = new TokenReplacer(provider, pattern);
     }
     
-    public DelayedBase(TokenReplacer replacer)
+    public DelayedBase(Class<?> owner, TokenReplacer replacer)
     {
-        super(null);
+        super(owner);
         this.replacer = replacer;
     }
 

--- a/src/main/java/net/minecraftforge/gradle/util/delayed/DelayedFile.java
+++ b/src/main/java/net/minecraftforge/gradle/util/delayed/DelayedFile.java
@@ -29,23 +29,23 @@ public class DelayedFile extends DelayedBase<File>
     protected final File hardcoded;
     protected transient final Project project;
     
-    public DelayedFile(File file)
+    public DelayedFile(Class<?> owner, File file)
     {
-        super((TokenReplacer)null);
+        super(owner, (TokenReplacer)null);
         hardcoded = file;
         project = null;
     }
     
-    public DelayedFile(Project project, ReplacementProvider provider, String pattern)
+    public DelayedFile(Class<?> owner, Project project, ReplacementProvider provider, String pattern)
     {
-        super(provider, pattern);
+        super(owner, provider, pattern);
         hardcoded = null;
         this.project = project;
     }
     
-    public DelayedFile(Project project, TokenReplacer replacer)
+    public DelayedFile(Class<?> owner, Project project, TokenReplacer replacer)
     {
-        super(replacer);
+        super(owner, replacer);
         hardcoded = null;
         this.project = project;
         
@@ -63,9 +63,9 @@ public class DelayedFile extends DelayedBase<File>
     public DelayedFileTree toZipTree()
     {
         if (hardcoded != null)
-            return new DelayedFileTree(hardcoded);
+            return new DelayedFileTree(DelayedFile.class, hardcoded);
         else
-            return new DelayedFileTree(project, replacer);
+            return new DelayedFileTree(DelayedFile.class, project, replacer);
         
     }
 }

--- a/src/main/java/net/minecraftforge/gradle/util/delayed/DelayedFileTree.java
+++ b/src/main/java/net/minecraftforge/gradle/util/delayed/DelayedFileTree.java
@@ -30,23 +30,23 @@ public class DelayedFileTree extends DelayedBase<FileTree>
     protected final File hardcoded;
     protected transient final Project project;
     
-    public DelayedFileTree(File file)
+    public DelayedFileTree(Class<?> owner, File file)
     {
-        super((TokenReplacer)null);
+        super(owner, (TokenReplacer)null);
         hardcoded = file;
         project = null;
     }
     
-    public DelayedFileTree(Project project, ReplacementProvider provider, String pattern)
+    public DelayedFileTree(Class<?> owner, Project project, ReplacementProvider provider, String pattern)
     {
-        super(provider, pattern);
+        super(owner, provider, pattern);
         hardcoded = null;
         this.project = project;
     }
     
-    public DelayedFileTree(Project project, TokenReplacer replacer)
+    public DelayedFileTree(Class<?> owner, Project project, TokenReplacer replacer)
     {
-        super(replacer);
+        super(owner, replacer);
         hardcoded = null;
         this.project = project;
         

--- a/src/main/java/net/minecraftforge/gradle/util/delayed/DelayedString.java
+++ b/src/main/java/net/minecraftforge/gradle/util/delayed/DelayedString.java
@@ -23,14 +23,14 @@ package net.minecraftforge.gradle.util.delayed;
 @SuppressWarnings("serial")
 public class DelayedString extends DelayedBase<String>
 {
-    public DelayedString(ReplacementProvider provider,  String pattern)
+    public DelayedString(Class<?> owner, ReplacementProvider provider,  String pattern)
     {
-        super(provider, pattern);
+        super(owner, provider, pattern);
     }
     
-    public DelayedString(TokenReplacer replacer)
+    public DelayedString(Class<?> owner, TokenReplacer replacer)
     {
-        super(replacer);
+        super(owner, replacer);
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/gradle/util/json/JsonFactory.java
+++ b/src/main/java/net/minecraftforge/gradle/util/json/JsonFactory.java
@@ -26,7 +26,6 @@ import java.io.IOException;
 import java.util.*;
 import java.util.Map.Entry;
 
-import com.beust.jcommander.internal.Lists;
 import com.google.common.base.Strings;
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;


### PR DESCRIPTION
Fixes compiling on 2.14 as well as importing to Eclipse (and maybe IntelliJ).
Makes all `Closure` implementations have owners, strips `thisObject` since it may lead to serialization loops.