### PR TITLE
Resolve maven deps without trailing slash and support https redirects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,6 +85,7 @@ dependencies {
     commonImplementation 'net.minecraftforge:artifactural:1.0.+'
     commonImplementation 'org.ow2.asm:asm-commons:6.2.1' //TODO: Remove and make standalone external tools?
     commonImplementation 'org.apache.maven:maven-artifact:3.6.0'
+    commonImplementation 'org.apache.httpcomponents:httpclient:4.3.3'
 
     mcpImplementation sourceSets.common.output
     patcherImplementation sourceSets.mcp.output

--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
@@ -47,7 +47,7 @@ public class DownloadAssets extends DefaultTask {
         Collections.sort(keys);
         for (String key : keys) {
             Asset asset = index.objects.get(key);
-            File target = Utils.getCache(getProject(), "assets/objects/", asset.getPath());
+            File target = Utils.getCache(getProject(), "assets", "objects", asset.getPath());
             if (!target.exists()) {
                 URL url = new URL(RESOURCE_REPO + asset.getPath());
                 getProject().getLogger().lifecycle("Downloading: " + url + " Asset: " + key);
@@ -58,7 +58,7 @@ public class DownloadAssets extends DefaultTask {
 
     private File getIndex() throws IOException {
         VersionJson json = Utils.loadJson(getMeta(), VersionJson.class);
-        File target = Utils.getCache(getProject(), "assets/indexes/" + json.assetIndex.id + ".json");
+        File target = Utils.getCache(getProject(), "assets" , "indexes", json.assetIndex.id + ".json");
         return Utils.updateDownload(getProject(), target, json.assetIndex);
     }
 
@@ -71,7 +71,7 @@ public class DownloadAssets extends DefaultTask {
     }
 
     public File getOutput() {
-        return Utils.getCache(getProject(), "assets/");
+        return Utils.getCache(getProject(), "assets");
     }
 
     private static class AssetIndex {


### PR DESCRIPTION
Fixes #571

This adds `org.apache.httpcomponents:httpclient` as a dependency. 
This version is the one used by Minecraft, and Gradle uses it internally.

Tested with JEI and Hwyla as dependencies, using the "wrong" maven (http, no trailing slash), and then again with the right maven.