### PR TITLE
Fix ForgeGradle printing sensible information into the log.

### DIFF
--- a/src/main/resources/net/minecraftforge/gradle/GradleStartCommon.java
+++ b/src/main/resources/net/minecraftforge/gradle/GradleStartCommon.java
@@ -167,7 +167,7 @@ public abstract class GradleStartCommon
             {
                 String value = (String) options.valueOf(key);
                 argMap.put(key, value);
-                if (!"password".equalsIgnoreCase(key))
+                if (!"password".equalsIgnoreCase(key) && !"accessToken".equalsIgnoreCase(key))
                     LOGGER.info(key + ": " + value);
             }
         }


### PR DESCRIPTION
The access token is already filtered out later [here](https://github.com/ichttt/ForgeGradle/blob/5109d806911138a15fa8760e12d29131354e1f82/src/main/resources/net/minecraftforge/gradle/GradleStartCommon.java#L134), but when setting the argument directly, it gets printed to the log anyways. This fixes this issue