### PR TITLE
[FG_3.0] Various fixes/changes to run configs

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
@@ -529,7 +529,7 @@ public class RunConfig extends GroovyObjectSupport implements Serializable {
         return isTargetClient || MCP_CLIENT_MAIN.equals(getMain()) || MC_CLIENT_MAIN.equals(getMain());
     }
 
-    private List<SourceSet> getAllSources() {
+    public List<SourceSet> getAllSources() {
         List<SourceSet> sources = getSources();
 
         getMods().stream().map(ModConfig::getSources).flatMap(Collection::stream).forEach(sources::add);


### PR DESCRIPTION
**Eclipse**:
- Now outputs **.launch** configuration files to the relative project's directory instead of the root project
- Defaults to use sources set in run configuration if no mods are set
- No longer replaces empty **MOD_CLASSES** environment variable when generating runs

<br />

**Misc**:
- Allows for multiple resource directories per mod