### PR TITLE
Remove ParallelizableTask

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/tasks/AbstractEditJarTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/AbstractEditJarTask.java
@@ -36,13 +36,11 @@ import net.minecraftforge.gradle.util.caching.CachedTask;
 
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.ParallelizableTask;
 import org.gradle.api.tasks.TaskAction;
 
 import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
 
-@ParallelizableTask
 public abstract class AbstractEditJarTask extends CachedTask
 {
     @InputFile

--- a/src/main/java/net/minecraftforge/gradle/tasks/Download.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/Download.java
@@ -35,12 +35,10 @@ import net.minecraftforge.gradle.util.caching.CachedTask;
 
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.ParallelizableTask;
 import org.gradle.api.tasks.TaskAction;
 
 import com.google.common.io.Closeables;
 
-@ParallelizableTask
 public class Download extends CachedTask
 {
     @Input

--- a/src/main/java/net/minecraftforge/gradle/tasks/EtagDownloadTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/EtagDownloadTask.java
@@ -33,7 +33,6 @@ import net.minecraftforge.gradle.common.Constants;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.ParallelizableTask;
 import org.gradle.api.tasks.TaskAction;
 
 import com.google.common.base.Charsets;
@@ -41,7 +40,6 @@ import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 
-@ParallelizableTask
 public class EtagDownloadTask extends DefaultTask
 {
     @Input

--- a/src/main/java/net/minecraftforge/gradle/tasks/ExtractConfigTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/ExtractConfigTask.java
@@ -36,12 +36,10 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.ParallelizableTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 
-@ParallelizableTask
 public class ExtractConfigTask extends CachedTask implements PatternFilterable
 {
 

--- a/src/main/java/net/minecraftforge/gradle/tasks/ExtractTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/ExtractTask.java
@@ -37,12 +37,10 @@ import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
-import org.gradle.api.tasks.ParallelizableTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
 
-@ParallelizableTask
 public class ExtractTask extends CachedTask implements PatternFilterable
 {
 

--- a/src/main/java/net/minecraftforge/gradle/tasks/GenEclipseRunTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/GenEclipseRunTask.java
@@ -39,7 +39,6 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.ParallelizableTask;
 import org.gradle.api.tasks.TaskAction;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -47,7 +46,6 @@ import org.w3c.dom.Element;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 
-@ParallelizableTask
 public class GenEclipseRunTask extends DefaultTask
 {
     //@formatter:off

--- a/src/main/java/net/minecraftforge/gradle/tasks/ObtainFernFlowerTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/ObtainFernFlowerTask.java
@@ -35,13 +35,11 @@ import net.minecraftforge.gradle.util.delayed.DelayedString;
 
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.ParallelizableTask;
 import org.gradle.api.tasks.TaskAction;
 
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 
-@ParallelizableTask
 public class ObtainFernFlowerTask extends CachedTask
 {
     @Input

--- a/src/main/java/net/minecraftforge/gradle/tasks/PatchSourcesTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/PatchSourcesTask.java
@@ -41,7 +41,6 @@ import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
-import org.gradle.api.tasks.ParallelizableTask;
 
 import com.cloudbees.diff.PatchException;
 import com.google.common.base.Charsets;
@@ -50,7 +49,6 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 
-@ParallelizableTask
 public class PatchSourcesTask extends AbstractEditJarTask
 {
     /*

--- a/src/main/java/net/minecraftforge/gradle/tasks/RemapSources.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/RemapSources.java
@@ -29,7 +29,6 @@ import net.minecraftforge.gradle.util.delayed.DelayedFile;
 import net.minecraftforge.gradle.util.mcp.JavadocAdder;
 
 import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.ParallelizableTask;
 
 import au.com.bytecode.opencsv.CSVReader;
 
@@ -39,7 +38,6 @@ import com.google.common.collect.Maps;
 import com.google.code.regexp.Matcher;
 import com.google.code.regexp.Pattern;
 
-@ParallelizableTask
 public class RemapSources extends AbstractEditJarTask
 {
     @InputFile

--- a/src/main/java/net/minecraftforge/gradle/tasks/SignJar.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/SignJar.java
@@ -42,7 +42,6 @@ import org.gradle.api.specs.Spec;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.ParallelizableTask;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.util.PatternFilterable;
 import org.gradle.api.tasks.util.PatternSet;
@@ -54,7 +53,6 @@ import com.google.common.io.ByteStreams;
 import groovy.lang.Closure;
 import groovy.util.MapEntry;
 
-@ParallelizableTask
 public class SignJar extends DefaultTask implements PatternFilterable
 {
     //@formatter:off

--- a/src/main/java/net/minecraftforge/gradle/user/TaskDepDummy.java
+++ b/src/main/java/net/minecraftforge/gradle/user/TaskDepDummy.java
@@ -26,10 +26,8 @@ import java.util.jar.JarEntry;
 import java.util.jar.JarOutputStream;
 
 import org.gradle.api.DefaultTask;
-import org.gradle.api.tasks.ParallelizableTask;
 import org.gradle.api.tasks.TaskAction;
 
-@ParallelizableTask
 public class TaskDepDummy extends DefaultTask
 {
     private Object outputFile;

--- a/src/main/java/net/minecraftforge/gradle/user/TaskSingleDeobfBin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/TaskSingleDeobfBin.java
@@ -36,7 +36,6 @@ import net.minecraftforge.gradle.util.caching.CachedTask;
 
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
-import org.gradle.api.tasks.ParallelizableTask;
 import org.gradle.api.tasks.TaskAction;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassWriter;
@@ -48,7 +47,6 @@ import au.com.bytecode.opencsv.CSVReader;
 import com.google.common.collect.Maps;
 import com.google.common.io.ByteStreams;
 
-@ParallelizableTask
 public class TaskSingleDeobfBin extends CachedTask
 {
     @InputFile

--- a/src/main/java/net/minecraftforge/gradle/user/TaskSingleReobf.java
+++ b/src/main/java/net/minecraftforge/gradle/user/TaskSingleReobf.java
@@ -36,7 +36,6 @@ import java.util.zip.ZipOutputStream;
 
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.tasks.ParallelizableTask;
 import org.gradle.api.tasks.TaskAction;
 
 import com.google.common.base.Charsets;
@@ -94,7 +93,6 @@ import net.minecraftforge.gradle.util.mcp.ReobfExceptor;
  * </pre>
  *
  */
-@ParallelizableTask
 public class TaskSingleReobf extends DefaultTask
 {
     private Object                 jar;


### PR DESCRIPTION
It was never actually used (see: https://discuss.gradle.org/t/parallelizabletask-is-removed-in-gradle-4-0/22970/7), and has been removed in Gradle 4.x so ForgeGradle doesn't compile on it.