### PR TITLE
Rewrite McpCleanup.stripComments to fix comment stripping bugs

### DIFF
--- a/src/test/java/net/minecraftforge/gradle/util/mcp/StripCommentsTest.java
+++ b/src/test/java/net/minecraftforge/gradle/util/mcp/StripCommentsTest.java
@@ -1,0 +1,62 @@
+/*
+ * A Gradle plugin for the creation of Minecraft mods and MinecraftForge plugins.
+ * Copyright (C) 2013 Minecraft Forge
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+package net.minecraftforge.gradle.util.mcp;
+
+import org.junit.Test;
+
+import com.google.common.io.ByteStreams;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.junit.Assert;
+
+public class StripCommentsTest
+{
+    private static final String[] INPUTS    = new String[] {"StripComments", "UnendedString"};
+    private static final String OUTPUT_POSTFIX = "Out";
+
+    @Test
+    public void testStripComments() throws IOException
+    {
+        for (String i : INPUTS)
+        {
+            String input = readResource(i);
+
+            input = McpCleanup.stripComments(input);
+
+            String[] expected = readResource(i + OUTPUT_POSTFIX).split("\r\n|\r|\n");
+            String[] actual = input.split("\r\n|\r|\n");
+
+            for (int k = 0; k < expected.length; k++)
+            {
+                System.out.println("EXPECTED >>"+expected[k]);
+                System.out.println("ACTUAL   >>"+actual[k]);
+                Assert.assertEquals(expected[k], actual[k]);
+            }
+        }
+    }
+
+    private String readResource(String name) throws IOException
+    {
+        InputStream stream = this.getClass().getClassLoader().getResourceAsStream(name);
+        return new String(ByteStreams.toByteArray(stream));
+    }
+}

--- a/src/test/resources/StripComments
+++ b/src/test/resources/StripComments
@@ -1,0 +1,17 @@
+public class StripComments
+{
+	//I am a single line comment
+	boolean flag = false;
+	/*
+	 * I am a multi line comment
+	 */
+	public static final String greeting = "hello world'a/*'";
+	public static final String nastyStr = "yadadada*";
+	//I should get removed
+	public static final String victimStr = "something or // other";
+
+	public void someMethod()
+	{
+		System.out.println("some test");
+	}
+}

--- a/src/test/resources/StripCommentsOut
+++ b/src/test/resources/StripCommentsOut
@@ -1,0 +1,15 @@
+public class StripComments
+{
+
+	boolean flag = false;
+
+	public static final String greeting = "hello world'a/*'";
+	public static final String nastyStr = "yadadada*";
+
+	public static final String victimStr = "something or // other";
+
+	public void someMethod()
+	{
+		System.out.println("some test");
+	}
+}

--- a/src/test/resources/UnendedString
+++ b/src/test/resources/UnendedString
@@ -1,0 +1,3 @@
+class UnendedString
+{
+} "\

--- a/src/test/resources/UnendedStringOut
+++ b/src/test/resources/UnendedStringOut
@@ -1,0 +1,3 @@
+class UnendedString
+{
+} "\


### PR DESCRIPTION
The method contained some bugs, like how asterisk in multi line comments would
not be stripped and strings ending with asterisks would cause comments to be
recognized within strings subsequent. The old version of the method was patchable,
but it would be more difficult than necessary to think about the correct behavior
as the logic for each state(if the current character was in code, a string or a comment)
was handled in several different places. Instead, the rewrite puts each state
into its own part of the code to make it easy to reason about.

The McpCleanup.stripComments, when applied to src/test/resources/StripComments yields
```
public class StripComments
{

    boolean flag = false;
    *
    public static final String greeting = "hello world'a/*'";
    public static final String nastyStr = "yadadada*";
    //I should get removed
    public static final String victimStr = "something or

    public void someMethod()
    {
        System.out.println("some test");
    }
}
```
Notice the stray asterisk after `boolean flag = false;` and the missing `other";` in `victimStr = "something or`. These are the bugs I'm talking about.

The stray asterisk bug occurs because when the old version came across an asterisk, it did not correctly handle the case where it is in a comment and is not followed by a forward slash. The `victimStr` bug occurs because the code looked ahead a character to handle certain cases and if the case is not met, it blindly added that character. In this case, the asterisk in `nastyStr` caused a look ahead to see if there was a forward slash, which would have caused the end of a comment. Since the next character was not a forward slash, the handling of the quote was skipped so `inComment` was the opposite of what it was supposed to be.

Since there might have been more bugs lurking in the method, I decided to rewrite it.

I've tested that the post decompile task (named fixMcSources under ForgePlugin) yields the same results under the setupDecompWorkspace task. Note that this bug does not come up in minecraft. Over at my fork which decompiles optifine, I found that some optifine classes exemplify this bug.