### PR TITLE
Improving configuration management for Minecraft and Deobfuscated mods

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -34,6 +34,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
+import org.gradle.internal.impldep.org.apache.commons.lang.text.StrBuilder;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -446,4 +447,16 @@ public class Utils {
         updateHash(target, HashFunction.MD5);
         return target;
     }
+
+    /**
+     * Uncapitalizes a string.
+     * Required due to both StringUtils classes not being on the classpath in certain gradle constructions.
+     *
+     * @param str The string.
+     * @return A uncapitalized version: CAT -> cAT, cat -> cat, Cat -> cat.
+     */
+    public static String uncapitalizeString(String str) {
+        return str != null && str.length() != 0 ? Character.toLowerCase(str.charAt(0)) + str.substring(1) : str;
+    }
+
 }

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -34,7 +34,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository;
-import org.gradle.internal.impldep.org.apache.commons.lang.text.StrBuilder;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -126,6 +126,11 @@ public class MinecraftUserRepo extends BaseRepo {
         );
     }
 
+    public Project getProject()
+    {
+        return project;
+    }
+
     @Override
     protected File getCacheRoot() {
         if (this.AT_HASH == null)
@@ -133,7 +138,7 @@ public class MinecraftUserRepo extends BaseRepo {
         return project.file("build/fg_cache/");
     }
 
-    public void validate(Configuration cfg, Map<String, RunConfig> runs, File natives, File assets) {
+    public void validate(List<Configuration> cfg, Map<String, RunConfig> runs, File natives, File assets) {
         getParents();
         if (mcp == null)
             throw new IllegalStateException("Invalid minecraft dependency: " + GROUP + ":" + NAME + ":" + VERSION);
@@ -158,7 +163,7 @@ public class MinecraftUserRepo extends BaseRepo {
                 if (CHANGING_USERDEV) {
                     _dep.setChanging(true);
                 }
-                cfg.getDependencies().add(_dep);
+                cfg.forEach(minecraft -> minecraft.getDependencies().add(_dep));
             });
             patcher = patcher.getParent();
         }

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -387,7 +387,11 @@ public class UserDevPlugin implements Plugin<Project> {
     private ExternalModuleDependency generateDeobfuscatedMinecraftDependency(MinecraftUserRepo repo, Logger logger)
     {
         final String minecraftDeobfuscatedDependencyString = repo.getDependencyString();
-        logger.info(String.format("Creating new deobfuscated minecraft dependency: %s", minecraftDeobfuscatedDependencyString));
+
+        //Log to the logger which MC has been selected for debugging purposes.
+        //Required by lex to see which version is being loaded.
+        logger.lifecycle(String.format("Creating new deobfuscated minecraft dependency: %s", minecraftDeobfuscatedDependencyString));
+
         return (ExternalModuleDependency) repo.getProject().getDependencies().create(minecraftDeobfuscatedDependencyString);
     }
 }

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -62,7 +62,6 @@ public class UserDevPlugin implements Plugin<Project> {
     public void apply(@Nonnull Project project) {
         @SuppressWarnings("unused")
         final Logger logger = project.getLogger();
-        logger.warn("Applying ForgeGradle.");
         final UserDevExtension extension = project.getExtensions().create("minecraft", UserDevExtension.class, project);
         if (project.getPluginManager().findPlugin("java") == null) {
             project.getPluginManager().apply("java");
@@ -139,8 +138,6 @@ public class UserDevPlugin implements Plugin<Project> {
                                                               .collect(Collectors.toList());
 
             final List<Configuration> validMinecraftConfigurations = this.validateMinecraftDependencies(minecraftConfigurations, p.getLogger());
-
-            logger.warn("Found: " + validMinecraftConfigurations.stream().map(Object::toString).collect(Collectors.joining(", ")) + " as configuration containing minecraft.");
 
             final MinecraftUserRepo mcrepo = generateMinecraftUserRepo(p, extension, validMinecraftConfigurations);
             final ExternalModuleDependency deobfuscatedMinecraftDependency = generateDeobfuscatedMinecraftDependency(mcrepo, logger);
@@ -316,7 +313,6 @@ public class UserDevPlugin implements Plugin<Project> {
             //This configuration (and with that its sourceSet) does not depend on minecraft skip it.
             if (information.isEmpty())
             {
-                logger.warn("Skipping configuration: " + configuration.getName() + " no minecraft dependency information has been found.");
                 continue;
             }
 
@@ -331,7 +327,6 @@ public class UserDevPlugin implements Plugin<Project> {
                   validInformation));
             }
 
-            logger.warn("Adding configuration: " + configuration.getName() + " as a configuration containing a dependency on minecraft with information: " + information);
             validConfigurations.add(configuration);
         }
 


### PR DESCRIPTION
### Reason for making PR:
It is not possible to add a deobfuscated Minecraft (or a deobfscated Mod for that matter) to a sourceSet that does not inherit from the main sourceSet.
This is caused by the `UserDevPlugin` that only creates a single `minecraft`-and `deobf`-configuration, from both of whom the `compile`-configuration extends, causing only the `main`-sourceset (and all its depends, like the `test`-sourceset) from being able to access Forge and Minecraft classes.

Following the Java convention for API's under gradle, an API should be put in a SourceSet named `api`, from which the `compile` configuration (and thus the main sourceset) needs to extend. Due to this api sourceset now being on a lower level then the main sourceset (and its minecraft configurations) the API sourceset is not able to access Minecraft or Forge classes, even though that is in most cases required. _An example would be an interface declaring some kind of object that would need to be registered to a ForgeRegistry, other simple examples come to mind easily._

### Implemented fix:
The solution is to follow the JavaPlugin convention scheme of creating configurations.
This PR will create two configuration named as such: _<sourceSetTaskName>Minecraft or minecraft (for the main sourceset) as well as <sourceSetTaskName>Deobf or deobf (for the main sourceset)_ for each sourceSet that is added to the `sourceSets {}` section of the build.gradle.

#### Required adaptations of the normal logic, to stay within the guidelines, of one MC version per Project.
When the project is now in its `afterEvaluate` phase and the relevant callback is made, we now need to check if a person added atleast one entry to any of the `minecraftXXXX` configurations, if all the configurations, that contain a minecraft dependency, contain exactly one entry, and that all the configurations that contain exactly one entry, contain all the same entries.

### Why not make all compileXXX configurations extends minecraft?
Cause this is not up to FG3 to decide, certain sourceset configuration might not need Minecraft, so it should not be added to its dependency list.

### Example:
This can now be used as follows:
``` groovy
dependencies {
    minecraft 'net.minecraftforge.test:forge:1.13-24.0.86-1.13-pre'
    apiMinecraft 'net.minecraftforge.test:forge:1.13-24.0.86-1.13-pre'
}
```

Also tested this with multiproject builds, and those seem to load as well, after a couple of runs of `gradle eclipse --no-daemon --refresh-dependencies`.