### PR TITLE
Use parent, not bound project, for getting FG dep

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
@@ -362,7 +362,7 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
         Dependency fgDepTemp = null;
         Configuration buildscriptClasspath = null;
         while (parent != null && fgDepTemp == null) {
-            buildscriptClasspath = project.getBuildscript().getConfigurations().getByName("classpath");
+            buildscriptClasspath = parent.getBuildscript().getConfigurations().getByName("classpath");
             fgDepTemp = Iterables.getFirst(buildscriptClasspath.getDependencies().matching(new Spec<Dependency>() {
                 @Override
                 public boolean isSatisfiedBy(Dependency element)


### PR DESCRIPTION
Apologies for #393 being so buggy. This fixes #400, properly.

- Tested on #400's repo ✔️
- `./gradlew build` ✔️ 