### PR TITLE
Fixing Task iteration in an InitScript.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ def gitVersion() {
     def raw = grgit.describe(longDescr: true, tags: true)
     def desc = (raw == null ? 'unknown-unknown-unknown' : raw).split('-') as List
     def hash = desc.remove(desc.size() - 1)
-    def offset = desc.remove(desc.size() - 1) + "00"
+    def offset = desc.remove(desc.size() - 1)
     def tag = desc.join('-')
     def branch = grgit.branch.current().name    
     return "${tag}.${offset}" //${t -> if (branch != 'master') t << '-' + branch}"

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ def gitVersion() {
     def raw = grgit.describe(longDescr: true, tags: true)
     def desc = (raw == null ? 'unknown-unknown-unknown' : raw).split('-') as List
     def hash = desc.remove(desc.size() - 1)
-    def offset = desc.remove(desc.size() - 1)
+    def offset = desc.remove(desc.size() - 1) + "00"
     def tag = desc.join('-')
     def branch = grgit.branch.current().name    
     return "${tag}.${offset}" //${t -> if (branch != 'master') t << '-' + branch}"

--- a/src/common/java/net/minecraftforge/gradle/common/task/ExtractMCPData.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/ExtractMCPData.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.util.function.Supplier;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 
@@ -45,6 +46,7 @@ public class ExtractMCPData extends DefaultTask {
     private static final Gson GSON = new GsonBuilder().create();
 
     private String key = "mappings";
+    private Supplier<File> configSupplier;
     private File config;
     private File output = getProject().file("build/" + getName() + "/output.srg");
 
@@ -81,10 +83,19 @@ public class ExtractMCPData extends DefaultTask {
 
     @InputFile
     public File getConfig() {
+        if (config == null && configSupplier != null)
+            config = configSupplier.get();
+
         return config;
     }
     public void setConfig(File value) {
         this.config = value;
+        this.configSupplier = null;
+    }
+    public void setConfig(Supplier<File> valueSupplier)
+    {
+        this.configSupplier = valueSupplier;
+        this.config = null;
     }
 
     @Input

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -130,7 +130,7 @@ public class UserDevPlugin implements Plugin<Project> {
 
         extractSrg.configure(task -> {
             task.dependsOn(downloadMcpConfig);
-            task.setConfig(downloadMcpConfig.get().getOutput());
+            task.setConfig(() -> downloadMcpConfig.get().getOutput());
         });
 
         createMcpToSrg.configure(task -> {


### PR DESCRIPTION
Hello,

This PR fixes a problem that occurs when an InitScript loops over the tasks and causes them to be realised before ForgeGradles afterEvaluate has been called.

This particular problem happens when a ProjectEvaluationListener is registered by an InitScript (like by the buildsystem TeamCity, which does this to listen to Test results) whos afterEvaluate method loops over all tasks in a project causing the extractSrg task to be realised, before FG3s afterEvaluate is triggered (since it is registered after the ProjectEvaluationListener) , which fails with an NPE, as can be seen here: https://gist.github.com/OrionDevelopment/d468fc30bfaea6f94736017f742367ce .

This problem can be solved in two ways (based on StackOverflow searches and Gradle Forum, visits and questions):
The first one is by using a callback, and lazily set the value. This is the solution that was used in this PR. It is not the most elegant solution IMO, but since it is only required in one task, it was what I opted for here.

The other solution would be to use a set of additional tasks to configure the tasks that are actually executed, by registering them properly and setting their AST configuration the execution order guarantees that our tasks would be configured properly. This would be much more work then was needed to solve my problem, so it was not attempted here. But I wanted to leave this bit of knowledge behind in case somebody else needs it later.

For people interested the actual NPE is caused by the DownloadMavenAritfact task, because its _artifact field is null when the extractSrg task is realised, due to our afterEvaluate block not having triggered yet, when the realisation of the extractSrg task asks the downloadMcpConfig task for its output file to link them together properly.

Hoping for a quick merge,

Orion