### PR TITLE
WIP: Don't shade the entire world

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -125,10 +125,22 @@ processResources {
 }
 
 jar {
+    // Shading could try to add duplicate classes
+    // fail instead of silently adding multiple entries with the same name
+    duplicatesStrategy=DuplicatesStrategy.FAIL
 
-    configurations.shade.each { dep ->
-        from(project.zipTree(dep)){
-            exclude 'META-INF', 'META-INF/**'
+    configurations.shade.getResolvedConfiguration().getResolvedArtifacts().each { dep ->
+        def id = dep.getModuleVersion().id
+        if (configurations.shade.dependencies.find { orig -> orig.group == id.group && orig.name == id.name }) {
+            // shade direct dependencies
+            from(project.zipTree(dep.file)) {
+                exclude 'META-INF', 'META-INF/**', 'module-info.class'
+            }
+        } else {
+            // add transitive dependencies as normal compile dependencies
+            // if a shaded dependency has a transitive dependency which must also be shaded
+            // it must be explicitly added as a shaded depncendy
+            dependencies.compile(id.toString())
         }
     }
 


### PR DESCRIPTION
* never shade module-info.class - can only be one module-info, must be at root of jar, doesn't make sense for a shaded dependency to provide it
* don't shade transitive dependencies of shaded dependencies
* error if duplicate jar entries would be added

* [x] Tested decomp workspace, dev workspace and builds of mdk, Reliquary, TickProfiler.
* [ ] Tested build of MinecraftForge.
* [x] Tested with gradlew 4.2 and gradle 2.14.

See https://github.com/MinecraftForge/ForgeGradle/issues/451#issuecomment-332007744