### PR TITLE
Add support for Kotlin source replacements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     compileOnly 'com.mojang:authlib:1.5.16'
     compileOnly "net.minecraft:launchwrapper:1.11"
 
-    compile "org.jetbrains.kotlin:kotlin-gradle-plugin:1.1.3-2"
+    compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:1.1.3-2"
 
     testCompile 'junit:junit:4.12'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,8 @@ dependencies {
     compileOnly 'com.mojang:authlib:1.5.16'
     compileOnly "net.minecraft:launchwrapper:1.11"
 
+    compile "org.jetbrains.kotlin:kotlin-gradle-plugin:1.1.3-2"
+
     testCompile 'junit:junit:4.12'
 }
 


### PR DESCRIPTION
This fixes #427. It basically uses the same approach as all the other additional languages, but it's actually more of a direct adaptation of the fix I referenced in that issue (which technically is based on the other additional languages xD). We can use the Kotlin Plugin API without strictly depending on it at mod build time by making it a compile-only dependency. I've tested it with both the kotlin plugin applied and without it, there are no issues loading the FG classes.
If leaving the references in there is considered too risky, I can move them to a wrapper class and interface that acts as a proxy to the actual implementation to minimise hard dependencies on the plugin.