### PR TITLE
[1.13] Fixes 'methodMissing' issue. Allows merging parent RunConfigs into multiple RunConfigs

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/EclipseHacks.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/EclipseHacks.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.Nonnull;
 import javax.xml.parsers.ParserConfigurationException;
 
 import org.apache.commons.io.IOUtils;
@@ -50,7 +51,8 @@ import net.minecraftforge.gradle.common.task.ExtractNatives;
 public class EclipseHacks {
 
     @SuppressWarnings("unchecked")
-    public static void doEclipseFixes(Project project, ExtractNatives nativesTask, DownloadAssets assetsTask, Map<String, RunConfig> runs) {
+    public static void doEclipseFixes(@Nonnull final MinecraftExtension minecraft, @Nonnull final ExtractNatives nativesTask, @Nonnull final DownloadAssets assetsTask) {
+        final Project project = minecraft.getProject();
         final File natives = nativesTask.getOutput();
         final File assets = assetsTask.getOutput();
 
@@ -88,8 +90,7 @@ public class EclipseHacks {
                         IOUtils.write(XmlUtil.serialize(xml), fos, StandardCharsets.UTF_8);
                     }
 
-                    for (Map.Entry<String, RunConfig> entry : runs.entrySet()) {
-                        RunConfig runConfig = entry.getValue();
+                    for (final RunConfig runConfig : minecraft.getRuns()) {
                         xml = new Node(null, "launchConfiguration", props("type", "org.eclipse.jdt.launching.localJavaApplication"));
 
                         String workDir = runConfig.getWorkingDirectory();
@@ -119,7 +120,7 @@ public class EclipseHacks {
                             xml.appendNode("stringAttribute", props("key", "org.eclipse.jdt.launching.VM_ARGUMENTS", "value", props));
                         }
 
-                        try (OutputStream fos = new FileOutputStream(project.file(entry.getKey() + ".launch"))) {
+                        try (OutputStream fos = new FileOutputStream(project.file(runConfig.getUniqueFileName() + ".launch"))) {
                             IOUtils.write(XmlUtil.serialize(xml), fos, StandardCharsets.UTF_8);
                         }
                     }

--- a/src/common/java/net/minecraftforge/gradle/common/util/IntellijUtils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/IntellijUtils.java
@@ -20,14 +20,13 @@
 
 package net.minecraftforge.gradle.common.util;
 
-import net.minecraftforge.gradle.common.task.DownloadAssets;
-import net.minecraftforge.gradle.common.task.ExtractNatives;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.tasks.TaskProvider;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import javax.annotation.Nonnull;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
@@ -39,153 +38,137 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.File;
-import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class IntellijUtils {
-    public static void createIntellijRunsTask(Project project, ExtractNatives extractNatives, DownloadAssets downloadAssets, Task prepareRun, Map<String, RunConfig> runs) {
-        TaskProvider<Task> genIntellijRuns = project.getTasks().register("genIntellijRuns", Task.class);
-        genIntellijRuns.configure(task0 -> {
-            task0.dependsOn(extractNatives, downloadAssets);
-            task0.doLast(task1 -> {
-                try {
-                    File runConfigurationsDir = new File(project.getRootProject().getProjectDir().getCanonicalFile(), ".idea/runConfigurations");
 
-                    if (!runConfigurationsDir.exists())
-                        runConfigurationsDir.mkdirs();
+    @SuppressWarnings("UnstableApiUsage")
+    public static void createIntellijRunsTask(@Nonnull final MinecraftExtension minecraft, @Nonnull final TaskProvider<Task> prepareRuns) {
+        final Project project = minecraft.getProject();
 
-                    DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-                    DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+        project.getTasks().register("genIntelliJRuns", Task.class, task -> {
+            task.dependsOn(prepareRuns.get());
 
-                    TransformerFactory transformerFactory = TransformerFactory.newInstance();
-                    Transformer transformer = transformerFactory.newTransformer();
-                    transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-                    transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
-                    runs.forEach((name, runConfig) -> {
-                        String moduleName = runConfig.getIdeaModule();
-                        if (moduleName == null)
-                            moduleName = project.getName() + "_main";
-                        createRunConfigurationXml(name, runConfig, runConfig.isSingleInstance(), docBuilder, transformer,
-                                    moduleName, Collections.singletonList(prepareRun), runConfigurationsDir);
-                    });
+            try {
+                final File runConfigurationsDir = new File(project.getRootProject().getRootDir(), ".idea/runConfigurations");
 
-                } catch (IOException | ParserConfigurationException | TransformerConfigurationException e) {
-                    e.printStackTrace();
+                if (!runConfigurationsDir.exists()) {
+                    runConfigurationsDir.mkdirs();
                 }
-            });
+
+                DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+                DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+                TransformerFactory transformerFactory = TransformerFactory.newInstance();
+                Transformer transformer = transformerFactory.newTransformer();
+
+                transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+                transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+
+                minecraft.getRuns().forEach(runConfig -> createRunConfigurationXML(project, runConfig, docBuilder, transformer, runConfigurationsDir));
+            } catch (ParserConfigurationException | TransformerConfigurationException e) {
+                e.printStackTrace();
+            }
         });
     }
 
-    public static void createRunConfigurationXml(Project project, String runName, RunConfig runConfig, boolean singleInstance, String moduleName, Collection<Task> dependencyTasks) {
-        try {
-            File runConfigurationsDir = new File(project.getProjectDir().getCanonicalFile(), ".idea/runConfigurations");
-
-            if (!runConfigurationsDir.exists())
-                runConfigurationsDir.mkdirs();
-
-            DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-            DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
-
-            TransformerFactory transformerFactory = TransformerFactory.newInstance();
-            Transformer transformer = transformerFactory.newTransformer();
-            transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-            transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
-
-            createRunConfigurationXml(runName, runConfig, singleInstance, docBuilder, transformer, moduleName, dependencyTasks, runConfigurationsDir);
-        } catch (IOException | ParserConfigurationException | TransformerConfigurationException e) {
-            e.printStackTrace();
-        }
-    }
-
-    private static void createRunConfigurationXml(String taskName, RunConfig runConfig, boolean singleInstance, DocumentBuilder docBuilder, Transformer transformer, String moduleName, Collection<Task> dependencyTasks, File runConfigurationsDir) {
-        String mainClass = runConfig.getMain();
-        String workDir = runConfig.getWorkingDirectory();
+    public static void createRunConfigurationXML(@Nonnull final Project project, @Nonnull final RunConfig runConfig, @Nonnull final DocumentBuilder docBuilder, @Nonnull final Transformer transformer, @Nonnull final File runConfigurationsDir) {
         Stream<String> propStream = runConfig.getProperties().entrySet().stream()
                 .map(kv -> String.format("-D%s=%s", kv.getKey(), kv.getValue()));
-
         String props = Stream.concat(propStream, runConfig.getJvmArgs().stream()).collect(Collectors.joining(" "));
-        String args = String.join(" ", runConfig.getArgs());
-
         Document doc = docBuilder.newDocument();
+        {
+            Element rootElement = doc.createElement("component");
+            {
+                Element configuration = doc.createElement("configuration");
+                {
+                    configuration.setAttribute("default", "false");
+                    configuration.setAttribute("name", runConfig.getUniqueName());
+                    configuration.setAttribute("type", "Application");
+                    configuration.setAttribute("factoryName", "Application");
+                    configuration.setAttribute("singleton", runConfig.isSingleInstance() ? "true" : "false");
 
-        Element rootElement = doc.createElement("component");
-        rootElement.setAttribute("name", "ProjectRunConfigurationManager");
-        doc.appendChild(rootElement);
+                    Element className = doc.createElement("option");
+                    {
+                        className.setAttribute("name", "MAIN_CLASS_NAME");
+                        className.setAttribute("value", runConfig.getMain());
+                    }
+                    configuration.appendChild(className);
 
-        Element configuration = doc.createElement("configuration");
-        configuration.setAttribute("default", "false");
-        configuration.setAttribute("name", taskName);
-        configuration.setAttribute("type", "Application");
-        configuration.setAttribute("factoryName", "Application");
-        configuration.setAttribute("singleton", singleInstance ? "true" : "false");
-        rootElement.appendChild(configuration);
+                    Element vmParameters = doc.createElement("option");
+                    {
+                        vmParameters.setAttribute("name", "VM_PARAMETERS");
+                        vmParameters.setAttribute("value", props);
+                    }
+                    configuration.appendChild(vmParameters);
 
-        Element className = doc.createElement("option");
-        className.setAttribute("name", "MAIN_CLASS_NAME");
-        className.setAttribute("value", mainClass);
-        configuration.appendChild(className);
+                    Element programParameters = doc.createElement("option");
+                    {
+                        programParameters.setAttribute("name", "PROGRAM_PARAMETERS");
+                        programParameters.setAttribute("value", String.join(" ", runConfig.getArgs()));
+                    }
+                    configuration.appendChild(programParameters);
 
-        Element vmParameters = doc.createElement("option");
-        vmParameters.setAttribute("name", "VM_PARAMETERS");
-        vmParameters.setAttribute("value", props);
-        configuration.appendChild(vmParameters);
+                    Element workingDirectory = doc.createElement("option");
+                    {
+                        workingDirectory.setAttribute("name", "WORKING_DIRECTORY");
+                        workingDirectory.setAttribute("value", runConfig.getWorkingDirectory());
+                    }
+                    configuration.appendChild(workingDirectory);
 
-        Element programParameters = doc.createElement("option");
-        programParameters.setAttribute("name", "PROGRAM_PARAMETERS");
-        programParameters.setAttribute("value", args);
-        configuration.appendChild(programParameters);
+                    Element module = doc.createElement("module");
+                    {
+                        module.setAttribute("name", runConfig.getIdeaModule());
+                    }
+                    configuration.appendChild(module);
 
-        if (workDir != null) {
-            Element workingDirectory = doc.createElement("option");
-            workingDirectory.setAttribute("name", "WORKING_DIRECTORY");
-            workingDirectory.setAttribute("value", workDir);
-            configuration.appendChild(workingDirectory);
+                    Element envs = doc.createElement("envs");
+                    runConfig.getEnvironment().forEach((name, value) -> {
+                        Element envEntry = doc.createElement("env");
+                        {
+                            envEntry.setAttribute("name", name);
+                            envEntry.setAttribute("value", value);
+                        }
+                        envs.appendChild(envEntry);
+                    });
+                    configuration.appendChild(envs);
+
+                    Element methods = doc.createElement("method");
+                    {
+                        methods.setAttribute("v", "2");
+
+                        Element makeTask = doc.createElement("option");
+                        {
+                            makeTask.setAttribute("name", "Make");
+                            makeTask.setAttribute("enabled", "true");
+                        }
+                        methods.appendChild(makeTask);
+
+                        Element gradleTask = doc.createElement("option");
+                        {
+                            gradleTask.setAttribute("name", "Gradle.BeforeRunTask");
+                            gradleTask.setAttribute("enabled", "true");
+                            gradleTask.setAttribute("tasks", project.getTasks().getByName("prepare" + Utils.capitalize(runConfig.getTaskName())).getPath());
+                            gradleTask.setAttribute("externalProjectPath", "$PROJECT_DIR$");
+                        }
+                        methods.appendChild(gradleTask);
+                    }
+                    configuration.appendChild(methods);
+                }
+                rootElement.appendChild(configuration);
+            }
+            doc.appendChild(rootElement);
         }
 
-        Element module = doc.createElement("module");
-        module.setAttribute("name", moduleName);
-        configuration.appendChild(module);
-
-        Element envs = doc.createElement("envs");
-        configuration.appendChild(envs);
-
-        runConfig.getEnvironment().entrySet().forEach(kvp -> {
-
-            Element envEntry = doc.createElement("env");
-            envEntry.setAttribute("name", kvp.getKey());
-            envEntry.setAttribute("value", kvp.getValue());
-            envs.appendChild(envEntry);
-        });
-
-        Element methods = doc.createElement("method");
-        methods.setAttribute("v", "2");
-        configuration.appendChild(methods);
-
-        Element makeTask = doc.createElement("option");
-        makeTask.setAttribute("name", "Make");
-        makeTask.setAttribute("enabled", "true");
-        methods.appendChild(makeTask);
-
-        dependencyTasks.forEach(dependencyTask -> {
-            Element gradleTask = doc.createElement("option");
-            gradleTask.setAttribute("name", "Gradle.BeforeRunTask");
-            gradleTask.setAttribute("enabled", "true");
-            gradleTask.setAttribute("tasks", dependencyTask.getName());
-            gradleTask.setAttribute("externalProjectPath", "$PROJECT_DIR$");
-            methods.appendChild(gradleTask);
-        });
-
         DOMSource source = new DOMSource(doc);
-        StreamResult result = new StreamResult(new File(runConfigurationsDir, taskName + ".xml"));
+        StreamResult result = new StreamResult(new File(runConfigurationsDir, runConfig.getUniqueFileName() + ".xml"));
+
         try {
             transformer.transform(source, result);
         } catch (TransformerException e) {
             e.printStackTrace();
         }
-
     }
+
 }

--- a/src/common/java/net/minecraftforge/gradle/common/util/MinecraftExtension.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MinecraftExtension.java
@@ -1,0 +1,146 @@
+/*
+ * ForgeGradle
+ * Copyright (C) 2018 Forge Development LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package net.minecraftforge.gradle.common.util;
+
+import groovy.lang.Closure;
+import net.minecraftforge.gradle.common.task.DownloadAssets;
+import net.minecraftforge.gradle.common.task.ExtractNatives;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.tasks.TaskProvider;
+
+import javax.annotation.Nonnull;
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public abstract class MinecraftExtension {
+
+    protected final Project project;
+    protected final NamedDomainObjectContainer<RunConfig> runs;
+
+    protected String mappings;
+    protected List<File> accessTransformers;
+
+    @Inject
+    public MinecraftExtension(@Nonnull final Project project) {
+        this.project = project;
+        this.runs = project.container(RunConfig.class, name -> new RunConfig(project, name));
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public NamedDomainObjectContainer<RunConfig> runs(Closure closure) {
+        return runs.configure(closure);
+    }
+
+    public NamedDomainObjectContainer<RunConfig> getRuns() {
+        return runs;
+    }
+
+    public void setMappings(@Nonnull String mappings) {
+        this.mappings = mappings;
+    }
+
+    public abstract void mappings(@Nonnull String channel, @Nonnull String version);
+
+    public void mappings(@Nonnull Map<String, String> mappings) {
+        String channel = mappings.get("channel");
+        String version = mappings.get("version");
+
+        if (channel == null || version == null) {
+            throw new IllegalArgumentException("Must specify both mappings channel and version");
+        }
+
+        mappings(channel, version);
+    }
+
+    public String getMappings() {
+        return mappings;
+    }
+
+    public void setAccessTransformers(List<File> accessTransformers) {
+        this.accessTransformers = new ArrayList<>(accessTransformers);
+    }
+
+    public void setAccessTransformers(File... accessTransformers) {
+        setAccessTransformers(Arrays.asList(accessTransformers));
+    }
+
+    public void setAccessTransformer(File accessTransformers) {
+        setAccessTransformers(accessTransformers);
+    }
+
+    public void accessTransformer(File... accessTransformers) {
+        getAccessTransformers().addAll(Arrays.asList(accessTransformers));
+    }
+
+    public void accessTransformers(File... accessTransformers) {
+        accessTransformer(accessTransformers);
+    }
+
+    @Nonnull
+    public List<File> getAccessTransformers() {
+        if (accessTransformers == null) {
+            accessTransformers = new ArrayList<>();
+        }
+
+        return accessTransformers;
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    public void createRunConfigTasks(@Nonnull final TaskProvider<ExtractNatives> extractNatives, @Nonnull final TaskProvider<DownloadAssets> downloadAssets) {
+        createRunConfigTasks(extractNatives.get(), downloadAssets.get());
+    }
+
+    @SuppressWarnings("UnstableApiUsage")
+    public void createRunConfigTasks(@Nonnull final ExtractNatives extractNatives, @Nonnull final DownloadAssets downloadAssets) {
+        TaskProvider<Task> prepareRuns = project.getTasks().register("prepareRuns", Task.class, task -> task.dependsOn(extractNatives, downloadAssets));
+
+        getRuns().forEach(RunConfig::mergeParents);
+
+        // Create run configurations _AFTER_ all projects have evaluated so that _ALL_ run configs exist and have been configured
+        project.getGradle().projectsEvaluated(gradle -> {
+            VersionJson json = null;
+
+            try {
+                json = Utils.loadJson(extractNatives.getMeta(), VersionJson.class);
+            } catch (IOException ignored) { }
+
+            List<String> additionalClientArgs = json != null ? json.getPlatformJvmArgs() : Collections.emptyList();
+
+            getRuns().forEach(RunConfig::mergeChildren);
+            getRuns().forEach(run -> run.createRunTask(prepareRuns, additionalClientArgs));
+
+            EclipseHacks.doEclipseFixes(this, extractNatives, downloadAssets);
+            IntellijUtils.createIntellijRunsTask(this, prepareRuns);
+        });
+    }
+
+}

--- a/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
@@ -20,33 +20,79 @@
 
 package net.minecraftforge.gradle.common.util;
 
+import com.google.common.collect.ImmutableList;
+import groovy.util.MapEntry;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.api.tasks.JavaExec;
+import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.TaskProvider;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.File;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
-import org.gradle.api.tasks.SourceSet;
-
-import com.google.common.base.Joiner;
-
-import groovy.lang.Closure;
-import groovy.lang.MissingPropertyException;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class RunConfig implements Serializable {
+
     private static final String MCP_CLIENT_MAIN = "mcp.client.Start";
     private static final String MC_CLIENT_MAIN = "net.minecraft.client.main.Main";
+
     private static final long serialVersionUID = 1L;
-    private String main;
-    private List<String> args;
-    private List<String> jvmArgs;
-    private Map<String, String> env;
-    private Map<String, String> props;
+
+    private transient final Project project;
+    private final String name;
+
+    private String taskName, main, ideaModule, workDir;
+
     private boolean singleInstance = false;
-    private String ideaModule;
-    private String workDir;
+
+    private List<String> args, jvmArgs;
     private List<SourceSet> sources;
+    private List<RunConfig> parents, children;
+    private Map<String, String> env, props, tokens;
+
+    public RunConfig(@Nonnull final Project project, @Nonnull final String name) {
+        this.project = project;
+        this.name = name;
+    }
+
+    public final String getName() {
+        return name;
+    }
+    public void setTaskName(String taskName) {
+        this.taskName = taskName;
+    }
+    public void taskName(String taskName) {
+        setTaskName(taskName);
+    }
+    public final String getTaskName() {
+        if (taskName == null) {
+            taskName = getName().replaceAll("[^a-zA-Z0-9\\-_]","");
+
+            if (!taskName.startsWith("run")) {
+                taskName = "run" + Utils.capitalize(taskName);
+            }
+        }
+
+        return taskName;
+    }
+    public final String getUniqueFileName() {
+        return project.getPath().length() > 1 ? String.join("_", String.join("_", project.getPath().substring(1).split(":")), getTaskName()) : getTaskName();
+    }
+    public final String getUniqueName() {
+        return getUniqueFileName().replaceAll("_", " ");
+    }
 
     public void environment(Map<String, Object> map) {
         this.setEnvironment(map);
@@ -134,7 +180,11 @@ public class RunConfig implements Serializable {
     public void setIdeaModule(String value) {
         this.ideaModule = value;
     }
-    public String getIdeaModule() {
+    public final String getIdeaModule() {
+        if (ideaModule == null) {
+            ideaModule = project.getName() + "_main";
+        }
+
         return ideaModule;
     }
 
@@ -145,6 +195,10 @@ public class RunConfig implements Serializable {
         this.workDir = value;
     }
     public String getWorkingDirectory() {
+        if (workDir == null) {
+            workDir = project.file("run").getAbsolutePath();
+        }
+
         return workDir;
     }
 
@@ -159,7 +213,6 @@ public class RunConfig implements Serializable {
             this.sources = new ArrayList<>();
         return this.sources;
     }
-
     private List<File> getSourceDirs() {
         final List<File> ret = new ArrayList<>();
         getSources().forEach(set -> {
@@ -170,22 +223,104 @@ public class RunConfig implements Serializable {
         return ret;
     }
 
-    public void merge(RunConfig other, boolean overwrite, Map<String, String> vars) {
-        vars.put("source_roots", Joiner.on(File.pathSeparator).join(getSourceDirs()));
+    public void setParents(List<RunConfig> parents) {
+        this.parents = parents;
+    }
+    public void parents(@Nonnull RunConfig... parents) {
+        getParents().addAll(Arrays.asList(parents));
+    }
+    public void parent(@Nonnull RunConfig parent) {
+        parents(parent);
+    }
+    public void parent(int index, @Nonnull RunConfig parent) {
+        getParents().add(Math.min(index, getParents().size()), parent);
+    }
+    public final List<RunConfig> getParents() {
+        if (parents == null) {
+            parents = new ArrayList<>();
+        }
 
+        return parents;
+    }
+
+    public void setChildren(List<RunConfig> children) {
+        this.children = children;
+    }
+    private Stream<RunConfig> entriesToRuns(@Nonnull MapEntry... children) {
+        return Stream.of(children).map(entry -> {
+            final Project project = entry.getKey() == null
+                    ? this.project : this.project.project(entry.getKey().toString());
+
+            final MinecraftExtension minecraft = project.getExtensions().findByType(MinecraftExtension.class);
+
+            return minecraft == null ? null : minecraft.getRuns().maybeCreate(entry.getValue().toString());
+        }).filter(Objects::nonNull);
+    }
+    public void setChildren(@Nonnull MapEntry... children) {
+        setChildren(entriesToRuns(children).collect(Collectors.toList()));
+    }
+    public void setChildren(@Nonnull Map<String, String> children) {
+        setChildren(children.entrySet().stream()
+                .map((entry) -> new MapEntry(entry.getKey(), entry.getValue()))
+                .toArray(MapEntry[]::new));
+    }
+    public void children(@Nonnull MapEntry... children) {
+        getChildren().addAll(entriesToRuns(children).collect(Collectors.toList()));
+    }
+    public void children(@Nonnull Map<String, String> children) {
+        children(children.entrySet().stream()
+                .map((entry) -> new MapEntry(entry.getKey(), entry.getValue()))
+                .toArray(MapEntry[]::new));
+    }
+    public void child(@Nullable String project, @Nullable String child) {
+        children(new MapEntry(project, child));
+    }
+    public void children(int index, @Nonnull MapEntry... children) {
+        getChildren().addAll(index, entriesToRuns(children).collect(Collectors.toList()));
+    }
+    public void children(int index, @Nonnull Map<String, String> children) {
+        children(index, children.entrySet().stream()
+                .map((entry) -> new MapEntry(entry.getKey(), entry.getValue()))
+                .toArray(MapEntry[]::new));
+    }
+    public void child(int index, @Nullable String project, @Nullable String child) {
+        children(index, new MapEntry(project, child));
+    }
+    public void children(@Nonnull RunConfig... children) {
+        getChildren().addAll(Arrays.asList(children));
+    }
+    public void child(@Nonnull RunConfig child) {
+        children(child);
+    }
+    public void children(int index, @Nonnull RunConfig... children) {
+        getChildren().addAll(Math.min(index, getParents().size()), Arrays.asList(children));
+    }
+    public void child(int index, @Nonnull RunConfig child) {
+        children(index, child);
+    }
+    public final List<RunConfig> getChildren() {
+        if (children == null) {
+            children = new ArrayList<>();
+        }
+
+        return children;
+    }
+
+    public void merge(RunConfig other, boolean overwrite) {
         this.singleInstance = other.singleInstance; // This always overwrite cuz there is no way to tell if it's set
         if (overwrite) {
             this.args = other.args == null ? this.args : other.args;
             this.main = other.main == null ? this.main : other.main;
             this.workDir = other.workDir == null ? this.workDir : other.workDir;
             this.ideaModule = other.ideaModule == null ? this.ideaModule : other.ideaModule;
+            this.sources = other.sources == null ? this.sources : other.sources;
 
             if (other.env != null) {
-                other.env.forEach((k,v) -> getEnvironment().put(k, replace(vars, v)));
+                other.env.forEach((k,v) -> getEnvironment().put(k, v));
             }
 
             if (other.props != null) {
-                other.props.forEach((k,v) -> getProperties().put(k, replace(vars, v)));
+                other.props.forEach((k,v) -> getProperties().put(k, v));
             }
         } else {
             this.args = other.args == null || this.args != null ? this.args : other.args;
@@ -194,13 +329,42 @@ public class RunConfig implements Serializable {
             this.ideaModule = other.ideaModule == null || this.ideaModule != null ? this.ideaModule : other.ideaModule;
 
             if (other.env != null) {
-                other.env.forEach((k,v) -> getEnvironment().putIfAbsent(k, replace(vars, v)));
+                other.env.forEach((k,v) -> getEnvironment().putIfAbsent(k, v));
             }
 
             if (other.props != null) {
-                other.props.forEach((k,v) -> getProperties().putIfAbsent(k, replace(vars, v)));
+                other.props.forEach((k,v) -> getProperties().putIfAbsent(k, v));
+            }
+
+            if (other.sources != null) {
+                getSources().addAll(0, other.sources);
             }
         }
+    }
+    public void merge(@Nonnull List<RunConfig> runs) {
+        runs.stream().distinct().filter(run -> run != this).forEach(run -> merge(run, false));
+    }
+    public void mergeParents() {
+        merge(getParents());
+    }
+    public void mergeChildren() {
+        merge(getChildren());
+    }
+
+    public void setTokens(Map<String, String> tokens) {
+        this.tokens = tokens;
+    }
+    private Map<String, String> getTokens() {
+        if (tokens == null) {
+            tokens = new HashMap<>();
+        }
+
+        return tokens;
+    }
+
+    private void replaceTokens() {
+        getEnvironment().keySet().forEach(key -> getEnvironment().compute(key, (k, value) -> replace(getTokens(), value)));
+        getProperties().keySet().forEach(key -> getProperties().compute(key, (k, value) -> replace(getTokens(), value)));
     }
 
     private String replace(Map<String, String> vars, String value) {
@@ -216,35 +380,74 @@ public class RunConfig implements Serializable {
         return isTargetClient || MCP_CLIENT_MAIN.equals(getMain()) || MC_CLIENT_MAIN.equals(getMain());
     }
 
-    public static class Container {
-        private Map<String, RunConfig> runs = new HashMap<>();
-
-        // This doesn't work, no idea why... so users must use =
-        public void methodMissing(String name, Object value) {
-            propertyMissing(name, value);
-        }
-
-        public Object propertyMissing(String name) {
-            if (!this.runs.containsKey(name))
-                throw new MissingPropertyException(name);
-            return this.runs.get(name);
-        }
-
-        public void propertyMissing(String name, Object value) {
-            if (!(value instanceof Closure))
-                throw new IllegalArgumentException("Argument must be Closure");
-
-            @SuppressWarnings("unchecked")
-            Closure<? extends RunConfig> closure = (Closure<? extends RunConfig>)value;
-            RunConfig run = new RunConfig();
-            closure.setResolveStrategy(Closure.DELEGATE_FIRST);
-            closure.setDelegate(run);
-            closure.call();
-            this.runs.put(name, run);
-        }
-
-        public Map<String, RunConfig> getRuns() {
-            return runs;
-        }
+    @Nonnull
+    @SuppressWarnings("UnstableApiUsage")
+    public final TaskProvider<JavaExec> createRunTask(@Nonnull final TaskProvider<Task> prepareRuns, @Nonnull final List<String> additionalClientArgs) {
+        return createRunTask(prepareRuns.get(), additionalClientArgs);
     }
+
+    @Nonnull
+    @SuppressWarnings("UnstableApiUsage")
+    public final TaskProvider<JavaExec> createRunTask(@Nonnull final Task prepareRuns, @Nonnull final List<String> additionalClientArgs) {
+        final List<SourceSet> sources = getSources().isEmpty()
+                ? ImmutableList.of(project.getConvention().getPlugin(JavaPluginConvention.class)
+                        .getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME))
+                : getSources();
+
+        getTokens().put("class_roots", sources.stream()
+                .map(source -> source.getOutput().getClassesDirs().getFiles())
+                .flatMap(Collection::stream)
+                .distinct().map(File::getAbsolutePath)
+                .collect(Collectors.joining(File.pathSeparator)));
+
+        getTokens().put("resource_roots", sources.stream()
+                .map(source -> source.getOutput().getResourcesDir())
+                .distinct().map(File::getAbsolutePath)
+                .collect(Collectors.joining(File.pathSeparator)));
+
+        replaceTokens();
+
+        if (isClient()) {
+            jvmArgs(additionalClientArgs);
+        }
+
+        TaskProvider<Task> prepareRun = project.getTasks().register("prepare" + Utils.capitalize(getTaskName()), Task.class, task -> {
+            task.dependsOn(prepareRuns, sources.stream().map(SourceSet::getClassesTaskName).toArray());
+
+            File workDir = new File(getWorkingDirectory());
+
+            if (!workDir.exists()) {
+                workDir.mkdirs();
+            }
+        });
+
+        return project.getTasks().register(getTaskName(), JavaExec.class, task -> {
+            task.dependsOn(prepareRun.get());
+
+            File workDir = new File(getWorkingDirectory());
+
+            if (!workDir.exists()) {
+                workDir.mkdirs();
+            }
+
+            task.setWorkingDir(workDir);
+            task.setMain(getMain());
+
+            task.args(getArgs());
+            task.jvmArgs(getJvmArgs());
+            task.environment(getEnvironment());
+            task.systemProperties(getProperties());
+
+            sources.stream().map(SourceSet::getRuntimeClasspath).forEach(task::classpath);
+
+            // Stop after this run task so it doesn't try to execute the run tasks, and their dependencies, of sub projects
+            task.doLast(t -> System.exit(0)); // TODO: Find better way to stop gracefully
+        });
+    }
+
+    @Override
+    public String toString() {
+        return "RunConfig[project='" + project.getPath() + "', name='" + getName() + "']";
+    }
+
 }

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -35,6 +35,7 @@ import org.apache.commons.io.IOUtils;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
 
+import javax.annotation.Nonnull;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -446,4 +447,10 @@ public class Utils {
         updateHash(target, HashFunction.MD5);
         return target;
     }
+
+    @Nonnull
+    public static final String capitalize(@Nonnull final String toCapitalize) {
+        return toCapitalize.length() > 1 ? toCapitalize.substring(0, 1).toUpperCase() + toCapitalize.substring(1) : toCapitalize;
+    }
+
 }

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
@@ -20,11 +20,14 @@
 
 package net.minecraftforge.gradle.patcher;
 
-import net.minecraftforge.gradle.common.task.ExtractMCPData;
-import net.minecraftforge.gradle.common.task.ExtractNatives;
+import com.google.common.collect.Lists;
 import net.minecraftforge.gradle.common.task.DownloadAssets;
 import net.minecraftforge.gradle.common.task.DownloadMCMeta;
-import net.minecraftforge.gradle.common.util.*;
+import net.minecraftforge.gradle.common.task.ExtractMCPData;
+import net.minecraftforge.gradle.common.task.ExtractNatives;
+import net.minecraftforge.gradle.common.util.BaseRepo;
+import net.minecraftforge.gradle.common.util.MavenArtifactDownloader;
+import net.minecraftforge.gradle.common.util.MinecraftRepo;
 import net.minecraftforge.gradle.mcp.MCPExtension;
 import net.minecraftforge.gradle.mcp.MCPPlugin;
 import net.minecraftforge.gradle.mcp.MCPRepo;
@@ -32,7 +35,7 @@ import net.minecraftforge.gradle.mcp.function.AccessTransformerFunction;
 import net.minecraftforge.gradle.mcp.task.DownloadMCPConfigTask;
 import net.minecraftforge.gradle.mcp.task.SetupMCPTask;
 import net.minecraftforge.gradle.patcher.task.DownloadMCPMappingsTask;
-import net.minecraftforge.gradle.patcher.task.TaskGenerateUserdevConfig;
+import net.minecraftforge.gradle.patcher.task.GenerateBinPatches;
 import net.minecraftforge.gradle.patcher.task.TaskApplyMappings;
 import net.minecraftforge.gradle.patcher.task.TaskApplyPatches;
 import net.minecraftforge.gradle.patcher.task.TaskApplyRangeMap;
@@ -41,13 +44,12 @@ import net.minecraftforge.gradle.patcher.task.TaskCreateSrg;
 import net.minecraftforge.gradle.patcher.task.TaskExtractExistingFiles;
 import net.minecraftforge.gradle.patcher.task.TaskExtractRangeMap;
 import net.minecraftforge.gradle.patcher.task.TaskFilterNewJar;
-import net.minecraftforge.gradle.patcher.task.GenerateBinPatches;
 import net.minecraftforge.gradle.patcher.task.TaskGeneratePatches;
+import net.minecraftforge.gradle.patcher.task.TaskGenerateUserdevConfig;
 import net.minecraftforge.gradle.patcher.task.TaskReobfuscateJar;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.gradle.api.Task;
 import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.SourceSet;
@@ -56,16 +58,9 @@ import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
 import org.gradle.api.tasks.bundling.Zip;
 import org.gradle.api.tasks.compile.JavaCompile;
-import org.gradle.plugins.ide.eclipse.GenerateEclipseClasspath;
-import com.google.common.collect.Lists;
 
 import javax.annotation.Nonnull;
 import java.io.File;
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 public class PatcherPlugin implements Plugin<Project> {
@@ -73,15 +68,15 @@ public class PatcherPlugin implements Plugin<Project> {
 
     @Override
     public void apply(@Nonnull Project project) {
-        final PatcherExtension extension = project.getExtensions().create("patcher", PatcherExtension.class, project);
+        final PatcherExtension extension = project.getExtensions().create(PatcherExtension.class, PatcherExtension.EXTENSION_NAME, PatcherExtension.class, project);
         if (project.getPluginManager().findPlugin("java") == null) {
             project.getPluginManager().apply("java");
         }
-        final JavaPluginConvention javaConv = (JavaPluginConvention)project.getConvention().getPlugins().get("java");
+        final JavaPluginConvention javaConv = (JavaPluginConvention) project.getConvention().getPlugins().get("java");
         final File natives_folder = project.file("build/natives/");
 
-        Jar jarConfig = (Jar)project.getTasks().getByName("jar");
-        JavaCompile javaCompile = (JavaCompile)project.getTasks().getByName("compileJava");
+        Jar jarConfig = (Jar) project.getTasks().getByName("jar");
+        JavaCompile javaCompile = (JavaCompile) project.getTasks().getByName("compileJava");
 
         TaskProvider<DownloadMCPMappingsTask> dlMappingsConfig = project.getTasks().register("downloadMappings", DownloadMCPMappingsTask.class);
         TaskProvider<DownloadMCMeta> dlMCMetaConfig = project.getTasks().register("downloadMCMeta", DownloadMCMeta.class);
@@ -106,7 +101,7 @@ public class PatcherPlugin implements Plugin<Project> {
         TaskProvider<Jar> sourcesJar = project.getTasks().register("sourcesJar", Jar.class);
         TaskProvider<Jar> universalJar = project.getTasks().register("universalJar", Jar.class);
         TaskProvider<Jar> userdevJar = project.getTasks().register("userdevJar", Jar.class);
-        TaskProvider<TaskGenerateUserdevConfig> userdevConfig = project.getTasks().register("userdevConfig", TaskGenerateUserdevConfig.class);
+        TaskProvider<TaskGenerateUserdevConfig> userdevConfig = project.getTasks().register("userdevConfig", TaskGenerateUserdevConfig.class, project);
         TaskProvider<DefaultTask> release = project.getTasks().register("release", DefaultTask.class);
 
         //Add Known repos
@@ -114,9 +109,9 @@ public class PatcherPlugin implements Plugin<Project> {
             e.setUrl("http://files.minecraftforge.net/maven/");
         });
         new BaseRepo.Builder()
-            .add(MCPRepo.create(project))
-            .add(MinecraftRepo.create(project))
-            .attach(project);
+                .add(MCPRepo.create(project))
+                .add(MinecraftRepo.create(project))
+                .attach(project);
         project.getRepositories().maven(e -> {
             e.setUrl("https://libraries.minecraft.net/");
             e.metadataSources(src -> src.artifact());
@@ -252,9 +247,15 @@ public class PatcherPlugin implements Plugin<Project> {
         userdevJar.configure(task -> {
             task.dependsOn(userdevConfig, genJoinedBinPatches, sourcesJar, genConfig);
             task.setOnlyIf(t -> extension.srgPatches);
-            task.from(userdevConfig.get().getOutput(), e -> {e.rename(f -> "config.json"); });
-            task.from(genJoinedBinPatches.get().getOutput(), e -> { e.rename(f -> "joined.lzma"); });
-            task.from(genConfig.get().getPatches(), e -> { e.into("patches/"); });
+            task.from(userdevConfig.get().getOutput(), e -> {
+                e.rename(f -> "config.json");
+            });
+            task.from(genJoinedBinPatches.get().getOutput(), e -> {
+                e.rename(f -> "joined.lzma");
+            });
+            task.from(genConfig.get().getPatches(), e -> {
+                e.into("patches/");
+            });
             task.setClassifier("userdev");
         });
 
@@ -263,8 +264,11 @@ public class PatcherPlugin implements Plugin<Project> {
             SourceSet mainSource = javaConv.getSourceSets().getByName("main");
             applyRangeConfig.get().setSources(mainSource.getJava().getSrcDirs().stream().filter(f -> !f.equals(extension.patchedSrc)).collect(Collectors.toList()));
             applyRangeBaseConfig.get().setSources(extension.patchedSrc);
-            mainSource.java(v -> { v.srcDir(extension.patchedSrc); });
-            mainSource.resources(v -> { }); //TODO: Asset downloading, needs asset index from json.
+            mainSource.java(v -> {
+                v.srcDir(extension.patchedSrc);
+            });
+            mainSource.resources(v -> {
+            }); //TODO: Asset downloading, needs asset index from json.
             javaConv.getSourceSets().stream().forEach(s -> extractRangeConfig.get().addSources(s.getJava().getSrcDirs()));
             extractRangeConfig.get().addDependencies(javaCompile.getClasspath());
 
@@ -274,7 +278,9 @@ public class PatcherPlugin implements Plugin<Project> {
 
             if (extension.patches != null) {
                 sourcesJar.get().dependsOn(genConfig);
-                sourcesJar.get().from(genConfig.get().getPatches(), e -> { e.into("patches/"); } );
+                sourcesJar.get().from(genConfig.get().getPatches(), e -> {
+                    e.into("patches/");
+                });
             }
 
             if (extension.parent != null) { //Most of this is done after evaluate, and checks for nulls to allow the build script to override us. We can't do it in the config step because if someone configs a task in the build script it resolves our config during evaluation.
@@ -283,7 +289,7 @@ public class PatcherPlugin implements Plugin<Project> {
                 PatcherPlugin patcher = extension.parent.getPlugins().findPlugin(PatcherPlugin.class);
 
                 if (mcp != null) {
-                    SetupMCPTask setupMCP = (SetupMCPTask)tasks.getByName("setupMCP");
+                    SetupMCPTask setupMCP = (SetupMCPTask) tasks.getByName("setupMCP");
 
                     if (extension.cleanSrc == null) {
                         extension.cleanSrc = setupMCP.getOutput();
@@ -297,7 +303,7 @@ public class PatcherPlugin implements Plugin<Project> {
                         genConfig.get().setClean(extension.cleanSrc);
                     }
 
-                    File mcpConfig = ((DownloadMCPConfigTask)tasks.getByName("downloadConfig")).getOutput();
+                    File mcpConfig = ((DownloadMCPConfigTask) tasks.getByName("downloadConfig")).getOutput();
 
                     if (createMcp2Srg.get().getSrg() == null) { //TODO: Make extractMCPData macro
                         TaskProvider<ExtractMCPData> ext = project.getTasks().register("extractSrg", ExtractMCPData.class);
@@ -341,7 +347,7 @@ public class PatcherPlugin implements Plugin<Project> {
                     }
 
                     if (extension.cleanSrc == null) {
-                        TaskApplyPatches task = (TaskApplyPatches)tasks.getByName(applyConfig.get().getName());
+                        TaskApplyPatches task = (TaskApplyPatches) tasks.getByName(applyConfig.get().getName());
                         extension.cleanSrc = task.getOutput();
                         applyConfig.get().dependsOn(task);
                         genConfig.get().dependsOn(task);
@@ -354,12 +360,12 @@ public class PatcherPlugin implements Plugin<Project> {
                     }
 
                     if (createMcp2Srg.get().getSrg() == null) {
-                        ExtractMCPData extract = ((ExtractMCPData)tasks.getByName("extractSrg"));
+                        ExtractMCPData extract = ((ExtractMCPData) tasks.getByName("extractSrg"));
                         if (extract != null) {
                             createMcp2Srg.get().setSrg(extract.getOutput());
                             createMcp2Srg.get().dependsOn(extract);
                         } else {
-                            TaskCreateSrg task = (TaskCreateSrg)tasks.getByName(createMcp2Srg.get().getName());
+                            TaskCreateSrg task = (TaskCreateSrg) tasks.getByName(createMcp2Srg.get().getName());
                             createMcp2Srg.get().setSrg(task.getSrg());
                             createMcp2Srg.get().dependsOn(task);
                         }
@@ -371,47 +377,47 @@ public class PatcherPlugin implements Plugin<Project> {
                     }
 
                     if (createExc.get().getSrg() == null) { //TODO: Make a macro for Srg/Static/Constructors
-                        ExtractMCPData extract = ((ExtractMCPData)tasks.getByName("extractSrg"));
+                        ExtractMCPData extract = ((ExtractMCPData) tasks.getByName("extractSrg"));
                         if (extract != null) {
                             createExc.get().setSrg(extract.getOutput());
                             createExc.get().dependsOn(extract);
                         } else {
-                            TaskCreateSrg task = (TaskCreateSrg)tasks.getByName(createExc.get().getName());
+                            TaskCreateSrg task = (TaskCreateSrg) tasks.getByName(createExc.get().getName());
                             createExc.get().setSrg(task.getSrg());
                             createExc.get().dependsOn(task);
                         }
                     }
                     if (createExc.get().getStatics() == null) {
-                        ExtractMCPData extract = ((ExtractMCPData)tasks.getByName("extractStatic"));
+                        ExtractMCPData extract = ((ExtractMCPData) tasks.getByName("extractStatic"));
                         if (extract != null) {
                             createExc.get().setStatics(extract.getOutput());
                             createExc.get().dependsOn(extract);
                         } else {
-                            TaskCreateExc task = (TaskCreateExc)tasks.getByName(createExc.get().getName());
+                            TaskCreateExc task = (TaskCreateExc) tasks.getByName(createExc.get().getName());
                             createExc.get().setStatics(task.getStatics());
                             createExc.get().dependsOn(task);
                         }
                     }
                     if (createExc.get().getConstructors() == null) {
-                        ExtractMCPData extract = ((ExtractMCPData)tasks.getByName("extractConstructors"));
+                        ExtractMCPData extract = ((ExtractMCPData) tasks.getByName("extractConstructors"));
                         if (extract != null) {
                             createExc.get().setConstructors(extract.getOutput());
                             createExc.get().dependsOn(extract);
                         } else {
-                            TaskCreateExc task = (TaskCreateExc)tasks.getByName(createExc.get().getName());
+                            TaskCreateExc task = (TaskCreateExc) tasks.getByName(createExc.get().getName());
                             createExc.get().setConstructors(task.getConstructors());
                             createExc.get().dependsOn(task);
                         }
                     }
                     for (TaskProvider<GenerateBinPatches> task : Lists.newArrayList(genJoinedBinPatches, genClientBinPatches, genServerBinPatches)) {
-                        GenerateBinPatches pgen = (GenerateBinPatches)tasks.getByName(task.get().getName());
+                        GenerateBinPatches pgen = (GenerateBinPatches) tasks.getByName(task.get().getName());
                         for (File patches : pgen.getPatchSets()) {
                             task.get().addPatchSet(patches);
                         }
                     }
 
                     filterNew.get().dependsOn(tasks.getByName("jar"));
-                    filterNew.get().addBlacklist(((Jar)tasks.getByName("jar")).getArchivePath());
+                    filterNew.get().addBlacklist(((Jar) tasks.getByName("jar")).getArchivePath());
                 } else {
                     throw new IllegalStateException("Parent must either be a Patcher or MCP project");
                 }
@@ -428,7 +434,7 @@ public class PatcherPlugin implements Plugin<Project> {
                 if (mcp == null) {
                     throw new IllegalStateException("AccessTransformers specified, with no MCP Parent");
                 }
-                SetupMCPTask setupMCP = (SetupMCPTask)mcp.getTasks().getByName("setupMCP");
+                SetupMCPTask setupMCP = (SetupMCPTask) mcp.getTasks().getByName("setupMCP");
                 setupMCP.addPreDecompile(project.getName() + "AccessTransformer", new AccessTransformerFunction(mcp, extension.getAccessTransformers()));
                 extension.getAccessTransformers().forEach(f -> {
                     userdevJar.get().from(f, e -> e.into("ats/"));
@@ -440,11 +446,11 @@ public class PatcherPlugin implements Plugin<Project> {
             applyRangeBaseConfig.get().setExcFiles(extension.getExcs());
 
             if (!extension.getExtraMappings().isEmpty()) {
-                extension.getExtraMappings().stream().filter(e -> e instanceof File).map(e -> (File)e).forEach(e -> {
+                extension.getExtraMappings().stream().filter(e -> e instanceof File).map(e -> (File) e).forEach(e -> {
                     userdevJar.get().from(e, c -> c.into("srgs/"));
                     userdevConfig.get().addSRG(e);
                 });
-                extension.getExtraMappings().stream().filter(e -> e instanceof String).map(e -> (String)e).forEach(e -> userdevConfig.get().addSRGLine(e));
+                extension.getExtraMappings().stream().filter(e -> e instanceof String).map(e -> (String) e).forEach(e -> userdevConfig.get().addSRGLine(e));
             }
 
             if (userdevConfig.get().getTool() == null) {
@@ -496,9 +502,12 @@ public class PatcherPlugin implements Plugin<Project> {
                 File server = MavenArtifactDownloader.generate(project, "net.minecraft:server:" + mcp_version + ":srg", true);
                 File joined = MavenArtifactDownloader.generate(project, "net.minecraft:joined:" + mcp_version + ":srg", true);
 
-                if (client == null || !client.exists()) throw new RuntimeException("Something horrible happenend, client SRG jar nor found");
-                if (server == null || !server.exists()) throw new RuntimeException("Something horrible happenend, server SRG jar nor found");
-                if (joined == null || !joined.exists()) throw new RuntimeException("Something horrible happenend, joined SRG jar nor found");
+                if (client == null || !client.exists())
+                    throw new RuntimeException("Something horrible happenend, client SRG jar nor found");
+                if (server == null || !server.exists())
+                    throw new RuntimeException("Something horrible happenend, server SRG jar nor found");
+                if (joined == null || !joined.exists())
+                    throw new RuntimeException("Something horrible happenend, joined SRG jar nor found");
 
                 reobfJar.get().dependsOn(createMcp2Srg);
                 reobfJar.get().setSrg(createMcp2Srg.get().getOutput());
@@ -521,11 +530,9 @@ public class PatcherPlugin implements Plugin<Project> {
                 filterNew.get().addBlacklist(joined);
             }
 
-            createRunConfigsTasks(project, extractNatives.get(), downloadAssets.get(), extension.getRuns());
-
             if (project.hasProperty("UPDATE_MAPPINGS")) {
-                String version = (String)project.property("UPDATE_MAPPINGS");
-                String channel = project.hasProperty("UPDATE_MAPPINGS_CHANNEL") ? (String)project.property("UPDATE_MAPPINGS_CHANNEL") : "snapshot";
+                String version = (String) project.property("UPDATE_MAPPINGS");
+                String channel = project.hasProperty("UPDATE_MAPPINGS_CHANNEL") ? (String) project.property("UPDATE_MAPPINGS_CHANNEL") : "snapshot";
 
                 TaskProvider<DownloadMCPMappingsTask> dlMappingsNew = project.getTasks().register("downloadMappingsNew", DownloadMCPMappingsTask.class);
                 dlMappingsNew.get().setMappings("de.oceanlabs.mcp:mcp_" + channel + ":" + version + "@zip");
@@ -547,6 +554,8 @@ public class PatcherPlugin implements Plugin<Project> {
                 TaskProvider<DefaultTask> updateMappings = project.getTasks().register("updateMappings", DefaultTask.class);
                 updateMappings.get().dependsOn(extractMappedNew.get());
             }
+
+            extension.createRunConfigTasks(extractNatives, downloadAssets);
         });
     }
 
@@ -566,31 +575,4 @@ public class PatcherPlugin implements Plugin<Project> {
         return null;
     }
 
-    private void createRunConfigsTasks(@Nonnull Project project, ExtractNatives extractNatives, DownloadAssets downloadAssets, Map<String, RunConfig> runs)
-    {
-        project.getTasks().withType(GenerateEclipseClasspath.class, t -> { t.dependsOn(extractNatives, downloadAssets); });
-        // Utility task to abstract the prerequisites when using the intellij run generation
-        TaskProvider<Task> prepareRun = project.getTasks().register("prepareRun", Task.class);
-        prepareRun.configure(task -> {
-            task.dependsOn(project.getTasks().getByName("classes"), extractNatives, downloadAssets);
-        });
-
-        VersionJson json = null;
-
-        try {
-            json = Utils.loadJson(extractNatives.getMeta(), VersionJson.class);
-        }
-        catch (IOException e) {}
-
-        List<String> additionalClientArgs = json != null ? json.getPlatformJvmArgs() : Collections.emptyList();
-
-        runs.values().forEach(runConfig -> {
-            if (runConfig.isClient()) {
-                runConfig.jvmArgs(additionalClientArgs);
-            }
-        });
-
-        EclipseHacks.doEclipseFixes(project, extractNatives, downloadAssets, runs);
-        IntellijUtils.createIntellijRunsTask(project, extractNatives, downloadAssets, prepareRun.get(), runs);
-    }
 }

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -163,18 +163,24 @@ public class MinecraftUserRepo extends BaseRepo {
             patcher = patcher.getParent();
         }
 
-        if (parent.getConfig().runs != null) {
-            Map<String, String> vars = new HashMap<>();
-            vars.put("assets_root", assets.getAbsolutePath());
-            vars.put("natives", natives.getAbsolutePath());
-            vars.put("mc_version", mcp.getMCVersion());
-            vars.put("mcp_version", mcp.getArtifact().getVersion());
-            vars.put("mcp_mappings", MAPPING);
+        Map<String, String> tokens = new HashMap<>();
+        tokens.put("assets_root", assets.getAbsolutePath());
+        tokens.put("natives", natives.getAbsolutePath());
+        tokens.put("mc_version", mcp.getMCVersion());
+        tokens.put("mcp_version", mcp.getArtifact().getVersion());
+        tokens.put("mcp_mappings", MAPPING);
 
+        if (parent.getConfig().runs != null) {
             parent.getConfig().runs.forEach((name, dev) -> {
-                runs.computeIfAbsent(name, k -> new RunConfig()).merge(dev, false, vars);
+                final RunConfig run = runs.get(name);
+
+                if (run != null) {
+                    run.parent(0, dev);
+                }
             });
         }
+
+        runs.forEach((name, run) -> run.setTokens(tokens));
     }
 
     @SuppressWarnings("unused")

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevExtension.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevExtension.java
@@ -20,63 +20,22 @@
 
 package net.minecraftforge.gradle.userdev;
 
+import net.minecraftforge.gradle.common.util.MinecraftExtension;
 import org.gradle.api.Project;
 
-import groovy.lang.Closure;
-import net.minecraftforge.gradle.common.util.RunConfig;
+import javax.annotation.Nonnull;
 
-import javax.inject.Inject;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+public class UserDevExtension extends MinecraftExtension {
 
-public class UserDevExtension {
-    private String mappings;
-    private List<File> accessTransformers = new ArrayList<>();
-    private RunConfig.Container runs = new RunConfig.Container();
+    public static final String EXTENSION_NAME = "minecraft";
 
-    @Inject
-    public UserDevExtension(Project project) {
+    public UserDevExtension(@Nonnull final Project project) {
+        super(project);
     }
 
-
-    // mappings channel: 'snapshot', version: '20180101'
-    public void mappings(Map<String, String> map) {
-        String channel = map.get("channel");
-        String version = map.get("version");
-        if (channel == null || version == null) {
-            throw new IllegalArgumentException("Must specify mappings channel and version");
-        }
-        setMappings(channel + '_' + version);
-    }
-    public void setMappings(String value) {
-        mappings = value;
-    }
-    public String getMappings() {
-        return mappings;
+    @Override
+    public void mappings(@Nonnull String channel, @Nonnull String version) {
+        setMappings(channel + "_" + version);
     }
 
-    public void accessTransformer(File file) {
-        this.setAccessTransformer(file);
-    }
-    public void setAccessTransformer(File file) {
-        this.accessTransformers.add(file);
-    }
-    public void setAccessTransformers(List<File> files) {
-         this.accessTransformers.clear();
-         this.accessTransformers.addAll(files);
-    }
-    public List<File> getAccessTransformers() {
-        return accessTransformers;
-    }
-
-    public void runs(Closure<? super RunConfig.Container> value) {
-        value.setResolveStrategy(Closure.DELEGATE_FIRST);
-        value.setDelegate(runs);
-        value.call();
-    }
-    public Map<String, RunConfig> getRuns() {
-        return this.runs.getRuns();
-    }
 }

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -20,7 +20,22 @@
 
 package net.minecraftforge.gradle.userdev;
 
-import net.minecraftforge.gradle.common.util.*;
+import net.minecraftforge.gradle.common.task.DownloadAssets;
+import net.minecraftforge.gradle.common.task.DownloadMCMeta;
+import net.minecraftforge.gradle.common.task.DownloadMavenArtifact;
+import net.minecraftforge.gradle.common.task.ExtractMCPData;
+import net.minecraftforge.gradle.common.task.ExtractNatives;
+import net.minecraftforge.gradle.common.util.BaseRepo;
+import net.minecraftforge.gradle.common.util.EclipseHacks;
+import net.minecraftforge.gradle.common.util.IntellijUtils;
+import net.minecraftforge.gradle.common.util.MinecraftRepo;
+import net.minecraftforge.gradle.common.util.RunConfig;
+import net.minecraftforge.gradle.common.util.Utils;
+import net.minecraftforge.gradle.common.util.VersionJson;
+import net.minecraftforge.gradle.mcp.MCPRepo;
+import net.minecraftforge.gradle.userdev.tasks.GenerateSRG;
+import net.minecraftforge.gradle.userdev.tasks.RenameJarInPlace;
+import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.NamedDomainObjectFactory;
 import org.gradle.api.Plugin;
@@ -35,17 +50,9 @@ import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.JavaExec;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.api.tasks.bundling.Jar;
-
-import net.minecraftforge.gradle.common.task.DownloadAssets;
-import net.minecraftforge.gradle.common.task.DownloadMCMeta;
-import net.minecraftforge.gradle.common.task.DownloadMavenArtifact;
-import net.minecraftforge.gradle.common.task.ExtractMCPData;
-import net.minecraftforge.gradle.common.task.ExtractNatives;
-import net.minecraftforge.gradle.mcp.MCPRepo;
-import net.minecraftforge.gradle.userdev.tasks.GenerateSRG;
-import net.minecraftforge.gradle.userdev.tasks.RenameJarInPlace;
 import org.gradle.plugins.ide.eclipse.GenerateEclipseClasspath;
 
+import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -53,8 +60,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-
-import javax.annotation.Nonnull;
 
 public class UserDevPlugin implements Plugin<Project> {
     private static String MINECRAFT = "minecraft";
@@ -64,7 +69,8 @@ public class UserDevPlugin implements Plugin<Project> {
     public void apply(@Nonnull Project project) {
         @SuppressWarnings("unused")
         final Logger logger = project.getLogger();
-        final UserDevExtension extension = project.getExtensions().create("minecraft", UserDevExtension.class, project);
+        final UserDevExtension extension = project.getExtensions().create(UserDevExtension.class, UserDevExtension.EXTENSION_NAME, UserDevExtension.class, project);
+
         if (project.getPluginManager().findPlugin("java") == null) {
             project.getPluginManager().apply("java");
         }
@@ -186,7 +192,7 @@ public class UserDevPlugin implements Plugin<Project> {
             project.getRepositories().mavenCentral(); //Needed for MCP Deps
             if (mcrepo == null)
                 throw new IllegalStateException("Missing 'minecraft' dependency entry.");
-            mcrepo.validate(minecraft, extension.getRuns(), extractNatives.get().getOutput(), downloadAssets.get().getOutput()); //This will set the MC_VERSION property.
+            mcrepo.validate(minecraft, extension.getRuns().getAsMap(), extractNatives.get().getOutput(), downloadAssets.get().getOutput()); //This will set the MC_VERSION property.
 
             String mcVer = (String)project.getExtensions().getExtraProperties().get("MC_VERSION");
             String mcpVer = (String)project.getExtensions().getExtraProperties().get("MCP_VERSION");
@@ -197,58 +203,8 @@ public class UserDevPlugin implements Plugin<Project> {
             reobfJar.dependsOn(createMcpToSrg);
             reobfJar.setMappings(createMcpToSrg.get().getOutput());
 
-            createRunConfigsTasks(project, extractNatives.get(), downloadAssets.get(), extension.getRuns());
+            extension.createRunConfigTasks(extractNatives, downloadAssets);
         });
     }
 
-    private void createRunConfigsTasks(@Nonnull Project project, ExtractNatives extractNatives, DownloadAssets downloadAssets, Map<String, RunConfig> runs)
-    {
-        project.getTasks().withType(GenerateEclipseClasspath.class, t -> { t.dependsOn(extractNatives, downloadAssets); });
-        // Utility task to abstract the prerequisites when using the intellij run generation
-        TaskProvider<Task> prepareRun = project.getTasks().register("prepareRun", Task.class);
-        prepareRun.configure(task -> {
-            task.dependsOn(project.getTasks().getByName("classes"), extractNatives, downloadAssets);
-        });
-
-        VersionJson json = null;
-
-        try {
-            json = Utils.loadJson(extractNatives.getMeta(), VersionJson.class);
-        }
-        catch (IOException e) {}
-
-        List<String> additionalClientArgs = json != null ? json.getPlatformJvmArgs() : Collections.emptyList();
-
-        runs.forEach((name, runConfig) -> {
-            if (runConfig.isClient())
-                runConfig.jvmArgs(additionalClientArgs);
-
-            String taskName = name.replaceAll("[^a-zA-Z0-9\\-_]","");
-            if (!taskName.startsWith("run"))
-                taskName = "run" + taskName.substring(0,1).toUpperCase() + taskName.substring(1);
-            TaskProvider<JavaExec> runTask = project.getTasks().register(taskName, JavaExec.class);
-            runTask.configure(task -> {
-                task.dependsOn(prepareRun.get());
-
-                task.setMain(runConfig.getMain());
-                task.setArgs(runConfig.getArgs());
-                task.systemProperties(runConfig.getProperties());
-                task.environment(runConfig.getEnvironment());
-                task.jvmArgs(runConfig.getJvmArgs());
-
-                String workDir = runConfig.getWorkingDirectory();
-                File file = new File(workDir);
-                if(!file.exists())
-                    file.mkdirs();
-
-                task.setWorkingDir(workDir);
-
-                JavaPluginConvention java = (JavaPluginConvention)project.getConvention().getPlugins().get("java");
-                task.setClasspath(java.getSourceSets().getByName("main").getRuntimeClasspath());
-            });
-        });
-
-        EclipseHacks.doEclipseFixes(project, extractNatives, downloadAssets, runs);
-        IntellijUtils.createIntellijRunsTask(project, extractNatives, downloadAssets, prepareRun.get(), runs);
-    }
 }


### PR DESCRIPTION
This is the refactored section I am using in my _**build.gradle**_:

```groovy
runs {
    client {
        ideaModule "${group}.${name}.main"
        workingDirectory project.file('run').canonicalPath

        source sourceSets.api
        source sourceSets.main
    }

    testClient {
        ideaModule "${group}.${name}.test"
        workingDirectory project.file('run').canonicalPath

        source sourceSets.api
        source sourceSets.main
        source sourceSets.test

        merge 'client'
    }

    server {
        ideaModule "${group}.${name}.main"
        workingDirectory project.file('run').canonicalPath

        source sourceSets.api
        source sourceSets.main
    }

    testServer {
        ideaModule "${group}.${name}.test"
        workingDirectory project.file('run').canonicalPath

        source sourceSets.api
        source sourceSets.main
        source sourceSets.test

        merge 'server'
    }
}
```

It removes the need to use `client = {` and also allows the ability of creating custom RunConfigs that merge from its parent's