### PR TITLE
Close Jar files after use

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     compile 'com.github.tony19:named-regexp:0.2.3' // 1.7 Named regexp features
     compile 'net.minecraftforge:forgeflower:1.0.342-SNAPSHOT' // Fernflower Forge edition
 
-    shade 'net.md-5:SpecialSource:1.7.4' // deobf and reobs
+    shade 'net.md-5:SpecialSource:1.8.0' // deobf and reobs
     // compile 'net.md-5:SpecialSource:1.7.4' // when md5 publishes
 
     // because curse

--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ dependencies {
     compile gradleApi()
 
     // moved to the beginning to be the overrider
-    compile 'org.ow2.asm:asm-debug-all:5.1'
+    compile 'org.ow2.asm:asm-debug-all:6.0_BETA'
     compile 'com.google.guava:guava:18.0'
 
     compile 'net.sf.opencsv:opencsv:2.3' // reading CSVs.. also used by SpecialSource

--- a/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
@@ -725,10 +725,12 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
                 }
                 else if (con.getResponseCode() == 200)
                 {
-                    InputStream stream = con.getInputStream();
-                    byte[] data = ByteStreams.toByteArray(stream);
+                    byte[] data;
+                    try (InputStream stream = con.getInputStream())
+                    {
+                        data = ByteStreams.toByteArray(stream);
+                    }
                     Files.write(data, cache);
-                    stream.close();
 
                     // write etag
                     etag = con.getHeaderField("ETag");

--- a/src/main/java/net/minecraftforge/gradle/common/Constants.java
+++ b/src/main/java/net/minecraftforge/gradle/common/Constants.java
@@ -319,17 +319,14 @@ public class Constants
         // make dirs just in case
         out.getParentFile().mkdirs();
 
-        FileInputStream fis = new FileInputStream(in);
-        FileOutputStream fout = new FileOutputStream(out);
-
-        FileChannel source = fis.getChannel();
-        FileChannel dest = fout.getChannel();
-
-        long size = source.size();
-        source.transferTo(0, size, dest);
-
-        fis.close();
-        fout.close();
+        try (FileInputStream fis = new FileInputStream(in);
+             FileOutputStream fout = new FileOutputStream(out);
+             FileChannel source = fis.getChannel();
+             FileChannel dest = fout.getChannel())
+        {
+            long size = source.size();
+            source.transferTo(0, size, dest);
+        }
     }
 
     /**
@@ -345,16 +342,13 @@ public class Constants
         // make dirs just in case
         out.getParentFile().mkdirs();
 
-        FileInputStream fis = new FileInputStream(in);
-        FileOutputStream fout = new FileOutputStream(out);
-
-        FileChannel source = fis.getChannel();
-        FileChannel dest = fout.getChannel();
-
-        source.transferTo(0, size, dest);
-
-        fis.close();
-        fout.close();
+        try (FileInputStream fis = new FileInputStream(in);
+             FileOutputStream fout = new FileOutputStream(out);
+             FileChannel source = fis.getChannel();
+             FileChannel dest = fout.getChannel())
+        {
+            source.transferTo(0, size, dest);
+        }
     }
 
     public static String hash(File file)
@@ -400,12 +394,10 @@ public class Constants
 
     public static String hashZip(File file, String function)
     {
-        try
+        try (ZipInputStream zin = new ZipInputStream(new FileInputStream(file)))
         {
             MessageDigest hasher = MessageDigest.getInstance(function);
-
-            ZipInputStream zin = new ZipInputStream(new FileInputStream(file));
-            ZipEntry entry = null;
+            ZipEntry entry;
             while ((entry = zin.getNextEntry()) != null)
             {
                 hasher.update(entry.getName().getBytes());

--- a/src/main/java/net/minecraftforge/gradle/patcher/TaskExtractExcModifiers.java
+++ b/src/main/java/net/minecraftforge/gradle/patcher/TaskExtractExcModifiers.java
@@ -64,31 +64,29 @@ class TaskExtractExcModifiers extends DefaultTask
         output.getParentFile().mkdirs();
         output.createNewFile();
         
-        
-        BufferedWriter writer = Files.newWriter(output, Charsets.UTF_8);
-        ZipInputStream zin = new ZipInputStream(new FileInputStream(input));
-        ZipEntry entry = null;
-
-        while ((entry = zin.getNextEntry()) != null)
+        try (BufferedWriter writer = Files.newWriter(output, Charsets.UTF_8);
+            ZipInputStream zin = new ZipInputStream(new FileInputStream(input)))
         {
-            if (entry.isDirectory())
-                continue;
+            ZipEntry entry;
 
-            String entryName = entry.getName();
-            
-            if (!entryName.endsWith(".class") || !entryName.startsWith("net/minecraft/"))
-                continue;
+            while ((entry = zin.getNextEntry()) != null)
+            {
+                if (entry.isDirectory())
+                    continue;
 
-            getProject().getLogger().debug("Processing " + entryName);
-            byte[] entryData = ByteStreams.toByteArray(zin);
+                String entryName = entry.getName();
 
-            ClassReader cr = new ClassReader(entryData);
-            ClassVisitor ca = new GenerateMapClassAdapter(writer);
-            cr.accept(ca, 0);
+                if (!entryName.endsWith(".class") || !entryName.startsWith("net/minecraft/"))
+                    continue;
+
+                getProject().getLogger().debug("Processing " + entryName);
+                byte[] entryData = ByteStreams.toByteArray(zin);
+
+                ClassReader cr = new ClassReader(entryData);
+                ClassVisitor ca = new GenerateMapClassAdapter(writer);
+                cr.accept(ca, 0);
+            }
         }
-
-        zin.close();
-        writer.close();
     }
     
     private static class GenerateMapClassAdapter extends ClassVisitor

--- a/src/main/java/net/minecraftforge/gradle/patcher/TaskGenBinPatches.java
+++ b/src/main/java/net/minecraftforge/gradle/patcher/TaskGenBinPatches.java
@@ -175,49 +175,48 @@ class TaskGenBinPatches extends DefaultTask
 
     private void createBinPatches(HashMap<String, byte[]> patches, String root, File base, File target) throws Exception
     {
-        JarFile cleanJ = new JarFile(base);
-        JarFile dirtyJ = new JarFile(target);
-
-        for (Map.Entry<String, String> entry : obfMapping.entrySet())
+        try (JarFile cleanJ = new JarFile(base);
+             JarFile dirtyJ = new JarFile(target))
         {
-            String obf = entry.getKey();
-            String srg = entry.getValue();
 
-            if (!patchedFiles.contains(obf)) // Not in the list of patch files.. we didn't edit it.
+            for (Map.Entry<String, String> entry : obfMapping.entrySet())
             {
-                continue;
+                String obf = entry.getKey();
+                String srg = entry.getValue();
+
+                if (!patchedFiles.contains(obf)) // Not in the list of patch files.. we didn't edit it.
+                {
+                    continue;
+                }
+
+                JarEntry cleanE = cleanJ.getJarEntry(obf + ".class");
+                JarEntry dirtyE = dirtyJ.getJarEntry(obf + ".class");
+
+                if (dirtyE == null) //Something odd happened.. a base MC class wasn't in the obfed jar?
+                {
+                    continue;
+                }
+
+                byte[] clean = (cleanE != null ? ByteStreams.toByteArray(cleanJ.getInputStream(cleanE)) : new byte[0]);
+                byte[] dirty = ByteStreams.toByteArray(dirtyJ.getInputStream(dirtyE));
+
+                byte[] diff = delta.compute(clean, dirty);
+
+                ByteArrayDataOutput out = ByteStreams.newDataOutput(diff.length + 50);
+                out.writeUTF(obf);                   // Clean name
+                out.writeUTF(obf.replace('/', '.')); // Source Notch name
+                out.writeUTF(srg.replace('/', '.')); // Source SRG Name
+                out.writeBoolean(cleanE != null);    // Exists in Clean
+                if (cleanE != null)
+                {
+                    out.writeInt(adlerHash(clean)); // Hash of Clean file
+                }
+                out.writeInt(diff.length); // Patch length
+                out.write(diff);           // Patch
+
+                patches.put(root + srg.replace('/', '.') + ".binpatch", out.toByteArray());
             }
-
-            JarEntry cleanE = cleanJ.getJarEntry(obf + ".class");
-            JarEntry dirtyE = dirtyJ.getJarEntry(obf + ".class");
-
-            if (dirtyE == null) //Something odd happened.. a base MC class wasn't in the obfed jar?
-            {
-                continue;
-            }
-
-            byte[] clean = (cleanE != null ? ByteStreams.toByteArray(cleanJ.getInputStream(cleanE)) : new byte[0]);
-            byte[] dirty = ByteStreams.toByteArray(dirtyJ.getInputStream(dirtyE));
-
-            byte[] diff = delta.compute(clean, dirty);
-
-            ByteArrayDataOutput out = ByteStreams.newDataOutput(diff.length + 50);
-            out.writeUTF(obf);                   // Clean name
-            out.writeUTF(obf.replace('/', '.')); // Source Notch name
-            out.writeUTF(srg.replace('/', '.')); // Source SRG Name
-            out.writeBoolean(cleanE != null);    // Exists in Clean
-            if (cleanE != null)
-            {
-                out.writeInt(adlerHash(clean)); // Hash of Clean file
-            }
-            out.writeInt(diff.length); // Patch length
-            out.write(diff);           // Patch
-
-            patches.put(root + srg.replace('/', '.') + ".binpatch", out.toByteArray());
         }
-
-        cleanJ.close();
-        dirtyJ.close();
     }
 
     private int adlerHash(byte[] input)
@@ -230,13 +229,14 @@ class TaskGenBinPatches extends DefaultTask
     private byte[] createPatchJar(HashMap<String, byte[]> patches) throws Exception
     {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        JarOutputStream jar = new JarOutputStream(out);
-        for (Map.Entry<String, byte[]> entry : patches.entrySet())
+        try (JarOutputStream jar = new JarOutputStream(out))
         {
-            jar.putNextEntry(new JarEntry("binpatch/" + entry.getKey()));
-            jar.write(entry.getValue());
+            for (Map.Entry<String, byte[]> entry : patches.entrySet())
+            {
+                jar.putNextEntry(new JarEntry("binpatch/" + entry.getKey()));
+                jar.write(entry.getValue());
+            }
         }
-        jar.close();
         return out.toByteArray();
     }
 
@@ -266,9 +266,10 @@ class TaskGenBinPatches extends DefaultTask
     private byte[] compress(byte[] data) throws Exception
     {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        LzmaOutputStream lzma = new LzmaOutputStream.Builder(out).useEndMarkerMode(true).build();
-        lzma.write(data);
-        lzma.close();
+        try (LzmaOutputStream lzma = new LzmaOutputStream.Builder(out).useEndMarkerMode(true).build())
+        {
+            lzma.write(data);
+        }
         return out.toByteArray();
     }
 

--- a/src/main/java/net/minecraftforge/gradle/patcher/TaskReobfuscate.java
+++ b/src/main/java/net/minecraftforge/gradle/patcher/TaskReobfuscate.java
@@ -116,25 +116,26 @@ class TaskReobfuscate extends DefaultTask
         JarRemapper remapper = new JarRemapper(null, mapping);
 
         // load jar
-        Jar input = Jar.init(inJar);
-
-        // ensure that inheritance provider is used
-        JointProvider inheritanceProviders = new JointProvider();
-        inheritanceProviders.add(new JarProvider(input));
-
-        if (classpath != null)
-            inheritanceProviders.add(new ClassLoaderProvider(new URLClassLoader(Constants.toUrls(classpath))));
-
-        mapping.setFallbackInheritanceProvider(inheritanceProviders);
-
-        File out = getOutJar();
-        if (!out.getParentFile().exists()) //Needed because SS doesn't create it.
+        try (Jar input = Jar.init(inJar))
         {
-            out.getParentFile().mkdirs();
-        }
+            // ensure that inheritance provider is used
+            JointProvider inheritanceProviders = new JointProvider();
+            inheritanceProviders.add(new JarProvider(input));
 
-        // remap jar
-        remapper.remapJar(input, getOutJar());
+            if (classpath != null)
+                inheritanceProviders.add(new ClassLoaderProvider(new URLClassLoader(Constants.toUrls(classpath))));
+
+            mapping.setFallbackInheritanceProvider(inheritanceProviders);
+
+            File out = getOutJar();
+            if (!out.getParentFile().exists()) //Needed because SS doesn't create it.
+            {
+                out.getParentFile().mkdirs();
+            }
+
+            // remap jar
+            remapper.remapJar(input, getOutJar());
+        }
     }
     
     public File getInJar()

--- a/src/main/java/net/minecraftforge/gradle/tasks/CrowdinDownload.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/CrowdinDownload.java
@@ -140,71 +140,78 @@ public class CrowdinDownload extends DefaultTask
         con.setRequestProperty("User-Agent", Constants.USER_AGENT);
         con.setInstanceFollowRedirects(true);
 
-        ZipInputStream zStream = new ZipInputStream(con.getInputStream());
         ZipOutputStream zOut = null;
-
-        if (!extract)
+        try (ZipInputStream zStream = new ZipInputStream(con.getInputStream()))
         {
-            Files.createParentDirs(output);
-            Files.touch(output);
-            zOut = new ZipOutputStream(new FileOutputStream(output));
-        }
-
-        ZipEntry entry;
-        while ((entry = zStream.getNextEntry()) != null)
-        {
-            if (entry.isDirectory() || entry.getSize() == 0)
+            if (!extract)
             {
-                continue;
+                Files.createParentDirs(output);
+                Files.touch(output);
+                zOut = new ZipOutputStream(new FileOutputStream(output));
             }
 
-            String data = CharStreams.readLines(new InputStreamReader(zStream), new LineProcessor<String>()
+            ZipEntry entry;
+            while ((entry = zStream.getNextEntry()) != null)
             {
-                StringBuilder out = new StringBuilder();
-                Splitter SPLITTER = Splitter.on('=').limit(2);
-
-                @Override
-                public boolean processLine(String line) throws IOException
+                try
                 {
-                    String[] pts = Iterables.toArray(SPLITTER.split(line), String.class);
-                    if (pts.length == 2)
+                    if (entry.isDirectory() || entry.getSize() == 0)
                     {
-                        out.append(pts[0]).append('=').append(
-                        pts[1].replace("\\!", "!")
-                              .replace("\\:", ":"))
-                        .append('\n');
+                        continue;
+                    }
+
+                    String data = CharStreams.readLines(new InputStreamReader(zStream), new LineProcessor<String>()
+                    {
+                        StringBuilder out = new StringBuilder();
+                        Splitter SPLITTER = Splitter.on('=').limit(2);
+
+                        @Override
+                        public boolean processLine(String line) throws IOException
+                        {
+                            String[] pts = Iterables.toArray(SPLITTER.split(line), String.class);
+                            if (pts.length == 2)
+                            {
+                                out.append(pts[0]).append('=').append(
+                                        pts[1].replace("\\!", "!")
+                                                .replace("\\:", ":"))
+                                        .append('\n');
+                            }
+                            else
+                                out.append(line).append('\n');
+                            return true;
+                        }
+
+                        @Override
+                        public String getResult()
+                        {
+                            return out.toString();
+                        }
+                    });
+
+                    if (extract)
+                    {
+                        getLogger().debug("Extracting file: " + entry.getName());
+                        File out = new File(output, entry.getName());
+                        Files.createParentDirs(out);
+                        Files.touch(out);
+                        Files.write(data.getBytes(Charsets.UTF_8), out);
                     }
                     else
-                        out.append(line).append('\n');
-                    return true;
-                }
-
-                @Override
-                public String getResult()
+                    {
+                        zOut.putNextEntry(new ZipEntry(entry.getName()));
+                        zOut.write(data.getBytes(Charsets.UTF_8));
+                    }
+                } finally
                 {
-                    return out.toString();
+                    zStream.closeEntry();
                 }
-            });
-
-            if (extract)
-            {
-                getLogger().debug("Extracting file: " + entry.getName());
-                File out = new File(output, entry.getName());
-                Files.createParentDirs(out);
-                Files.touch(out);
-                Files.write(data.getBytes(Charsets.UTF_8), out);
             }
-            else
-            {
-                zOut.putNextEntry(new ZipEntry(entry.getName()));
-                zOut.write(data.getBytes(Charsets.UTF_8));
-                zOut.closeEntry();
-            }
-            zStream.closeEntry();
         }
-        zStream.close();
-        if (zOut != null)
-            zOut.close();
+        finally
+        {
+            if (zOut != null)
+                zOut.close();
+        }
 
         con.disconnect();
     }

--- a/src/main/java/net/minecraftforge/gradle/tasks/DeobfuscateJar.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/DeobfuscateJar.java
@@ -299,8 +299,7 @@ public class DeobfuscateJar extends CachedTask
 
     private void removeUnknownClasses(File inJar, Map<String, MCInjectorStruct> config) throws IOException
     {
-        ZipFile zip = new ZipFile(inJar);
-        try
+        try (ZipFile zip = new ZipFile(inJar))
         {
             Iterator<Map.Entry<String, MCInjectorStruct>> entries = config.entrySet().iterator();
             while (entries.hasNext())
@@ -333,10 +332,6 @@ public class DeobfuscateJar extends CachedTask
                     }
                 }
             }
-        }
-        finally
-        {
-            zip.close();
         }
     }
 

--- a/src/main/java/net/minecraftforge/gradle/tasks/DeobfuscateJar.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/DeobfuscateJar.java
@@ -155,28 +155,29 @@ public class DeobfuscateJar extends CachedTask
         JarRemapper remapper = new JarRemapper(srgProcessor, mapping, atProcessor);
 
         // load jar
-        Jar input = Jar.init(inJar);
-
-        // ensure that inheritance provider is used
-        JointProvider inheritanceProviders = new JointProvider();
-        inheritanceProviders.add(new JarProvider(input));
-        mapping.setFallbackInheritanceProvider(inheritanceProviders);
-
-        // remap jar
-        remapper.remapJar(input, outJar);
-
-        // throw error for broken AT lines
-        if (accessMap.brokenLines.size() > 0 && failOnAtError)
+        try (Jar input = Jar.init(inJar))
         {
-            getLogger().error("{} Broken Access Transformer lines:", accessMap.brokenLines.size());
-            for (String line : accessMap.brokenLines.values())
+            // ensure that inheritance provider is used
+            JointProvider inheritanceProviders = new JointProvider();
+            inheritanceProviders.add(new JarProvider(input));
+            mapping.setFallbackInheritanceProvider(inheritanceProviders);
+
+            // remap jar
+            remapper.remapJar(input, outJar);
+
+            // throw error for broken AT lines
+            if (accessMap.brokenLines.size() > 0 && failOnAtError)
             {
-                getLogger().error(" ---  {}", line);
+                getLogger().error("{} Broken Access Transformer lines:", accessMap.brokenLines.size());
+                for (String line : accessMap.brokenLines.values())
+                {
+                    getLogger().error(" ---  {}", line);
+                }
+
+                // TODO: add info for disabling
+
+                throw new RuntimeException("Your Access Transformers be broke!");
             }
-
-            // TODO: add info for disabling
-
-            throw new RuntimeException("Your Access Transformers be broke!");
         }
     }
 

--- a/src/main/java/net/minecraftforge/gradle/tasks/Download.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/Download.java
@@ -63,17 +63,14 @@ public class Download extends CachedTask
         connect.setRequestProperty("User-Agent", Constants.USER_AGENT);
         connect.setInstanceFollowRedirects(true);
 
-        ReadableByteChannel  inChannel  = Channels.newChannel(connect.getInputStream());
-        FileOutputStream     outFile = new FileOutputStream(outputFile);
-        FileChannel          outChannel = outFile.getChannel();
-
-        // If length is longer than what is available, it copies what is available according to java docs.
-        // Therefore, I use Long.MAX_VALUE which is a theoretical maximum.
-        outChannel.transferFrom(inChannel, 0, Long.MAX_VALUE);
-
-        outChannel.close(); //Should close outFile but just in case
-        Closeables.close(outFile, true);
-        inChannel.close();
+        try (ReadableByteChannel  inChannel  = Channels.newChannel(connect.getInputStream());
+             FileOutputStream     outFile = new FileOutputStream(outputFile);
+             FileChannel          outChannel = outFile.getChannel())
+        {
+            // If length is longer than what is available, it copies what is available according to java docs.
+            // Therefore, I use Long.MAX_VALUE which is a theoretical maximum.
+            outChannel.transferFrom(inChannel, 0, Long.MAX_VALUE);
+        }
 
         getLogger().info("Download complete");
     }

--- a/src/main/java/net/minecraftforge/gradle/tasks/DownloadAssetsTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/DownloadAssetsTask.java
@@ -187,13 +187,11 @@ public class DownloadAssetsTask extends DefaultTask
                         {
                             // download
                             ReadableByteChannel channel = Channels.newChannel(new URL(Constants.URL_ASSETS + "/" + asset.path).openStream());
-                            FileOutputStream fout = new FileOutputStream(file);
-                            FileChannel fileChannel = fout.getChannel();
-                            
-                            fileChannel.transferFrom(channel, 0, asset.size);
-                            
-                            channel.close();
-                            fout.close();
+                            try (FileOutputStream fout = new FileOutputStream(file);
+                                 FileChannel fileChannel = fout.getChannel())
+                            {
+                                fileChannel.transferFrom(channel, 0, asset.size);
+                            }
                         }
                         else
                         {

--- a/src/main/java/net/minecraftforge/gradle/tasks/EtagDownloadTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/EtagDownloadTask.java
@@ -97,9 +97,10 @@ public class EtagDownloadTask extends DefaultTask
                     case 200: // worked
 
                         // write file
-                        InputStream stream = con.getInputStream();
-                        Files.write(ByteStreams.toByteArray(stream), outFile);
-                        stream.close();
+                        try (InputStream stream = con.getInputStream())
+                        {
+                            Files.write(ByteStreams.toByteArray(stream), outFile);
+                        }
 
                         // write etag
                         etag = con.getHeaderField("ETag");

--- a/src/main/java/net/minecraftforge/gradle/tasks/GenSrgs.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/GenSrgs.java
@@ -151,142 +151,130 @@ public class GenSrgs extends CachedTask
         Files.createParentDirs(getMcpToNotch());
 
         // create streams
+        try (
         BufferedWriter notchToSrg = Files.newWriter(getNotchToSrg(), Charsets.UTF_8);
         BufferedWriter notchToMcp = Files.newWriter(getNotchToMcp(), Charsets.UTF_8);
         BufferedWriter srgToMcp = Files.newWriter(getSrgToMcp(), Charsets.UTF_8);
         BufferedWriter mcpToSrg = Files.newWriter(getMcpToSrg(), Charsets.UTF_8);
-        BufferedWriter mcpToNotch = Files.newWriter(getMcpToNotch(), Charsets.UTF_8);
-
-        String line, temp, mcpName;
-        // packages
-        for (Entry<String, String> e : inSrg.packageMap.entrySet())
+        BufferedWriter mcpToNotch = Files.newWriter(getMcpToNotch(), Charsets.UTF_8))
         {
-            line = "PK: "+e.getKey()+" "+e.getValue();
 
-            // nobody cares about the packages.
-            notchToSrg.write(line);
-            notchToSrg.newLine();
+            String line, temp, mcpName;
+            // packages
+            for (Entry<String, String> e : inSrg.packageMap.entrySet())
+            {
+                line = "PK: " + e.getKey() + " " + e.getValue();
 
-            notchToMcp.write(line);
-            notchToMcp.newLine();
+                // nobody cares about the packages.
+                notchToSrg.write(line);
+                notchToSrg.newLine();
 
-            // No package changes from MCP to SRG names
-            //srgToMcp.write(line);
-            //srgToMcp.newLine();
+                notchToMcp.write(line);
+                notchToMcp.newLine();
 
-            // No package changes from MCP to SRG names
-            //mcpToSrg.write(line);
-            //mcpToSrg.newLine();
+                // No package changes from MCP to SRG names
+                //srgToMcp.write(line);
+                //srgToMcp.newLine();
 
-            // reverse!
-            mcpToNotch.write("PK: "+e.getValue()+" "+e.getKey());
-            mcpToNotch.newLine();
+                // No package changes from MCP to SRG names
+                //mcpToSrg.write(line);
+                //mcpToSrg.newLine();
+
+                // reverse!
+                mcpToNotch.write("PK: " + e.getValue() + " " + e.getKey());
+                mcpToNotch.newLine();
+            }
+
+            // classes
+            for (Entry<String, String> e : inSrg.classMap.entrySet())
+            {
+                line = "CL: " + e.getKey() + " " + e.getValue();
+
+                // same...
+                notchToSrg.write(line);
+                notchToSrg.newLine();
+
+                // SRG and MCP have the same class names
+                notchToMcp.write(line);
+                notchToMcp.newLine();
+
+                line = "CL: " + e.getValue() + " " + e.getValue();
+
+                // deobf: same classes on both sides.
+                srgToMcp.write("CL: " + e.getValue() + " " + e.getValue());
+                srgToMcp.newLine();
+
+                // reobf: same classes on both sides.
+                mcpToSrg.write("CL: " + e.getValue() + " " + e.getValue());
+                mcpToSrg.newLine();
+
+                // output is notch
+                mcpToNotch.write("CL: " + e.getValue() + " " + e.getKey());
+                mcpToNotch.newLine();
+            }
+
+            // fields
+            for (Entry<String, String> e : inSrg.fieldMap.entrySet())
+            {
+                line = "FD: " + e.getKey() + " " + e.getValue();
+
+                // same...
+                notchToSrg.write("FD: " + e.getKey() + " " + e.getValue());
+                notchToSrg.newLine();
+
+                temp = e.getValue().substring(e.getValue().lastIndexOf('/') + 1);
+                mcpName = e.getValue();
+                if (fields.containsKey(temp))
+                    mcpName = mcpName.replace(temp, fields.get(temp));
+
+                // SRG and MCP have the same class names
+                notchToMcp.write("FD: " + e.getKey() + " " + mcpName);
+                notchToMcp.newLine();
+
+                // srg name -> mcp name
+                srgToMcp.write("FD: " + e.getValue() + " " + mcpName);
+                srgToMcp.newLine();
+
+                // mcp name -> srg name
+                mcpToSrg.write("FD: " + mcpName + " " + e.getValue());
+                mcpToSrg.newLine();
+
+                // output is notch
+                mcpToNotch.write("FD: " + mcpName + " " + e.getKey());
+                mcpToNotch.newLine();
+            }
+
+            // methods
+            for (Entry<MethodData, MethodData> e : inSrg.methodMap.entrySet())
+            {
+                line = "MD: " + e.getKey() + " " + e.getValue();
+
+                // same...
+                notchToSrg.write("MD: " + e.getKey() + " " + e.getValue());
+                notchToSrg.newLine();
+
+                temp = e.getValue().name.substring(e.getValue().name.lastIndexOf('/') + 1);
+                mcpName = e.getValue().toString();
+                if (methods.containsKey(temp))
+                    mcpName = mcpName.replace(temp, methods.get(temp));
+
+                // SRG and MCP have the same class names
+                notchToMcp.write("MD: " + e.getKey() + " " + mcpName);
+                notchToMcp.newLine();
+
+                // srg name -> mcp name
+                srgToMcp.write("MD: " + e.getValue() + " " + mcpName);
+                srgToMcp.newLine();
+
+                // mcp name -> srg name
+                mcpToSrg.write("MD: " + mcpName + " " + e.getValue());
+                mcpToSrg.newLine();
+
+                // output is notch
+                mcpToNotch.write("MD: " + mcpName + " " + e.getKey());
+                mcpToNotch.newLine();
+            }
         }
-
-        // classes
-        for (Entry<String, String> e : inSrg.classMap.entrySet())
-        {
-            line = "CL: "+e.getKey()+" "+e.getValue();
-
-            // same...
-            notchToSrg.write(line);
-            notchToSrg.newLine();
-
-            // SRG and MCP have the same class names
-            notchToMcp.write(line);
-            notchToMcp.newLine();
-
-            line = "CL: "+e.getValue()+" "+e.getValue();
-
-            // deobf: same classes on both sides.
-            srgToMcp.write("CL: "+e.getValue()+" "+e.getValue());
-            srgToMcp.newLine();
-
-            // reobf: same classes on both sides.
-            mcpToSrg.write("CL: "+e.getValue()+" "+e.getValue());
-            mcpToSrg.newLine();
-
-            // output is notch
-            mcpToNotch.write("CL: "+e.getValue()+" "+e.getKey());
-            mcpToNotch.newLine();
-        }
-
-        // fields
-        for (Entry<String, String> e : inSrg.fieldMap.entrySet())
-        {
-            line = "FD: "+e.getKey()+" "+e.getValue();
-
-            // same...
-            notchToSrg.write("FD: "+e.getKey()+" "+e.getValue());
-            notchToSrg.newLine();
-
-            temp = e.getValue().substring(e.getValue().lastIndexOf('/')+1);
-            mcpName = e.getValue();
-            if (fields.containsKey(temp))
-                mcpName = mcpName.replace(temp, fields.get(temp));
-
-            // SRG and MCP have the same class names
-            notchToMcp.write("FD: "+e.getKey()+" "+mcpName);
-            notchToMcp.newLine();
-
-            // srg name -> mcp name
-            srgToMcp.write("FD: "+e.getValue()+" "+mcpName);
-            srgToMcp.newLine();
-
-            // mcp name -> srg name
-            mcpToSrg.write("FD: "+mcpName+" "+e.getValue());
-            mcpToSrg.newLine();
-
-            // output is notch
-            mcpToNotch.write("FD: "+mcpName+" "+e.getKey());
-            mcpToNotch.newLine();
-        }
-
-        // methods
-        for (Entry<MethodData, MethodData> e : inSrg.methodMap.entrySet())
-        {
-            line = "MD: "+e.getKey()+" "+e.getValue();
-
-            // same...
-            notchToSrg.write("MD: "+e.getKey()+" "+e.getValue());
-            notchToSrg.newLine();
-
-            temp = e.getValue().name.substring(e.getValue().name.lastIndexOf('/')+1);
-            mcpName = e.getValue().toString();
-            if (methods.containsKey(temp))
-                mcpName = mcpName.replace(temp, methods.get(temp));
-
-            // SRG and MCP have the same class names
-            notchToMcp.write("MD: "+e.getKey()+" "+mcpName);
-            notchToMcp.newLine();
-
-            // srg name -> mcp name
-            srgToMcp.write("MD: "+e.getValue()+" "+mcpName);
-            srgToMcp.newLine();
-
-            // mcp name -> srg name
-            mcpToSrg.write("MD: "+mcpName+" "+e.getValue());
-            mcpToSrg.newLine();
-
-            // output is notch
-            mcpToNotch.write("MD: "+mcpName+" "+e.getKey());
-            mcpToNotch.newLine();
-        }
-
-        notchToSrg.flush();
-        notchToSrg.close();
-
-        notchToMcp.flush();
-        notchToMcp.close();
-
-        srgToMcp.flush();
-        srgToMcp.close();
-
-        mcpToSrg.flush();
-        mcpToSrg.close();
-
-        mcpToNotch.flush();
-        mcpToNotch.close();
     }
 
     private void writeOutExcs(SrgContainer inSrg, Map<String, String> excRemap, Map<String, String> methods) throws IOException

--- a/src/main/java/net/minecraftforge/gradle/tasks/JenkinsChangelog.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/JenkinsChangelog.java
@@ -21,8 +21,7 @@ package net.minecraftforge.gradle.tasks;
 
 import groovy.util.MapEntry;
 
-import java.io.File;
-import java.io.IOException;
+import java.io.*;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLConnection;
@@ -130,7 +129,10 @@ public class JenkinsChangelog extends DefaultTask
             getProject().getLogger().debug(auth);
             con.addRequestProperty("Authorization", auth);
         }
-        return new String(ByteStreams.toByteArray(con.getInputStream()));
+        try (InputStream is = con.getInputStream())
+        {
+            return new String(ByteStreams.toByteArray(is));
+        }
     }
 
     private String cleanJson(String data, String part)

--- a/src/main/java/net/minecraftforge/gradle/tasks/MergeJars.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/MergeJars.java
@@ -86,33 +86,10 @@ public class MergeJars extends CachedTask
 
     private void processJar(File clientInFile, File serverInFile, File outFile) throws IOException
     {
-        ZipFile cInJar = null;
-        ZipFile sInJar = null;
-        ZipOutputStream outJar = null;
-
-        try
+        try (ZipFile cInJar = new ZipFile(clientInFile);
+             ZipFile sInJar = new ZipFile(serverInFile);
+             ZipOutputStream outJar = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(outFile))))
         {
-            try
-            {
-                cInJar = new ZipFile(clientInFile);
-                sInJar = new ZipFile(serverInFile);
-            }
-            catch (FileNotFoundException e)
-            {
-                throw new FileNotFoundException("Could not open input file: " + e.getMessage());
-            }
-
-            // different messages.
-
-            try
-            {
-                outJar = new ZipOutputStream(new BufferedOutputStream(new FileOutputStream(outFile)));
-            }
-            catch (FileNotFoundException e)
-            {
-                throw new FileNotFoundException("Could not open output file: " + e.getMessage());
-            }
-
             // read in the jars, and initalize some variables
             HashSet<String> resources = new HashSet<String>();
             HashMap<String, ZipEntry> cClasses = getClassEntries(cInJar, outJar, resources);
@@ -139,8 +116,12 @@ public class MergeJars extends CachedTask
                 byte[] data = processClass(cData, sData);
 
                 ZipEntry newEntry = new ZipEntry(cEntry.getName());
-                outJar.putNextEntry(newEntry);
-                outJar.write(data);
+                try {
+                    outJar.putNextEntry(newEntry);
+                    outJar.write(data);
+                } finally {
+                    outJar.closeEntry();
+                }
                 cAdded.add(name);
             }
 
@@ -160,43 +141,19 @@ public class MergeJars extends CachedTask
                 ZipEntry newEntry = new ZipEntry(classPath);
                 if (!cAdded.contains(eName))
                 {
-                    outJar.putNextEntry(newEntry);
-                    outJar.write(getClassBytes(name));
+                    try {
+                        outJar.putNextEntry(newEntry);
+                        outJar.write(getClassBytes(name));
+                    } finally {
+                        outJar.closeEntry();
+                    }
                 }
             }
 
         }
-        finally
+        catch (FileNotFoundException e)
         {
-            if (cInJar != null)
-            {
-                try
-                {
-                    cInJar.close();
-                }
-                catch (IOException e)
-                {}
-            }
-
-            if (sInJar != null)
-            {
-                try
-                {
-                    sInJar.close();
-                }
-                catch (IOException e)
-                {}
-            }
-            if (outJar != null)
-            {
-                try
-                {
-                    outJar.close();
-                }
-                catch (IOException e)
-                {}
-            }
-
+            throw new FileNotFoundException("Could not open input/output file: " + e.getMessage());
         }
     }
 
@@ -227,7 +184,10 @@ public class MergeJars extends CachedTask
 
     private byte[] readEntry(ZipFile inFile, ZipEntry entry) throws IOException
     {
-        return ByteStreams.toByteArray(inFile.getInputStream(entry));
+        try (InputStream is = inFile.getInputStream(entry))
+        {
+            return ByteStreams.toByteArray(is);
+        }
     }
 
     private AnnotationNode getSideAnn(boolean isClientOnly)

--- a/src/main/java/net/minecraftforge/gradle/tasks/ObtainFernFlowerTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/ObtainFernFlowerTask.java
@@ -71,20 +71,20 @@ public class ObtainFernFlowerTask extends CachedTask
         connect.setRequestProperty("User-Agent", Constants.USER_AGENT);
         connect.setInstanceFollowRedirects(true);
 
-        final ZipInputStream zin = new ZipInputStream(connect.getInputStream());
-        ZipEntry entry = null;
-
-        while ((entry = zin.getNextEntry()) != null)
+        try (final ZipInputStream zin = new ZipInputStream(connect.getInputStream()))
         {
-            if (Constants.lower(entry.getName()).endsWith("fernflower.jar"))
+            ZipEntry entry;
+
+            while ((entry = zin.getNextEntry()) != null)
             {
-                ff.getParentFile().mkdirs();
-                Files.touch(ff);
-                Files.write(ByteStreams.toByteArray(zin), ff);
+                if (Constants.lower(entry.getName()).endsWith("fernflower.jar"))
+                {
+                    ff.getParentFile().mkdirs();
+                    Files.touch(ff);
+                    Files.write(ByteStreams.toByteArray(zin), ff);
+                }
             }
         }
-
-        zin.close();
 
         getLogger().info("Download and Extraction complete");
     }

--- a/src/main/java/net/minecraftforge/gradle/tasks/SplitJarTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/SplitJarTask.java
@@ -75,48 +75,47 @@ public class SplitJarTask extends CachedTask implements PatternFilterable
         out2.getParentFile().mkdirs();
 
         // begin reading jar
-        final JarOutputStream zout1 = new JarOutputStream(new FileOutputStream(out1));
-        final JarOutputStream zout2 = new JarOutputStream(new FileOutputStream(out2));
+        try (JarOutputStream zout1 = new JarOutputStream(new FileOutputStream(out1));
+             JarOutputStream zout2 = new JarOutputStream(new FileOutputStream(out2)))
+        {
 
-        getProject().zipTree(input).visit(new FileVisitor() {
+            getProject().zipTree(input).visit(new FileVisitor() {
 
-            @Override
-            public void visitDir(FileVisitDetails details)
-            {
-                // ignore directories
-            }
-
-            @Override
-            public void visitFile(FileVisitDetails details)
-            {
-                JarEntry entry = new JarEntry(details.getPath());
-                entry.setSize(details.getSize());
-                entry.setTime(details.getLastModified());
-
-                try
+                @Override
+                public void visitDir(FileVisitDetails details)
                 {
-                    if (spec.isSatisfiedBy(details))
+                    // ignore directories
+                }
+
+                @Override
+                public void visitFile(FileVisitDetails details)
+                {
+                    JarEntry entry = new JarEntry(details.getPath());
+                    entry.setSize(details.getSize());
+                    entry.setTime(details.getLastModified());
+
+                    try
                     {
-                        zout1.putNextEntry(entry);
-                        details.copyTo(zout1);
-                        zout1.closeEntry();
+                        if (spec.isSatisfiedBy(details))
+                        {
+                            zout1.putNextEntry(entry);
+                            details.copyTo(zout1);
+                            zout1.closeEntry();
+                        }
+                        else
+                        {
+                            zout2.putNextEntry(entry);
+                            details.copyTo(zout2);
+                            zout2.closeEntry();
+                        }
                     }
-                    else
+                    catch (IOException e)
                     {
-                        zout2.putNextEntry(entry);
-                        details.copyTo(zout2);
-                        zout2.closeEntry();
+                        Throwables.propagate(e);
                     }
                 }
-                catch (IOException e)
-                {
-                    Throwables.propagate(e);
-                }
-            }
-        });
-
-        zout1.close();
-        zout2.close();
+            });
+        }
     }
 
     public File getInJar()

--- a/src/main/java/net/minecraftforge/gradle/tasks/fernflower/ByteCodeProvider.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/fernflower/ByteCodeProvider.java
@@ -34,15 +34,12 @@ class ByteCodeProvider implements IBytecodeProvider {
         if (internalPath == null) {
             return InterpreterUtil.getBytes(file);
         } else {
-            ZipFile archive = new ZipFile(file);
-            try {
+            try (ZipFile archive = new ZipFile(file)) {
                 ZipEntry entry = archive.getEntry(internalPath);
                 if (entry == null) {
                     throw new IOException("Entry not found: " + internalPath);
                 }
                 return InterpreterUtil.getBytes(archive, entry);
-            } finally {
-                archive.close();
             }
         }
     }

--- a/src/main/java/net/minecraftforge/gradle/user/TaskDepDummy.java
+++ b/src/main/java/net/minecraftforge/gradle/user/TaskDepDummy.java
@@ -41,11 +41,12 @@ public class TaskDepDummy extends DefaultTask
         out.getParentFile().mkdirs();
         
         // yup.. a dummy jar....
-        JarOutputStream stream = new JarOutputStream(new FileOutputStream(out));
-        stream.putNextEntry(new JarEntry("dummyThing"));
-        stream.write(0xffffffff);
-        stream.closeEntry();
-        stream.close();
+        try (JarOutputStream stream = new JarOutputStream(new FileOutputStream(out)))
+        {
+            stream.putNextEntry(new JarEntry("dummyThing"));
+            stream.write(0xffffffff);
+            stream.closeEntry();
+        }
     }
 
     public File getOutputFile()

--- a/src/main/java/net/minecraftforge/gradle/user/TaskRecompileMc.java
+++ b/src/main/java/net/minecraftforge/gradle/user/TaskRecompileMc.java
@@ -123,22 +123,22 @@ public class TaskRecompileMc extends CachedTask
 
     private static void extractSources(File tempDir, File inJar) throws IOException
     {
-        ZipInputStream zin = new ZipInputStream(new FileInputStream(inJar));
-        ZipEntry entry = null;
-
-        while ((entry = zin.getNextEntry()) != null)
+        try (ZipInputStream zin = new ZipInputStream(new FileInputStream(inJar)))
         {
-            // we dont care about directories.. we can make em later when needed
-            // we only want java files to compile too, can grab the other resources from the jar later
-            if (entry.isDirectory() || !entry.getName().endsWith(".java"))
-                continue;
+            ZipEntry entry;
 
-            File out = new File(tempDir, entry.getName());
-            out.getParentFile().mkdirs();
-            Files.asByteSink(out).writeFrom(zin);
+            while ((entry = zin.getNextEntry()) != null)
+            {
+                // we dont care about directories.. we can make em later when needed
+                // we only want java files to compile too, can grab the other resources from the jar later
+                if (entry.isDirectory() || !entry.getName().endsWith(".java"))
+                    continue;
+
+                File out = new File(tempDir, entry.getName());
+                out.getParentFile().mkdirs();
+                Files.asByteSink(out).writeFrom(zin);
+            }
         }
-
-        zin.close();
     }
 
     private void createOutput(File outJar, File sourceJar, File classDir, File resourceJar) throws IOException

--- a/src/main/java/net/minecraftforge/gradle/user/TaskSingleReobf.java
+++ b/src/main/java/net/minecraftforge/gradle/user/TaskSingleReobf.java
@@ -222,17 +222,18 @@ public class TaskSingleReobf extends DefaultTask
         JarRemapper remapper = new JarRemapper(null, mapping);
 
         // load jar
-        Jar inputJar = Jar.init(input);
+        try (Jar inputJar = Jar.init(input))
+        {
+            // ensure that inheritance provider is used
+            JointProvider inheritanceProviders = new JointProvider();
+            inheritanceProviders.add(new JarProvider(inputJar));
+            if (classpath != null)
+                inheritanceProviders.add(new ClassLoaderProvider(new URLClassLoader(Constants.toUrls(classpath))));
+            mapping.setFallbackInheritanceProvider(inheritanceProviders);
 
-        // ensure that inheritance provider is used
-        JointProvider inheritanceProviders = new JointProvider();
-        inheritanceProviders.add(new JarProvider(inputJar));
-        if (classpath != null)
-            inheritanceProviders.add(new ClassLoaderProvider(new URLClassLoader(Constants.toUrls(classpath))));
-        mapping.setFallbackInheritanceProvider(inheritanceProviders);
-
-        // remap jar
-        remapper.remapJar(inputJar, output);
+            // remap jar
+            remapper.remapJar(inputJar, output);
+        }
     }
 
     private void applyExtraTransformers(File inJar, File outJar, List<ReobfTransformer> transformers) throws IOException

--- a/src/main/java/net/minecraftforge/gradle/user/patcherUser/forge/ForgePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/patcherUser/forge/ForgePlugin.java
@@ -101,13 +101,14 @@ public class ForgePlugin extends PatcherUserBasePlugin<ForgeExtension>
                         byte[] LOCATION_BEFORE = new byte[] { 0x40, (byte) 0xB1, (byte) 0x8B, (byte) 0x81, 0x23, (byte) 0xBC, 0x00, 0x14, 0x1A, 0x25, (byte) 0x96, (byte) 0xE7, (byte) 0xA3, (byte) 0x93, (byte) 0xBE, 0x1E };
                         byte[] LOCATION_AFTER = new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xC0, 0x58, (byte) 0xFB, (byte) 0xF3, 0x23, (byte) 0xBC, 0x00, 0x14, 0x1A, 0x51, (byte) 0xF3, (byte) 0x8C, 0x7B, (byte) 0xBB, 0x77, (byte) 0xC6 };
 
-                        FileOutputStream fos = new FileOutputStream(f);
-                        fos.write(LOCATION_BEFORE);//Unknown but w/e
-                        fos.write((byte) ((projectDir.length() & 0xFF) >> 8));
-                        fos.write((byte) ((projectDir.length() & 0xFF) >> 0));
-                        fos.write(projectDir.getBytes());
-                        fos.write(LOCATION_AFTER);//Unknown but w/e
-                        fos.close();
+                        try (FileOutputStream fos = new FileOutputStream(f))
+                        {
+                            fos.write(LOCATION_BEFORE);//Unknown but w/e
+                            fos.write((byte) ((projectDir.length() & 0xFF) >> 8));
+                            fos.write((byte) ((projectDir.length() & 0xFF) >> 0));
+                            fos.write(projectDir.getBytes());
+                            fos.write(LOCATION_AFTER);//Unknown but w/e
+                        }
                     }
                     catch (IOException e)
                     {

--- a/src/main/java/net/minecraftforge/gradle/util/mcp/McpCleanup.java
+++ b/src/main/java/net/minecraftforge/gradle/util/mcp/McpCleanup.java
@@ -33,13 +33,12 @@ public class McpCleanup
 
     public static String stripComments(String text)
     {
-        StringReader in = new StringReader(text);
-        StringWriter out = new StringWriter(text.length());
         boolean inComment = false;
         boolean inString = false;
         char c;
         int ci;
-        try
+        try (StringReader in = new StringReader(text);
+             StringWriter out = new StringWriter(text.length()))
         {
             while ((ci = in.read()) != -1)
             {
@@ -126,14 +125,12 @@ public class McpCleanup
                             }
                     }
             }
-            out.close();
+            text = out.toString();
         }
         catch (Exception e)
         {
             throw new RuntimeException(e);
         }
-        
-        text = out.toString();
 
         text = COMMENTS_TRAILING.matcher(text).replaceAll("");
         text = COMMENTS_NEWLINES.matcher(text).replaceAll(Constants.NEWLINE);

--- a/src/main/java/net/minecraftforge/gradle/util/patching/ContextualPatch.java
+++ b/src/main/java/net/minecraftforge/gradle/util/patching/ContextualPatch.java
@@ -203,9 +203,11 @@ public final class ContextualPatch
         patchReader.close();
 
         byte[] buffer = new byte[MAGIC.length()];
-        InputStream in = new FileInputStream(patchFile);
-        int read = in.read(buffer);
-        in.close();
+        int read;
+        try (InputStream in = new FileInputStream(patchFile))
+        {
+            read = in.read(buffer);
+        }
         if (read != -1 && MAGIC.equals(new String(buffer, "utf8")))
         {  // NOI18N
             encoding = "utf8"; // NOI18N


### PR DESCRIPTION
* Updates SpecialSource with fixes for jar files not being closed - from #445
* Updates asm to 6.0_BETA to match the version required for new SpecialSource
* Close jar files in ForgeGradle always, using try with resources
* Close jar related input streams always
* Close URLClassLoaders after using for inheritance providers

Fixes md-5/SpecialSource/issues/45