### PR TITLE
Add support for VSCode run configs

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/IDEUtils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/IDEUtils.java
@@ -22,6 +22,11 @@ package net.minecraftforge.gradle.common.util;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Triple;
 import org.gradle.api.Project;
@@ -46,6 +51,9 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.Writer;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -60,11 +68,13 @@ public final class IDEUtils {
     public static void createIDEGenRunsTasks(@Nonnull final MinecraftExtension minecraft, @Nonnull final TaskProvider<Task> prepareRuns, @Nonnull final TaskProvider<Task> makeSourceDirs) {
         final Project project = minecraft.getProject();
 
-        final Map<String, Triple<List<Object>, File, RunConfigurationGenerator>> ideConfigurationGenerators = ImmutableMap.<String, Triple<List<Object>, File, RunConfigurationGenerator>>builder()
+        final Map<String, Triple<List<Object>, File, RunConfigurationBuilder>> ideConfigurationGenerators = ImmutableMap.<String, Triple<List<Object>, File, RunConfigurationBuilder>>builder()
                 .put("genIntellijRuns", ImmutableTriple.of(Collections.singletonList(prepareRuns.get()),
-                        new File(project.getRootProject().getRootDir(), ".idea/runConfigurations"), IDEUtils::createIntellijRunConfigurationXML))
+                        new File(project.getRootProject().getRootDir(), ".idea/runConfigurations"), new XMLConfigurationBuilder(IDEUtils::createIntellijRunConfigurationXML)))
                 .put("genEclipseRuns", ImmutableTriple.of(ImmutableList.of(prepareRuns.get(), makeSourceDirs.get()),
-                        project.getProjectDir(), IDEUtils::createEclipseRunConfigurationXML))
+                        project.getProjectDir(), new XMLConfigurationBuilder(IDEUtils::createEclipseRunConfigurationXML)))
+                .put("genVSCodeRuns", ImmutableTriple.of(ImmutableList.of(prepareRuns.get(), makeSourceDirs.get()),
+                        new File(project.getProjectDir(), ".vscode"), new JsonConfigurationBuilder(IDEUtils::createVSCodeRunConfiguration)))
                 .build();
 
         ideConfigurationGenerators.forEach((taskName, configurationGenerator) -> {
@@ -73,40 +83,12 @@ public final class IDEUtils {
                 task.dependsOn(configurationGenerator.getLeft());
 
                 task.doLast(t -> {
-                    try {
-                        final File runConfigurationsDir = configurationGenerator.getMiddle();
+                    final File runConfigurationsDir = configurationGenerator.getMiddle();
 
-                        if (!runConfigurationsDir.exists()) {
-                            runConfigurationsDir.mkdirs();
-                        }
-
-                        final DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
-                        final DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
-                        final TransformerFactory transformerFactory = TransformerFactory.newInstance();
-                        final Transformer transformer = transformerFactory.newTransformer();
-
-                        transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-                        transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
-
-                        minecraft.getRuns().forEach(runConfig -> {
-                            final Stream<String> propStream = runConfig.getProperties().entrySet().stream().map(kv -> String.format("-D%s=%s", kv.getKey(), kv.getValue()));
-                            final String props = Stream.concat(propStream, runConfig.getJvmArgs().stream()).collect(Collectors.joining(" "));
-                            final Map<String, Document> documents = configurationGenerator.getRight().createRunConfigurationXML(project, runConfig, props, docBuilder);
-
-                            documents.forEach((fileName, document) -> {
-                                final DOMSource source = new DOMSource(document);
-                                final StreamResult result = new StreamResult(new File(runConfigurationsDir, fileName));
-
-                                try {
-                                    transformer.transform(source, result);
-                                } catch (TransformerException e) {
-                                    e.printStackTrace();
-                                }
-                            });
-                        });
-                    } catch (ParserConfigurationException | TransformerConfigurationException e) {
-                        e.printStackTrace();
+                    if (!runConfigurationsDir.exists()) {
+                        runConfigurationsDir.mkdirs();
                     }
+                    configurationGenerator.getRight().createConfig(minecraft, runConfigurationsDir, project);
                 });
             });
         });
@@ -231,49 +213,7 @@ public final class IDEUtils {
                 {
                     envs.setAttribute("key", "org.eclipse.debug.core.environmentVariables");
 
-                    runConfig.getEnvironment().compute("MOD_CLASSES", (key, value) -> {
-                        // Only replace environment variable if it is already set
-                        if (value == null || value.isEmpty()) {
-                            return value;
-                        }
-
-                        final EclipseModel eclipse = project.getExtensions().findByType(EclipseModel.class);
-
-                        if (eclipse != null) {
-                            final Map<String, String> outputs = eclipse.getClasspath().resolveDependencies().stream()
-                                    .filter(SourceFolder.class::isInstance)
-                                    .map(SourceFolder.class::cast)
-                                    .map(SourceFolder::getOutput)
-                                    .distinct()
-                                    .collect(Collectors.toMap(output -> output.split("/")[output.split("/").length - 1], output -> project.file(output).getAbsolutePath()));
-
-                            if (runConfig.getMods().isEmpty()) {
-                                return runConfig.getAllSources().stream()
-                                        .map(SourceSet::getName)
-                                        .filter(outputs::containsKey)
-                                        .map(outputs::get)
-                                        .map(s -> String.join(File.pathSeparator, s, s)) // <resources>:<classes>
-                                        .collect(Collectors.joining(File.pathSeparator));
-                            } else {
-                                final SourceSet main = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
-
-                                return runConfig.getMods().stream()
-                                        .map(modConfig -> {
-                                            return (modConfig.getSources().isEmpty() ? Stream.of(main) : modConfig.getSources().stream())
-                                                    .map(SourceSet::getName)
-                                                    .filter(outputs::containsKey)
-                                                    .map(outputs::get)
-                                                    .map(output -> modConfig.getName() + "%%" + output)
-                                                    .map(s -> String.join(File.pathSeparator, s, s)); // <resources>:<classes>
-                                        })
-                                        .flatMap(Function.identity())
-                                        .collect(Collectors.joining(File.pathSeparator));
-                            }
-                        }
-
-                        return value;
-                    });
-
+                    runConfig.getEnvironment().compute("MOD_CLASSES", (key, value) -> mapModClasses(key, value, project, runConfig));
                     runConfig.getEnvironment().forEach((name, value) -> {
                         final Element envEntry = javaDocument.createElement("mapEntry");
                         {
@@ -292,12 +232,168 @@ public final class IDEUtils {
         return documents;
     }
 
+    @Nonnull
+    private static JsonObject createVSCodeRunConfiguration(@Nonnull final Project project, @Nonnull final RunConfig runConfig, @Nonnull final String props) {
+        JsonObject config = new JsonObject();
+        config.addProperty("type", "java");
+        config.addProperty("name", runConfig.getTaskName());
+        config.addProperty("request", "launch");
+        config.addProperty("mainClass", runConfig.getMain());
+        config.addProperty("projectName", project.getName());
+        config.addProperty("cwd", replaceRootDirBy(project, runConfig.getWorkingDirectory().toString(), "${workspaceFolder}"));
+        config.addProperty("vmArgs", props);
+        config.addProperty("args", String.join(" ", runConfig.getArgs()));
+        JsonObject env = new JsonObject();
+        runConfig.getEnvironment().compute("MOD_CLASSES", (key, value) -> replaceRootDirBy(project, mapModClasses(key, value, project, runConfig), "${workspaceFolder}"));
+        runConfig.getEnvironment().compute("nativesDirectory", (key, value) -> replaceRootDirBy(project, value, "${workspaceFolder}"));
+        runConfig.getEnvironment().forEach((name, value) -> {
+            env.addProperty(name, value);
+        });
+        config.add("env", env);
+        return config;
+    }
+
+    private static String replaceRootDirBy(@Nonnull final Project project, String value, @Nonnull final String replacement) {
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+        return value.replace(project.getRootDir().toString(), replacement);
+    }
+
+    private static String mapModClasses(String key, String value, @Nonnull final Project project, @Nonnull final RunConfig runConfig) {
+        // Only replace environment variable if it is already set
+        if (value == null || value.isEmpty()) {
+            return value;
+        }
+
+        final EclipseModel eclipse = project.getExtensions().findByType(EclipseModel.class);
+
+        if (eclipse != null) {
+            final Map<String, String> outputs = eclipse.getClasspath().resolveDependencies().stream()
+                    .filter(SourceFolder.class::isInstance)
+                    .map(SourceFolder.class::cast)
+                    .map(SourceFolder::getOutput)
+                    .distinct()
+                    .collect(Collectors.toMap(output -> output.split("/")[output.split("/").length - 1], output -> project.file(output).getAbsolutePath()));
+
+            if (runConfig.getMods().isEmpty()) {
+                return runConfig.getAllSources().stream()
+                        .map(SourceSet::getName)
+                        .filter(outputs::containsKey)
+                        .map(outputs::get)
+                        .map(s -> String.join(File.pathSeparator, s, s)) // <resources>:<classes>
+                        .collect(Collectors.joining(File.pathSeparator));
+            } else {
+                final SourceSet main = project.getConvention().getPlugin(JavaPluginConvention.class).getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME);
+
+                return runConfig.getMods().stream()
+                        .map(modConfig -> {
+                            return (modConfig.getSources().isEmpty() ? Stream.of(main) : modConfig.getSources().stream())
+                                    .map(SourceSet::getName)
+                                    .filter(outputs::containsKey)
+                                    .map(outputs::get)
+                                    .map(output -> modConfig.getName() + "%%" + output)
+                                    .map(s -> String.join(File.pathSeparator, s, s)); // <resources>:<classes>
+                        })
+                        .flatMap(Function.identity())
+                        .collect(Collectors.joining(File.pathSeparator));
+            }
+        }
+
+        return value;
+    }
+
     @FunctionalInterface
-    private interface RunConfigurationGenerator {
+    private interface XMLRunConfigurationGenerator {
 
         @Nonnull
         Map<String, Document> createRunConfigurationXML(@Nonnull final Project project, @Nonnull final RunConfig runConfig, @Nonnull final String props, @Nonnull final DocumentBuilder documentBuilder);
 
     }
 
+    @FunctionalInterface
+    private interface JsonRunConfigurationGenerator {
+
+        @Nonnull
+        JsonObject createRunConfigurationJson(@Nonnull final Project project, @Nonnull final RunConfig runConfig, @Nonnull final String props);
+
+    }
+
+    private interface RunConfigurationBuilder {
+
+        void createConfig(@Nonnull final MinecraftExtension minecraft, @Nonnull final File runConfigurationsDir, @Nonnull final Project project);
+
+    }
+
+    private static class XMLConfigurationBuilder implements RunConfigurationBuilder {
+
+        private XMLRunConfigurationGenerator configGenerator;
+
+        public XMLConfigurationBuilder(XMLRunConfigurationGenerator generator) {
+            configGenerator = generator;
+        }
+
+        @Override
+        public void createConfig(@Nonnull final MinecraftExtension minecraft, @Nonnull final File runConfigurationsDir, @Nonnull final Project project) {
+            try {
+                final DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
+                final DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
+                final TransformerFactory transformerFactory = TransformerFactory.newInstance();
+                final Transformer transformer = transformerFactory.newTransformer();
+
+                transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+                transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
+
+                minecraft.getRuns().forEach(runConfig -> {
+                    final Stream<String> propStream = runConfig.getProperties().entrySet().stream().map(kv -> String.format("-D%s=%s", kv.getKey(), kv.getValue()));
+                    final String props = Stream.concat(propStream, runConfig.getJvmArgs().stream()).collect(Collectors.joining(" "));
+                    final Map<String, Document> documents = configGenerator.createRunConfigurationXML(project, runConfig, props, docBuilder);
+
+                    documents.forEach((fileName, document) -> {
+                        final DOMSource source = new DOMSource(document);
+                        final StreamResult result = new StreamResult(new File(runConfigurationsDir, fileName));
+
+                        try {
+                            transformer.transform(source, result);
+                        } catch (TransformerException e) {
+                            e.printStackTrace();
+                        }
+                    });
+                });
+            } catch (ParserConfigurationException | TransformerConfigurationException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private static class JsonConfigurationBuilder implements RunConfigurationBuilder {
+
+        private JsonRunConfigurationGenerator configGenerator;
+
+        public JsonConfigurationBuilder(JsonRunConfigurationGenerator generator) {
+            configGenerator = generator;
+        }
+
+        @Override
+        public void createConfig(@Nonnull final MinecraftExtension minecraft, @Nonnull final File runConfigurationsDir, @Nonnull final Project project) {
+            final JsonObject rootObject = new JsonObject();
+            rootObject.addProperty("version", "0.2.0");
+            JsonArray runConfigs = new JsonArray();
+            minecraft.getRuns().forEach(runConfig -> {
+                final Stream<String> propStream = runConfig.getProperties().entrySet().stream().map(kv -> String.format("-D%s=%s", kv.getKey(), kv.getValue()));
+                final String props = Stream.concat(propStream, runConfig.getJvmArgs().stream()).collect(Collectors.joining(" "));
+                runConfigs.add(configGenerator.createRunConfigurationJson(project, runConfig, props));
+            });
+            rootObject.add("configurations", runConfigs);
+            Writer writer;
+            try {
+                writer = new FileWriter(new File(runConfigurationsDir, "launch.json"));
+                Gson gson = new GsonBuilder().setPrettyPrinting().create();
+                writer.write(gson.toJson(rootObject));
+                writer.close();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR add `genVSCodeRuns` to create runs file for VS Code. This makes modding on VS Code easier and more convenient.

As Visual Studio Code already import the gradle project himself when you add the project folder to the workspace, typing the command is the only step to take.

![VScoderuns](https://user-images.githubusercontent.com/1993583/57337295-24697680-7129-11e9-8ff8-9a21e094057c.jpg)


Since the current code was only design to generate a run file in the XML format, I refactored the code to make it a little more flexible.

Note: The Java extension for VSCode use Eclipse JDT Language Server, the behavior is therefore similar to Eclipse. Binary file are compiled to the folder `bin/` so I also need to remap `MOD_CLASSES`.