### PR TITLE
Fix NPE when depending on a non-patched Minecraft

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -40,6 +40,7 @@ import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
+import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.tasks.compile.JavaCompile;
 
 import com.amadornes.artifactural.api.artifact.ArtifactIdentifier;
@@ -163,7 +164,7 @@ public class MinecraftUserRepo extends BaseRepo {
             patcher = patcher.getParent();
         }
 
-        if (parent.getConfig().runs != null) {
+        if (parent != null && parent.getConfig().runs != null) { // There might be no patchers to parent, so it may only be a vanilla mcp dependency
             Map<String, String> vars = new HashMap<>();
             vars.put("assets_root", assets.getAbsolutePath());
             vars.put("natives", natives.getAbsolutePath());
@@ -959,8 +960,16 @@ public class MinecraftUserRepo extends BaseRepo {
             for (File ext : extraDeps)
                 files.add(ext);
             compile.setClasspath(project.files(files));
-            compile.setSourceCompatibility(parent.getConfig().getSourceCompatibility());
-            compile.setTargetCompatibility(parent.getConfig().getTargetCompatibility());
+            if (parent != null) {
+                compile.setSourceCompatibility(parent.getConfig().getSourceCompatibility());
+                compile.setTargetCompatibility(parent.getConfig().getTargetCompatibility());
+            } else {
+                final JavaPluginConvention java = project.getConvention().findPlugin(JavaPluginConvention.class);
+                if (java != null) {
+                    compile.setSourceCompatibility(java.getSourceCompatibility().toString());
+                    compile.setTargetCompatibility(java.getTargetCompatibility().toString());
+                }
+            }
             compile.setDestinationDir(output);
             compile.setSource(source.isDirectory() ? project.fileTree(source) : project.zipTree(source));
 


### PR DESCRIPTION
If one were to try the following as a dependency:
```
minecraft 'net.minecraft:server:1.13'
```

a very nice NPE will crop up during build script setup in Gradle.

This fixes that NPE, and the side effects of the parent being null at this point, would only result in depending on a dependency that does not have a `Patcher` requirement. I've tested this locally in three cases: `client`, `server`, and `joined` as artifact names, and all will provide the correct set up dependencies on dependency resolution as intended. This does not affect forge user dev environments since using Forge as a dependency will result in a patcher being detected and run configurations being added on to.