### PR TITLE
[WIP, experimental] Class javadocs

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/tasks/RemapSources.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/RemapSources.java
@@ -125,6 +125,7 @@ public class RemapSources extends AbstractEditJarTask
     @Override
     public String asRead(String name, String text)
     {
+        String className = name.replace(".java", "").replaceAll("[/\\\\]", ".");
         ArrayList<String> newLines = new ArrayList<String>();
         for (String line : Constants.lines(text))
         {
@@ -132,7 +133,7 @@ public class RemapSources extends AbstractEditJarTask
             // if we aren't doing javadocs... screw dat.
             if (addsJavadocs)
             {
-                injectJavadoc(newLines, line, name, methodDocs::get, fieldDocs::get, classDocs::get);
+                injectJavadoc(newLines, line, className, methodDocs::get, fieldDocs::get, classDocs::get);
             }
             newLines.add(replaceInLine(line));
         }
@@ -146,11 +147,11 @@ public class RemapSources extends AbstractEditJarTask
      *
      * @param lines The current file content (to be modified by this method)
      * @param line The line that was just read (will not be in the list)
-     * @param name The file's name (including ending .java)
+     * @param name The fully qualified name of the class
      * @param methodFunc A function that takes a method SRG id and returns its javadoc
      * @param fieldFunc A function that takes a field SRG id and returns its javadoc
-     * @param classFunc A function that takes a filename (with .java) followed by the 
-     * class name and returns its javadoc
+     * @param classFunc A function that takes a qualified class name, and then the inner
+     * class name, and returns its javadoc
      */
     public static void injectJavadoc(List<String> lines, String line, String name,
             Function<String, String> methodFunc, Function<String, String> fieldFunc, Function<String, String> classFunc)
@@ -193,7 +194,7 @@ public class RemapSources extends AbstractEditJarTask
             return;
         }
 
-        if (name.endsWith("package-info.java")) {
+        if (name.endsWith("package-info")) {
             matcher = PACKAGE_JAVADOC_PATTERN.matcher(line);
             if (matcher.find()) {
                 String javadoc = classFunc.apply(name + ":" + matcher.group("name"));

--- a/src/main/java/net/minecraftforge/gradle/tasks/RemapSources.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/RemapSources.java
@@ -65,10 +65,11 @@ public class RemapSources extends AbstractEditJarTask
     private final Map<String, String> classDocs    = Maps.newHashMap();
 
 
-    private static final Pattern      SRG_FINDER             = Pattern.compile("func_[0-9]+_[a-zA-Z_]+|field_[0-9]+_[a-zA-Z_]+|p_[\\w]+_\\d+_\\b");
-    private static final Pattern      METHOD_JAVADOC_PATTERN = Pattern.compile("^(?<indent>(?: {4})+|\\t+)(?!return)(?:\\w+\\s+)*(?<generic><[\\w\\W]*>\\s+)?(?<return>\\w+[\\w$.]*(?:<[\\w\\W]*>)?[\\[\\]]*)\\s+(?<name>func_[0-9]+_[a-zA-Z_]+)\\(");
-    private static final Pattern      FIELD_JAVADOC_PATTERN  = Pattern.compile("^(?<indent>(?: {4})+|\\t+)(?!return)(?:\\w+\\s+)*(?:\\w+[\\w$.]*(?:<[\\w\\W]*>)?[\\[\\]]*)\\s+(?<name>field_[0-9]+_[a-zA-Z_]+) *(?:=|;)");
-    private static final Pattern      CLASS_JAVADOC_PATTERN  = Pattern.compile("^(?<indent>(?: {4})*|\\t*)(?:\\w+\\s+)*(?:class|interface|enum) (?<name>\\w+)");
+    private static final Pattern SRG_FINDER              = Pattern.compile("func_[0-9]+_[a-zA-Z_]+|field_[0-9]+_[a-zA-Z_]+|p_[\\w]+_\\d+_\\b");
+    private static final Pattern METHOD_JAVADOC_PATTERN  = Pattern.compile("^(?<indent>(?: {4})+|\\t+)(?!return)(?:\\w+\\s+)*(?<generic><[\\w\\W]*>\\s+)?(?<return>\\w+[\\w$.]*(?:<[\\w\\W]*>)?[\\[\\]]*)\\s+(?<name>func_[0-9]+_[a-zA-Z_]+)\\(");
+    private static final Pattern FIELD_JAVADOC_PATTERN   = Pattern.compile("^(?<indent>(?: {4})+|\\t+)(?!return)(?:\\w+\\s+)*(?:\\w+[\\w$.]*(?:<[\\w\\W]*>)?[\\[\\]]*)\\s+(?<name>field_[0-9]+_[a-zA-Z_]+) *(?:=|;)");
+    private static final Pattern CLASS_JAVADOC_PATTERN   = Pattern.compile("^(?<indent>(?: {4})*|\\t*)(?:\\w+\\s+)*(?:class|interface|enum) (?<name>\\w+)");
+    private static final Pattern PACKAGE_JAVADOC_PATTERN = Pattern.compile("^package (?<name>.+);");
 
     @Override
     public void doStuffBefore() throws Exception
@@ -190,6 +191,19 @@ public class RemapSources extends AbstractEditJarTask
             }
 
             return;
+        }
+
+        if (name.endsWith("package-info.java")) {
+            matcher = PACKAGE_JAVADOC_PATTERN.matcher(line);
+            if (matcher.find()) {
+                String javadoc = classFunc.apply(name + ":" + matcher.group("name"));
+                if (!Strings.isNullOrEmpty(javadoc))
+                {
+                    insertAboveAnnotations(lines, JavadocAdder.buildJavadoc("", javadoc, true));
+                }
+
+                return;
+            }
         }
     }
 

--- a/src/main/java/net/minecraftforge/gradle/util/mcp/JavadocAdder.java
+++ b/src/main/java/net/minecraftforge/gradle/util/mcp/JavadocAdder.java
@@ -36,10 +36,10 @@ public final class JavadocAdder
      * Converts a raw javadoc string into a nicely formatted, indented, and wrapped string.
      * @param indent the indent to be inserted before every line.
      * @param javadoc The javadoc string to be processed
-     * @param isMethod If this javadoc is for a method or a field
+     * @param forceMultiline If this javadoc should always be spread over multiple lines even if it can fit in one
      * @return A fully formatted javadoc comment string complete with comment characters and newlines.
      */
-    public static String buildJavadoc(String indent, String javadoc, boolean isMethod)
+    public static String buildJavadoc(String indent, String javadoc, boolean forceMultiline)
     {
         StringBuilder builder = new StringBuilder();
         
@@ -50,7 +50,7 @@ public final class JavadocAdder
             list.addAll(wrapText(line, 120 - (indent.length() + 3)));
         }
 
-        if (list.size() > 1 || isMethod)
+        if (list.size() > 1 || forceMultiline)
         {
             builder.append(indent);
             builder.append("/**");

--- a/src/test/java/net/minecraftforge/gradle/util/mcp/JavadocInserterTest.java
+++ b/src/test/java/net/minecraftforge/gradle/util/mcp/JavadocInserterTest.java
@@ -46,7 +46,7 @@ public class JavadocInserterTest
         for (String line : Constants.lines(input))
         {
             System.out.println(line);
-            RemapSources.injectJavadoc(newLines, line, method -> "Javadoc For: " + method, field -> "Javadoc For: " + field);
+            RemapSources.injectJavadoc(newLines, line, "", method -> "Javadoc For: " + method, field -> "Javadoc For: " + field, cls -> null);
             newLines.add(line);
         }
         String output = Joiner.on(Constants.NEWLINE).join(newLines);


### PR DESCRIPTION
See ModCoderPack/MCPBot-Issues#589.

Experimental support for defining class javadocs, more to show that it can be done than to actually do it.  Requires a `classes.csv` file to be given to the `RemapSources` task; otherwise nothing happens.  Here is [the csv I've been using](https://gist.github.com/Pokechu22/295368414eb621b451315fb62e823f34).

The technique I'm using is to look for class declarations, and then combine the name there and the file it's declared in.  I also re-use this for packages.

This is just a proof of concept at the moment; the actual logic is messy (for instance, I don't know if including filenames in a CSV file is good, packages might be better).