### PR TITLE
Move the AT process for dependencies to before source injection

### DIFF
--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/ExecuteFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/ExecuteFunction.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ExecutionException;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -115,8 +116,8 @@ public class ExecuteFunction implements MCPFunction {
         String mainClass = jarFile.getManifest().getMainAttributes().getValue(Attributes.Name.MAIN_CLASS);
         jarFile.close();
 
-        // Execute command
-        JavaExec java = environment.project.getTasks().create("_", JavaExec.class);
+        // Execute command // We have to randomize the task name in the event another instance is being used
+        JavaExec java = environment.project.getTasks().create("_" + new Random().nextInt(1237) * 51, JavaExec.class);
         java.setJvmArgs(jvmArgList);
         java.setArgs(runArgList);
         java.setClasspath(environment.project.files(jar));


### PR DESCRIPTION
Previously, an AT could be declared, and the dependency would be
properly AT'ed, but only after sources were injected, remapped, and
patched and recompiled. This caused two problems:
- IDE's won't attach sources of the dependency because the sources are
  not matching access to the binary dependency.
- No verification of whether the ATs will cause errors at runtime due
  to access errors or verification errors (classes extending and
  overriding with weaker access).

Also fix a potential corner case where duplicate tasks may be created
by Gradle being silly.

This has been tested with both forge as a dependency with new AT's being added, and with vanilla as a dependency. Some advantages of the AT process occurring before source creation and recompilation is that the compiler errors will be clearly shown in gradle task logs on IDE import or just Gradle dependency resolution during builds, saving time in the future having to potentially back track the offending AT that would otherwise show up in runtime tests.