### PR TITLE
[FG-2.2] Update to MCInjector 1.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ dependencies {
 
     // mcp stuff
     shade 'de.oceanlabs.mcp:RetroGuard:3.6.6'
-    shade 'de.oceanlabs.mcp:mcinjector:3.4-SNAPSHOT'
+    shade 'de.oceanlabs.mcp:mcinjector:3.6'
     shade 'net.minecraftforge.srg2source:Srg2Source:4.0-SNAPSHOT'
 
     //Stuff used in the GradleStart classes


### PR DESCRIPTION
Fixes #472.

Code diff (1.11.2):

```diff
diff --git a/projects/src/main/java/net/minecraft/client/renderer/RenderGlobal.java b/projects/src/main/java/net/minecraft/client/renderer/RenderGlobal.java
index 821cf8a..2a20535 100644
--- a/projects/src/main/java/net/minecraft/client/renderer/RenderGlobal.java
+++ b/projects/src/main/java/net/minecraft/client/renderer/RenderGlobal.java
@@ -2262,7 +2262,7 @@ public class RenderGlobal implements IWorldEventListener, IResourceManagerReload
         byte setFacing;
         final int counter;
 
-        private ContainerLocalRenderInformation(RenderChunk renderChunkIn, EnumFacing facingIn, @Nullable int counterIn) {
+        private ContainerLocalRenderInformation(RenderChunk renderChunkIn, @Nullable EnumFacing facingIn, int counterIn) {
             this.renderChunk = renderChunkIn;
             this.facing = facingIn;
             this.counter = counterIn;
diff --git a/projects/src/main/java/net/minecraft/network/play/server/SPacketPlayerListItem.java b/projects/src/main/java/net/minecraft/network/play/server/SPacketPlayerListItem.java
index d4fec5c..4839a72 100644
--- a/projects/src/main/java/net/minecraft/network/play/server/SPacketPlayerListItem.java
+++ b/projects/src/main/java/net/minecraft/network/play/server/SPacketPlayerListItem.java
@@ -198,7 +198,7 @@ public class SPacketPlayerListItem implements Packet<INetHandlerPlayClient> {
         private final GameProfile profile;
         private final ITextComponent displayName;
 
-        public AddPlayerData(GameProfile profileIn, int latencyIn, GameType gameModeIn, @Nullable ITextComponent displayNameIn) {
+        public AddPlayerData(GameProfile profileIn, int latencyIn, @Nullable GameType gameModeIn, @Nullable ITextComponent displayNameIn) {
             this.profile = profileIn;
             this.ping = latencyIn;
             this.gamemode = gameModeIn;
```

This does switch to asm 6.1 from 5.1, which seems to cause other changes (among others, it looks like the remapped jar has some attributes in a different order, causing a lot of class files with different hashes).  This seems more likely to cause issues than the migration from 6.0 for FG 2.3, but doesn't seem to have actually caused any problems for me.