### PR TITLE
Fix returning fields in methods adding javadocs

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/tasks/RemapSources.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/RemapSources.java
@@ -63,7 +63,7 @@ public class RemapSources extends AbstractEditJarTask
 
     private static final Pattern      SRG_FINDER             = Pattern.compile("func_[0-9]+_[a-zA-Z_]+|field_[0-9]+_[a-zA-Z_]+|p_[\\w]+_\\d+_\\b");
     private static final Pattern      METHOD_JAVADOC_PATTERN = Pattern.compile("^(?<indent>(?: {4})+|\\t+)(?!return)(?:\\w+\\s+)*(?<generic><[\\w\\W]*>\\s+)?(?<return>\\w+[\\w$.]*(?:<[\\w\\W]*>)?[\\[\\]]*)\\s+(?<name>func_[0-9]+_[a-zA-Z_]+)\\(");
-    private static final Pattern      FIELD_JAVADOC_PATTERN  = Pattern.compile("^(?<indent>(?: {4})+|\\t+)(?:\\w+\\s+)*(?:\\w+[\\w$.]*(?:<[\\w\\W]*>)?[\\[\\]]*)\\s+(?<name>field_[0-9]+_[a-zA-Z_]+) *(?:=|;)");
+    private static final Pattern      FIELD_JAVADOC_PATTERN  = Pattern.compile("^(?<indent>(?: {4})+|\\t+)(?!return)(?:\\w+\\s+)*(?:\\w+[\\w$.]*(?:<[\\w\\W]*>)?[\\[\\]]*)\\s+(?<name>field_[0-9]+_[a-zA-Z_]+) *(?:=|;)");
 
     @Override
     public void doStuffBefore() throws Exception

--- a/src/test/java/net/minecraftforge/gradle/util/mcp/JavadocInserterTest.java
+++ b/src/test/java/net/minecraftforge/gradle/util/mcp/JavadocInserterTest.java
@@ -22,18 +22,15 @@ package net.minecraftforge.gradle.util.mcp;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.List;
-
-import net.minecraftforge.gradle.common.Constants;
-import net.minecraftforge.gradle.tasks.RemapSources;
 
 import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.base.Joiner;
-import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
-import com.google.code.regexp.Matcher;
+
+import net.minecraftforge.gradle.common.Constants;
+import net.minecraftforge.gradle.tasks.RemapSources;
 
 public class JavadocInserterTest
 {
@@ -41,14 +38,15 @@ public class JavadocInserterTest
     private static final String EXPECTED = "JavadocInserterTestOut";
 
     @Test
-    public void tstJavadocInserter() throws IOException
+    public void testJavadocInserter() throws IOException
     {
         String input = readResource(INPUT);
 
         ArrayList<String> newLines = new ArrayList<String>();
         for (String line : Constants.lines(input))
         {
-            injectJavadoc(newLines, line);
+            System.out.println(line);
+            RemapSources.injectJavadoc(newLines, line, method -> "Javadoc For: " + method, field -> "Javadoc For: " + field);
             newLines.add(line);
         }
         String output = Joiner.on(Constants.NEWLINE).join(newLines);
@@ -64,48 +62,11 @@ public class JavadocInserterTest
         }
     }
 
-    private void injectJavadoc(List<String> newLines, String line)
-    {
-        System.out.println(line);
-        // methods
-        Matcher matcher = RemapSources.METHOD.matcher(line);
-        if (matcher.find())
-        {
-            String javadoc = "Javadoc For: " + matcher.group("name");
-            if (!Strings.isNullOrEmpty(javadoc))
-            {
-                insetAboveAnnotations(newLines, JavadocAdder.buildJavadoc(matcher.group("indent"), javadoc, true));
-            }
-
-            // worked, so return and dont try the fields.
-            return;
-        }
-
-        // fields
-        matcher = RemapSources.FIELD.matcher(line);
-        if (matcher.find())
-        {
-            String javadoc = "Javadoc For: " + matcher.group("name");
-            if (!Strings.isNullOrEmpty(javadoc))
-            {
-                insetAboveAnnotations(newLines, JavadocAdder.buildJavadoc(matcher.group("indent"), javadoc, false));
-            }
-        }
-    }
-
-    private static void insetAboveAnnotations(List<String> list, String line)
-    {
-        int back = 0;
-        while (list.get(list.size() - 1 - back).trim().startsWith("@"))
-        {
-            back++;
-        }
-        list.add(list.size() - back, line);
-    }
-
     private String readResource(String name) throws IOException
     {
-        InputStream stream = this.getClass().getClassLoader().getResourceAsStream(name);
-        return new String(ByteStreams.toByteArray(stream));
+        try (InputStream stream = this.getClass().getClassLoader().getResourceAsStream(name))
+        {
+            return new String(ByteStreams.toByteArray(stream));
+        }
     }
 }

--- a/src/test/resources/JavadocInserterTest
+++ b/src/test/resources/JavadocInserterTest
@@ -9,6 +9,8 @@
     Map<,> field_8_a; //This will get javadocs even tho its invalid cuz we dont care if its valid just that it grabs all the generics
     Map<Test[], Bob[]>[] field_9_a;
     Map<? extends Object & Turtle> field_10_a;
+    @Nullable
+    Object field_11_a;
 
 
 
@@ -23,10 +25,45 @@
     Map<Test[], Bob[]>[] func_9_a();
     Map<? extends Object & Turtle> func_10_a();
     public static <T extends Enum<T> & IStringSerializable> PropertyEnum<T> func_11_a();
+    @Nullable
+    Object func_12_a();
 
 
 
-    //These SHOULDN'T get javadocs
-    return func_1_a();
+    // Non-SRG methods (e.g. from non-obf interfaces) should not get docs
+    public int size();
+    public List<? extends T> findAll(Class<T> clazz);
 
+    // Methods and fields in methods shouldn't get docs
+    boolean foo() {
+        someVar = func_2_a();
+        func_2_a().aField++;
+        test(func_2_a());
+        return func_2_a();
+    }
+    boolean bar() {
+        someVar = field_2_a;
+        test(field_2_a);
+        field_2_a++;
+        return field_2_a;
+    }
+
+
+
+    // Inner and anonymous classes
+    class Nested {
+        int field_101_a;
+        int func_101_a();
+    }
+
+    Object inner() {
+        class MethodNested {
+            boolean field_102_a;
+            boolean func_102_a();
+        }
+        return new Object() {
+            boolean field_103_a;
+            boolean func_103_a();
+        }
+    }
 }

--- a/src/test/resources/JavadocInserterTestOut
+++ b/src/test/resources/JavadocInserterTestOut
@@ -19,6 +19,9 @@
     Map<Test[], Bob[]>[] field_9_a;
     /** Javadoc For: field_10_a */
     Map<? extends Object & Turtle> field_10_a;
+    /** Javadoc For: field_11_a */
+    @Nullable
+    Object field_11_a;
 
 
 
@@ -66,10 +69,60 @@
      * Javadoc For: func_11_a
      */
     public static <T extends Enum<T> & IStringSerializable> PropertyEnum<T> func_11_a();
+    /**
+     * Javadoc For: func_12_a
+     */
+    @Nullable
+    Object func_12_a();
 
 
 
-    //These SHOULDN'T get javadocs
-    return func_1_a();
+    // Non-SRG methods (e.g. from non-obf interfaces) should not get docs
+    public int size();
+    public List<? extends T> findAll(Class<T> clazz);
 
+    // Methods and fields in methods shouldn't get docs
+    boolean foo() {
+        someVar = func_2_a();
+        func_2_a().aField++;
+        test(func_2_a());
+        return func_2_a();
+    }
+    boolean bar() {
+        someVar = field_2_a;
+        test(field_2_a);
+        field_2_a++;
+        return field_2_a;
+    }
+
+
+
+    // Inner and anonymous classes
+    class Nested {
+        /** Javadoc For: field_101_a */
+        int field_101_a;
+        /**
+         * Javadoc For: func_101_a
+         */
+        int func_101_a();
+    }
+
+    Object inner() {
+        class MethodNested {
+            /** Javadoc For: field_102_a */
+            boolean field_102_a;
+            /**
+             * Javadoc For: func_102_a
+             */
+            boolean func_102_a();
+        }
+        return new Object() {
+            /** Javadoc For: field_103_a */
+            boolean field_103_a;
+            /**
+             * Javadoc For: func_103_a
+             */
+            boolean func_103_a();
+        }
+    }
 }


### PR DESCRIPTION
Fixes #462.  Also some general cleanup of the code related to javadocs (and more test cases).

For reference, here's a diff of the changes to 1.12.2 with this fix:

```diff
diff --git a/net/minecraft/advancements/critereon/DistancePredicate.java b/net/minecraft/advancements/critereon/DistancePredicate.java
index f5444ed..89f0df4 100644
--- a/net/minecraft/advancements/critereon/DistancePredicate.java
+++ b/net/minecraft/advancements/critereon/DistancePredicate.java
@@ -49,7 +49,6 @@ public class DistancePredicate {
             MinMaxBounds minmaxbounds4 = MinMaxBounds.deserialize(jsonobject.get("absolute"));
             return new DistancePredicate(minmaxbounds, minmaxbounds1, minmaxbounds2, minmaxbounds3, minmaxbounds4);
         } else {
-            /** The predicate that matches any distance. */
             return ANY;
         }
     }
diff --git a/net/minecraft/advancements/critereon/EnchantmentPredicate.java b/net/minecraft/advancements/critereon/EnchantmentPredicate.java
index 2625d2e..4eed8f8 100644
--- a/net/minecraft/advancements/critereon/EnchantmentPredicate.java
+++ b/net/minecraft/advancements/critereon/EnchantmentPredicate.java
@@ -67,7 +67,6 @@ public class EnchantmentPredicate {
             MinMaxBounds minmaxbounds = MinMaxBounds.deserialize(jsonobject.get("levels"));
             return new EnchantmentPredicate(enchantment, minmaxbounds);
         } else {
-            /** The predicate that matches any set of enchantments. */
             return ANY;
         }
     }
diff --git a/net/minecraft/advancements/critereon/EntityPredicate.java b/net/minecraft/advancements/critereon/EntityPredicate.java
index 892f14c..7d767d9 100644
--- a/net/minecraft/advancements/critereon/EntityPredicate.java
+++ b/net/minecraft/advancements/critereon/EntityPredicate.java
@@ -64,7 +64,6 @@ public class EntityPredicate {
             NBTPredicate nbtpredicate = NBTPredicate.deserialize(jsonobject.get("nbt"));
             return new EntityPredicate(resourcelocation, distancepredicate, locationpredicate, mobeffectspredicate, nbtpredicate);
         } else {
-            /** The predicate that matches any entity. */
             return ANY;
         }
     }
diff --git a/net/minecraft/advancements/critereon/MobEffectsPredicate.java b/net/minecraft/advancements/critereon/MobEffectsPredicate.java
index d316008..2a6965e 100644
--- a/net/minecraft/advancements/critereon/MobEffectsPredicate.java
+++ b/net/minecraft/advancements/critereon/MobEffectsPredicate.java
@@ -71,7 +71,6 @@ public class MobEffectsPredicate {
 
             return new MobEffectsPredicate(map);
         } else {
-            /** The predicate that matches any set of effects. */
             return ANY;
         }
     }
diff --git a/net/minecraft/advancements/critereon/NBTPredicate.java b/net/minecraft/advancements/critereon/NBTPredicate.java
index cc7d1e5..69bd160 100644
--- a/net/minecraft/advancements/critereon/NBTPredicate.java
+++ b/net/minecraft/advancements/critereon/NBTPredicate.java
@@ -51,7 +51,6 @@ public class NBTPredicate {
 
             return new NBTPredicate(nbttagcompound);
         } else {
-            /** The predicate that matches any NBT tag. */
             return ANY;
         }
     }
diff --git a/net/minecraft/client/Minecraft.java b/net/minecraft/client/Minecraft.java
index b1bf587..9b9bcee 100644
--- a/net/minecraft/client/Minecraft.java
+++ b/net/minecraft/client/Minecraft.java
@@ -2222,7 +2222,6 @@ public class Minecraft implements IThreadListener, ISnooperInfo {
     }
 
     public static boolean isGuiEnabled() {
-        /** The instance of the Minecraft Client, set in the constructor. */
         return instance == null || !instance.gameSettings.hideGUI;
     }
 
@@ -2469,7 +2468,6 @@ public class Minecraft implements IThreadListener, ISnooperInfo {
      * Return the singleton Minecraft instance for the game
      */
     public static Minecraft getMinecraft() {
-        /** The instance of the Minecraft Client, set in the constructor. */
         return instance;
     }
 
@@ -2882,10 +2880,6 @@ public class Minecraft implements IThreadListener, ISnooperInfo {
     }
 
     public static int getDebugFPS() {
-        /**
-         * This is set to fpsCounter every debug screen update, and is shown on the debug screen. It's also sent as part
-         * of the usage snooping.
-         */
         return debugFPS;
     }
 
diff --git a/net/minecraft/client/gui/inventory/GuiContainerCreative.java b/net/minecraft/client/gui/inventory/GuiContainerCreative.java
index a945cc0..923e4b1 100644
--- a/net/minecraft/client/gui/inventory/GuiContainerCreative.java
+++ b/net/minecraft/client/gui/inventory/GuiContainerCreative.java
@@ -716,7 +716,6 @@ public class GuiContainerCreative extends InventoryEffectRenderer {
      * Returns the index of the currently selected tab.
      */
     public int getSelectedTabIndex() {
-        /** Currently selected creative inventory tab index. */
         return selectedTabIndex;
     }
 
diff --git a/net/minecraft/client/renderer/ActiveRenderInfo.java b/net/minecraft/client/renderer/ActiveRenderInfo.java
index 1a10e83..4297fc7 100644
--- a/net/minecraft/client/renderer/ActiveRenderInfo.java
+++ b/net/minecraft/client/renderer/ActiveRenderInfo.java
@@ -90,27 +90,22 @@ public class ActiveRenderInfo {
     }
 
     public static float getRotationX() {
-        /** The X component of the entity's yaw rotation */
         return rotationX;
     }
 
     public static float getRotationXZ() {
-        /** The combined X and Z components of the entity's pitch rotation */
         return rotationXZ;
     }
 
     public static float getRotationZ() {
-        /** The Z component of the entity's yaw rotation */
         return rotationZ;
     }
 
     public static float getRotationYZ() {
-        /** The Y component (scaled along the Z axis) of the entity's pitch rotation */
         return rotationYZ;
     }
 
     public static float getRotationXY() {
-        /** The Y component (scaled along the X axis) of the entity's pitch rotation */
         return rotationXY;
     }
 }
\ No newline at end of file
diff --git a/net/minecraft/client/renderer/RenderHelper.java b/net/minecraft/client/renderer/RenderHelper.java
index 8fc0db7..264006d 100644
--- a/net/minecraft/client/renderer/RenderHelper.java
+++ b/net/minecraft/client/renderer/RenderHelper.java
@@ -59,7 +59,6 @@ public class RenderHelper {
         COLOR_BUFFER.clear();
         COLOR_BUFFER.put(p_74521_0_).put(p_74521_1_).put(p_74521_2_).put(p_74521_3_);
         COLOR_BUFFER.flip();
-        /** Float buffer used to set OpenGL material colors */
         return COLOR_BUFFER;
     }
 
diff --git a/net/minecraft/client/renderer/Tessellator.java b/net/minecraft/client/renderer/Tessellator.java
index b2eede4..3ba0b77 100644
--- a/net/minecraft/client/renderer/Tessellator.java
+++ b/net/minecraft/client/renderer/Tessellator.java
@@ -11,7 +11,6 @@ public class Tessellator {
     private static final Tessellator INSTANCE = new Tessellator(2097152);
 
     public static Tessellator getInstance() {
-        /** The static instance of the Tessellator. */
         return INSTANCE;
     }
 
diff --git a/net/minecraft/client/renderer/entity/RenderArmorStand.java b/net/minecraft/client/renderer/entity/RenderArmorStand.java
index bf94630..bb99def 100644
--- a/net/minecraft/client/renderer/entity/RenderArmorStand.java
+++ b/net/minecraft/client/renderer/entity/RenderArmorStand.java
@@ -36,7 +36,6 @@ public class RenderArmorStand extends RenderLivingBase<EntityArmorStand> {
      * Returns the location of an entity's texture. Doesn't seem to be called unless you call Render.bindEntityTexture.
      */
     protected ResourceLocation getEntityTexture(EntityArmorStand entity) {
-        /** A constant instance of the armor stand texture, wrapped inside a ResourceLocation wrapper. */
         return TEXTURE_ARMOR_STAND;
     }
 
diff --git a/net/minecraft/client/resources/DefaultPlayerSkin.java b/net/minecraft/client/resources/DefaultPlayerSkin.java
index cc8d581..635d0eb 100644
--- a/net/minecraft/client/resources/DefaultPlayerSkin.java
+++ b/net/minecraft/client/resources/DefaultPlayerSkin.java
@@ -16,7 +16,6 @@ public class DefaultPlayerSkin {
      * Returns the default skind for versions prior to 1.8, which is always the Steve texture.
      */
     public static ResourceLocation getDefaultSkinLegacy() {
-        /** The default skin for the Steve model. */
         return TEXTURE_STEVE;
     }
 
diff --git a/net/minecraft/entity/EntityList.java b/net/minecraft/entity/EntityList.java
index 90a9ce4..cd8e940 100644
--- a/net/minecraft/entity/EntityList.java
+++ b/net/minecraft/entity/EntityList.java
@@ -250,12 +250,6 @@ public class EntityList {
      * @return A collection of all known entity types. Do not modify this collection.
      */
     public static Set<ResourceLocation> getEntityNameList() {
-        /**
-         * A list of all known entity types.
-         *  
-         * @deprecated DO NOT USE. This field does not exist under forge, and mods using it will break if forge is
-         * installed. Use {@link #getEntityNameList()} instead.
-         */
         return KNOWN_TYPES;
     }
 
diff --git a/net/minecraft/init/Bootstrap.java b/net/minecraft/init/Bootstrap.java
index 181f7f8..e53719c 100644
--- a/net/minecraft/init/Bootstrap.java
+++ b/net/minecraft/init/Bootstrap.java
@@ -83,7 +83,6 @@ public class Bootstrap {
      * Is Bootstrap registration already done?
      */
     public static boolean isRegistered() {
-        /** Whether the blocks, items, etc have already been registered */
         return alreadyRegistered;
     }
 
diff --git a/net/minecraft/tileentity/TileEntityBrewingStand.java b/net/minecraft/tileentity/TileEntityBrewingStand.java
index 1d2cc3c..654acc7 100644
--- a/net/minecraft/tileentity/TileEntityBrewingStand.java
+++ b/net/minecraft/tileentity/TileEntityBrewingStand.java
@@ -295,7 +295,6 @@ public class TileEntityBrewingStand extends TileEntityLockable implements ITicka
 
     public int[] getSlotsForFace(EnumFacing side) {
         if (side == EnumFacing.UP) {
-            /** an array of the input slot indices */
             return SLOTS_FOR_UP;
         } else {
             return side == EnumFacing.DOWN ? SLOTS_FOR_DOWN : OUTPUT_SLOTS;
diff --git a/net/minecraft/util/text/translation/LanguageMap.java b/net/minecraft/util/text/translation/LanguageMap.java
index e67d892..4304c4c 100644
--- a/net/minecraft/util/text/translation/LanguageMap.java
+++ b/net/minecraft/util/text/translation/LanguageMap.java
@@ -50,7 +50,6 @@ public class LanguageMap {
      * Return the StringTranslate singleton instance
      */
     static LanguageMap getInstance() {
-        /** Is the private singleton instance of StringTranslate. */
         return instance;
     }
 
diff --git a/net/minecraft/world/biome/BiomeJungle.java b/net/minecraft/world/biome/BiomeJungle.java
index 327e7a7..ba32c4f 100644
--- a/net/minecraft/world/biome/BiomeJungle.java
+++ b/net/minecraft/world/biome/BiomeJungle.java
@@ -52,7 +52,6 @@ public class BiomeJungle extends Biome {
 
     public WorldGenAbstractTree getRandomTreeFeature(Random rand) {
         if (rand.nextInt(10) == 0) {
-            /** The big tree generator. */
             return BIG_TREE_FEATURE;
         } else if (rand.nextInt(2) == 0) {
             return new WorldGenShrub(JUNGLE_LOG, OAK_LEAF);
diff --git a/net/minecraft/world/biome/BiomeMesa.java b/net/minecraft/world/biome/BiomeMesa.java
index 9c02674..d1b58ac 100644
--- a/net/minecraft/world/biome/BiomeMesa.java
+++ b/net/minecraft/world/biome/BiomeMesa.java
@@ -59,7 +59,6 @@ public class BiomeMesa extends Biome {
     }
 
     public WorldGenAbstractTree getRandomTreeFeature(Random rand) {
-        /** The tree generator. */
         return TREE_FEATURE;
     }
 
diff --git a/net/minecraft/world/biome/BiomeSwamp.java b/net/minecraft/world/biome/BiomeSwamp.java
index 5a2e27a..ed71763 100644
--- a/net/minecraft/world/biome/BiomeSwamp.java
+++ b/net/minecraft/world/biome/BiomeSwamp.java
@@ -33,7 +33,6 @@ public class BiomeSwamp extends Biome {
     }
 
     public WorldGenAbstractTree getRandomTreeFeature(Random rand) {
-        /** The swamp tree generator. */
         return SWAMP_FEATURE;
     }
 
diff --git a/net/minecraft/world/storage/ThreadedFileIOBase.java b/net/minecraft/world/storage/ThreadedFileIOBase.java
index 85d8e08..4006cdc 100644
--- a/net/minecraft/world/storage/ThreadedFileIOBase.java
+++ b/net/minecraft/world/storage/ThreadedFileIOBase.java
@@ -22,7 +22,6 @@ public class ThreadedFileIOBase implements Runnable {
      * Retrieves an instance of the threadedFileIOBase.
      */
     public static ThreadedFileIOBase getThreadedIOInstance() {
-        /** Instance of ThreadedFileIOBase */
         return INSTANCE;
     }
```