### PR TITLE
Fixes incompatibility with gradle of version 4.4.1 and above

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -902,7 +902,12 @@ public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePl
             JavaExec exec = makeTask("runClient", JavaExec.class);
             exec.getOutputs().dir(delayedFile(REPLACE_RUN_DIR));
             exec.setMain(GRADLE_START_CLIENT);
-            exec.workingDir(delayedFile(REPLACE_RUN_DIR));
+            exec.doFirst(new Action<Task>() {
+                @Override
+                public void execute(Task task) {
+                    ((JavaExec) task).workingDir(delayedFile(REPLACE_RUN_DIR));
+                }
+            });
             exec.setStandardOutput(System.out);
             exec.setErrorOutput(System.err);
 
@@ -919,7 +924,12 @@ public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePl
             JavaExec exec = makeTask("runServer", JavaExec.class);
             exec.getOutputs().dir(delayedFile(REPLACE_RUN_DIR));
             exec.setMain(GRADLE_START_SERVER);
-            exec.workingDir(delayedFile(REPLACE_RUN_DIR));
+            exec.doFirst(new Action<Task>() {
+                @Override
+                public void execute(Task task) {
+                    ((JavaExec) task).workingDir(delayedFile(REPLACE_RUN_DIR));
+                }
+            });
             exec.setStandardOutput(System.out);
             exec.setStandardInput(System.in);
             exec.setErrorOutput(System.err);

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -902,12 +902,7 @@ public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePl
             JavaExec exec = makeTask("runClient", JavaExec.class);
             exec.getOutputs().dir(delayedFile(REPLACE_RUN_DIR));
             exec.setMain(GRADLE_START_CLIENT);
-            exec.doFirst(new Action<Task>() {
-                @Override
-                public void execute(Task task) {
-                    ((JavaExec) task).workingDir(delayedFile(REPLACE_RUN_DIR));
-                }
-            });
+            exec.doFirst(task -> ((JavaExec) task).workingDir(delayedFile(REPLACE_RUN_DIR)));
             exec.setStandardOutput(System.out);
             exec.setErrorOutput(System.err);
 
@@ -924,12 +919,7 @@ public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePl
             JavaExec exec = makeTask("runServer", JavaExec.class);
             exec.getOutputs().dir(delayedFile(REPLACE_RUN_DIR));
             exec.setMain(GRADLE_START_SERVER);
-            exec.doFirst(new Action<Task>() {
-                @Override
-                public void execute(Task task) {
-                    ((JavaExec) task).workingDir(delayedFile(REPLACE_RUN_DIR));
-                }
-            });
+            exec.doFirst(task -> ((JavaExec) task).workingDir(delayedFile(REPLACE_RUN_DIR)));
             exec.setStandardOutput(System.out);
             exec.setStandardInput(System.in);
             exec.setErrorOutput(System.err);


### PR DESCRIPTION
Closes #469

Since the gradle 4.4.1 update, the files are no longer created with delay.
Thus, we must add files to working directly before the task is actually executed, not at the time of definition.

A working example is here: https://gist.github.com/liach/f28c67e3052129968bf09950b709a804