### PR TITLE
Fix server run arguments getting incorrectly added to the JVM args

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -259,7 +259,7 @@ public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePl
             exec.classpath(jarTask.getArchivePath());
             exec.dependsOn(jarTask);
             exec.jvmArgs(getServerJvmArgs(getExtension()));
-            exec.jvmArgs(getServerRunArgs(getExtension()));
+            exec.args(getServerRunArgs(getExtension()));
         }
 
         // complain about version number


### PR DESCRIPTION
For the `runServer` task the run arguments are getting incorrectly added to the JVM args which causes the JVM to crash on startup if any arguments are defined. This changes the method call so they get added as normal program arguments.

Example: https://github.com/SpongePowered/SpongeVanilla/issues/258
