### PR TITLE
[FG-2.2] Add checks for unsupported minecraft versions.

### DIFF
--- a/src/test/java/net/minecraftforge/gradle/versions/ExtensionForgeVersionTest.java
+++ b/src/test/java/net/minecraftforge/gradle/versions/ExtensionForgeVersionTest.java
@@ -46,6 +46,7 @@ public class ExtensionForgeVersionTest
 
         this.ext = this.testProject.getExtensions().findByType(ForgeExtension.class);   // unlike getByType(), does not throw exception
         assertNotNull(this.ext);
+        this.ext.setSuppressVersionTest(true);
     }
 
     // Invalid version notation! The following are valid notations. BuildNumber, version, version-branch, mcversion-version-branch, and pomotion (sic)

--- a/src/test/java/net/minecraftforge/gradle/versions/ExtensionLiteLoaderVersionTest.java
+++ b/src/test/java/net/minecraftforge/gradle/versions/ExtensionLiteLoaderVersionTest.java
@@ -44,6 +44,7 @@ public class ExtensionLiteLoaderVersionTest
 
         this.ext = this.testProject.getExtensions().findByType(LiteloaderExtension.class);   // unlike getByType(), does not throw exception
         assertNotNull(this.ext);
+        this.ext.setSuppressVersionTest(true);
     }
 
     // Invalid version notation! The following are valid notations. BuildNumber, version, version-branch, mcversion-version-branch, and pomotion (sic)

--- a/src/test/java/net/minecraftforge/gradle/versions/ExtensionMcpMappingTest.java
+++ b/src/test/java/net/minecraftforge/gradle/versions/ExtensionMcpMappingTest.java
@@ -46,6 +46,7 @@ public class ExtensionMcpMappingTest
 
         this.ext = this.testProject.getExtensions().findByType(TweakerExtension.class);   // unlike getByType(), does not throw exception
         assertNotNull(this.ext);
+        this.ext.setSuppressVersionTest(true);
         
         this.ext.setTweakClass("some.thing.other"); // to ignore any issues regarding this.
     }


### PR DESCRIPTION
This adds a quick check for supported minecraft versions when it is set. I assuming Minecraft will keep to semantic versioning, but if a version detail cannot be parsed, 0 will be used instead.

So `1.7.10` > `1.7.🍌`

This will fix the issue of updating to 1.12 and forgetting to update fg to 2.3, thus corrupting your cache.

FG-2.3 version: #431 