### PR TITLE
Add class javadoc injection

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/JavadocAdder.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/JavadocAdder.java
@@ -37,10 +37,10 @@ public final class JavadocAdder
      * Converts a raw javadoc string into a nicely formatted, indented, and wrapped string.
      * @param indent the indent to be inserted before every line.
      * @param javadoc The javadoc string to be processed
-     * @param isMethod If this javadoc is for a method or a field
+     * @param multiline If this javadoc is mutlilined (for a field, it isn't) even if there is only one line in the doc
      * @return A fully formatted javadoc comment string complete with comment characters and newlines.
      */
-    public static String buildJavadoc(String indent, String javadoc, boolean isMethod)
+    public static String buildJavadoc(String indent, String javadoc, boolean multiline)
     {
         StringBuilder builder = new StringBuilder();
 
@@ -51,7 +51,7 @@ public final class JavadocAdder
             list.addAll(wrapText(line, 120 - (indent.length() + 3)));
         }
 
-        if (list.size() > 1 || isMethod)
+        if (list.size() > 1 || multiline)
         {
             builder.append(indent);
             builder.append("/**");


### PR DESCRIPTION
This allows classes to also have Javadoc documentation, provided the bot provides the appropriate data in the exports.