### PR TITLE
Fix #403 Add fallback URL for MCP json

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/common/Constants.java
+++ b/src/main/java/net/minecraftforge/gradle/common/Constants.java
@@ -115,12 +115,15 @@ public class Constants
 
 
     // urls
-    public static final String URL_MC_MANIFEST  = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
-    public static final String URL_FF           = "http://files.minecraftforge.net/fernflower-fix-1.0.zip";
-    public static final String URL_ASSETS       = "http://resources.download.minecraft.net";
-    public static final String URL_LIBRARY      = "https://libraries.minecraft.net/";
-    public static final String URL_FORGE_MAVEN  = "http://files.minecraftforge.net/maven";
-    public static final String URL_MCP_JSON     = "http://export.mcpbot.bspk.rs/versions.json";
+    public static final String URL_MC_MANIFEST     = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
+    public static final String URL_FF              = "http://files.minecraftforge.net/fernflower-fix-1.0.zip";
+    public static final String URL_ASSETS          = "http://resources.download.minecraft.net";
+    public static final String URL_LIBRARY         = "https://libraries.minecraft.net/";
+    public static final String URL_FORGE_MAVEN     = "http://files.minecraftforge.net/maven";
+    public static final List<String> URLS_MCP_JSON = Arrays.asList(
+            URL_FORGE_MAVEN + "/de/oceanlabs/mcp/versions.json",
+            "http://export.mcpbot.bspk.rs/versions.json"
+    );
 
     // configs
     public static final String CONFIG_MCP_DATA       = "forgeGradleMcpData";


### PR DESCRIPTION
bspkrs added the MCP json to http://files.minecraftforge.net/maven/de/oceanlabs/mcp/versions.json
See #403

This PR makes ForgeGradle check both URLs, falling back on the old one if the new one is down for some reason.