### PR TITLE
Fix depedency resolution issues, take 3

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -113,6 +113,7 @@ public class MinecraftUserRepo extends BaseRepo {
     private MCP mcp;
     @SuppressWarnings("unused")
     private Repository repo;
+    private Set<File> extraDataFiles;
 
     /* TODO:
      * Steps to produce each dep:
@@ -206,6 +207,64 @@ public class MinecraftUserRepo extends BaseRepo {
                 runs.computeIfAbsent(name, k -> new RunConfig()).merge(dev, false, vars);
             });
         }
+        this.extraDataFiles = this.buildExtraDataFiles();
+    }
+
+    /**
+     * Previously, Configuration.resolve() was called indirectly from
+     * BaseRepo.getArtifact(). Due to the extensive amount of Gradle code that
+     * runs as a result of the resolve() call, deadlock could occur as follows:
+     *
+     * 1. Thread #1: During resolution of a dependency, Gradle calls
+     * BaseRepo#getArtifact(). The 'synchronized' block is entering,
+     * causing a lock to be taken on the artifact name
+     *
+     * 2. Thread #2: On a different thread, internal Gradle code takes a lock
+     * in the class org.gradle.internal.event.DefaultListenerManager.EventBroadcast.ListenerDispatch
+     *
+     * 3. Thread #1: Execution continues on the 'BaseRepo#getArtifact()' call
+     * stack, reaching the call to Configuration.resolve(). This call leads
+     * to Gradle internally dispatching events through the same class
+     * org.gradle.internal.event.DefaultListenerManager.EventBroadcast.ListenerDispatch.
+     * This thread is now blocked on the internal Gradle lock taken by Thread #2
+     *
+     * 4. Thread #2: Execution continues, and attempts to resolve the same
+     * dependency that Thread #1 is currently resolving. Since Thread #1 is
+     * still in the 'synchronized' block with the same artifact name, Thread #2
+     * blocks.
+     *
+     * These threads are now deadlocked: Thread #1 is holding the
+     * BaseRepo#getArtifact lock while waiting on an internal Gradle lock,
+     * while Thread #2 is holding the same internal Gradle lock while waiting
+     * on the BaseRepo#getArtifact lock.
+     *
+     * Visit https://git.io/fhHLk to see a stack dump showing this deadlock
+     *
+     * Fortunately, the solution is fairly simply. We can move the entire
+     * dependency creation/resolution block to an earlier point in
+     * ForgeGradle's execution. Since the client 'data'/'extra'/libraries only
+     * depend on the MCP config file, we can do this during plugin
+     * initialization.
+     *
+     * This has the added benefit of speeding up ForgeGradle - this block of
+     * code will only be executed once, instead of during every call to
+     * compileJava
+     * @return
+     */
+    private Set<File> buildExtraDataFiles() {
+        Configuration cfg = project.getConfigurations().create(getNextCompileName());
+        List<String> deps = new ArrayList<>();
+        deps.add("net.minecraft:client:" + mcp.getMCVersion() + ":extra");
+        deps.add("net.minecraft:client:" + mcp.getMCVersion() + ":data");
+        deps.addAll(mcp.getLibraries());
+        Patcher patcher = parent;
+        while (patcher != null) {
+            deps.addAll(patcher.getLibraries());
+            patcher = patcher.getParent();
+        }
+        deps.forEach(dep -> cfg.getDependencies().add(project.getDependencies().create(dep)));
+        Set<File> files = cfg.resolve();
+        return files;
     }
 
     @SuppressWarnings("unused")
@@ -980,9 +1039,13 @@ public class MinecraftUserRepo extends BaseRepo {
         return target;
     }
 
+    private String getNextCompileName() {
+        return "_compileJava_" + compileTaskCount++;
+    }
+
     private int compileTaskCount = 1;
     private File compileJava(File source, File... extraDeps) {
-        JavaCompile compile = project.getTasks().create("_compileJava_" + compileTaskCount++, JavaCompile.class);
+        JavaCompile compile = project.getTasks().create(getNextCompileName(), JavaCompile.class);
         try {
             File output = project.file("build/" + compile.getName() + "/");
             if (output.exists()) {
@@ -992,18 +1055,7 @@ public class MinecraftUserRepo extends BaseRepo {
                 // we need to ensure that the output directory already exists
                 output.mkdirs();
             }
-            Configuration cfg = project.getConfigurations().create(compile.getName());
-            List<String> deps = new ArrayList<>();
-            deps.add("net.minecraft:client:" + mcp.getMCVersion() + ":extra");
-            deps.add("net.minecraft:client:" + mcp.getMCVersion() + ":data");
-            deps.addAll(mcp.getLibraries());
-            Patcher patcher = parent;
-            while (patcher != null) {
-                deps.addAll(patcher.getLibraries());
-                patcher = patcher.getParent();
-            }
-            deps.forEach(dep -> cfg.getDependencies().add(project.getDependencies().create(dep)));
-            Set<File> files = cfg.resolve();
+            Set<File> files = Sets.newHashSet(this.extraDataFiles);
             for (File ext : extraDeps)
                 files.add(ext);
             compile.setClasspath(project.files(files));

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -531,6 +531,18 @@ public class MinecraftUserRepo extends BaseRepo {
                 while ((entry = zin.getNextEntry()) != null) {
                     if (!entry.getName().startsWith(prefix) || entry.isDirectory())
                         continue;
+
+                    // If an entry has a specific side in its name, don't apply
+                    // it when we're on the opposite side. Entries without a specific
+                    // side should always be applied
+                    if ("server".equals(NAME) && entry.getName().contains("/client/")) {
+                        continue;
+                    }
+
+                    if ("client".equals(NAME) && entry.getName().contains("/server/")) {
+                        continue;
+                    }
+
                     String name = entry.getName().substring(prefix.length());
                     if ("package-info-template.java".equals(name)) {
                         template = new String(IOUtils.toByteArray(zin), StandardCharsets.UTF_8);

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/HackyJavaCompile.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/HackyJavaCompile.java
@@ -1,0 +1,78 @@
+/*
+ * ForgeGradle
+ * Copyright (C) 2018 Forge Development LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+package net.minecraftforge.gradle.userdev.tasks;
+
+import com.google.common.collect.Sets;
+import org.gradle.api.internal.OverlappingOutputs;
+import org.gradle.api.internal.TaskExecutionHistory;
+import org.gradle.api.internal.tasks.OriginTaskExecutionMetadata;
+import org.gradle.api.tasks.compile.JavaCompile;
+
+import java.io.File;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
+// A terrible hack to use JavaCompile while bypassing
+// Gradle's normal task infrastructure.
+public class HackyJavaCompile extends JavaCompile {
+
+    public void doHackyCompile() {
+
+        // What follows is a horrible hack to allow us to call JavaCompile
+        // from our dependency resolver.
+        // As described in https://github.com/MinecraftForge/ForgeGradle/issues/550,
+        // invoking Gradle tasks in the normal way can lead to deadlocks
+        // when done from a dependency resolver.
+
+        // To avoid these issues, we invoke the 'compile' method on JavaCompile
+        // using reflection.
+
+        // Normally, the output history is set by Gradle. Since we're bypassing
+        // the normal gradle task infrastructure, we need to do it ourselves.
+        this.getOutputs().setHistory(new TaskExecutionHistory() {
+
+            @Override
+            public Set<File> getOutputFiles() {
+                // We explicitly clear the output directory
+                // ourselves, so it's okay that this is totally wrong.
+                return Sets.newHashSet();
+            }
+
+            @Nullable
+            @Override
+            public OverlappingOutputs getOverlappingOutputs() {
+                return null;
+            }
+
+            @Nullable
+            @Override
+            public OriginTaskExecutionMetadata getOriginExecutionMetadata() {
+                return null;
+            }
+        });
+
+        // Do the actual compilation,
+        // bypassing a bunch of Gradle's other stuff (e.g. internal event listener mechanism)
+        this.compile();
+    }
+
+}


### PR DESCRIPTION
This PR fixes the deadlock issue in https://github.com/MinecraftForge/ForgeGradle/issues/550.

I've also fixed an issue with client-only injections - the previous fix didn't apply to MinecraftUserRepo