### PR TITLE
Fix Obfuscation deadlock with IntelliJ

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -178,6 +178,9 @@ public class UserDevPlugin implements Plugin<Project> {
 
             if (!internalObfConfiguration.getDependencies().isEmpty()) {
                 deobfrepo = new DeobfuscatingRepo(project, internalObfConfiguration, deobfuscator);
+                if (deobfrepo.getResolvedOrigin() == null) {
+                    project.getLogger().error("DeobfRepo attempted to resolve an origin repo early but failed, this may cause issues with some IDEs");
+                }
             }
             remapper.attachMappings(extension.getMappings());
 

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/util/DeobfuscatingRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/util/DeobfuscatingRepo.java
@@ -38,7 +38,7 @@ public class DeobfuscatingRepo extends BaseRepo {
     private final Project project;
 
     //once resolved by gradle, will contain SRG-named artifacts for us to deobf
-    private Configuration origin;
+    private final Configuration origin;
     private ResolvedConfiguration resolvedOrigin;
     private Deobfuscator deobfuscator;
 
@@ -96,12 +96,14 @@ public class DeobfuscatingRepo extends BaseRepo {
         return deobfuscator.deobfPom(origFile, mapping, getArtifactPath(artifact, mapping));
     }
 
-    private ResolvedConfiguration getResolvedOrigin() {
-        if (resolvedOrigin == null) {
-            resolvedOrigin = origin.getResolvedConfiguration();
-        }
+    public ResolvedConfiguration getResolvedOrigin() {
+        synchronized (origin) {
+            if (resolvedOrigin == null) {
+                resolvedOrigin = origin.getResolvedConfiguration();
+            }
 
-        return resolvedOrigin;
+            return resolvedOrigin;
+        }
     }
 
     private Optional<File> findArtifactFile(Artifact artifact) {


### PR DESCRIPTION
With the help of @OrionDevelopment we were able to find and hopefully eliminate the issue of some IDEs (sometimes) deadlocking when using `fg.deobf` in gradle configs.

Description from Orion, because he's a lot better at describing this stuff:

Due to the fact that IDEA (and possibly also eclipse) resolve dependency information in parallel for each module, during the build finishing phase the daemon worker thread holds a lock on the notification system. This lock prevents the worker thread (which is spawned by the daemon worker thread to handle the resolving of dependency information) from notifying the IDEA handler of the impending resolution of dependencies (since the DeobfusctingRepo has not been called yet, its origin has not been resolved, during the same phase that the other configurations got resolved).

This PR locks down the access to the origin configuration as well as force the resolution of its dependencies early, so that this happens in afterEvaluate, which means that the lock on the notification system is not yet held by the DaemonWorker, since the build has not finished yet, allowing IDEA to resolve the dependencies properly in the build finished phase, preventing the deadlock form occurring.