### PR TITLE
Replacing the raw main jar with the recompiled jar, when sources are requested.

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -961,6 +961,9 @@ public class MinecraftUserRepo extends BaseRepo {
 
             Utils.updateHash(sources, HashFunction.SHA1);
             cache.save();
+
+            //TODO: insert findRecomp(names, true)
+            //TODO: replace raw with recomp
         }
         return sources.exists() ? sources : null;
     }


### PR DESCRIPTION
The sources jar is generated from the recompiled jar instead of the raw jar.
This causes discrepancies when an IDE then tries to find the sources of certain classes with in that sources-main jar combination.

To fix these discrepancies the main raw jar is replaced with the recompiled jar, this way the sources jar, which is generated from the recompile jar is in sync.

Several precautions have been taken to prevent problems in a threaded environment:
A external FileLock is created to prevent other programs from modifying the File externally. And an in repo lock object is created to prevent the repo from writing to that jar in a multi threaded in jvm scenario.

I ran this solution for a couple of hours continuously creating and recreating, both sources and jars to figure out if this is causing any issues, so far none have surfaced, however i am still not sure if this is enough, and input on the solution used to replace the jars is highly welcome.