### PR TITLE
Changing the repository and caching scheme to take individual projects, within a workspace, into account.

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/MinecraftRepo.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MinecraftRepo.java
@@ -26,15 +26,13 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
 import java.util.zip.ZipOutputStream;
 
+import com.google.common.collect.Maps;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.Project;
@@ -55,7 +53,7 @@ import net.minecraftforge.gradle.common.util.VersionJson.Download;
 import net.minecraftforge.gradle.common.util.VersionJson.OS;
 
 public class MinecraftRepo extends BaseRepo {
-    private static MinecraftRepo INSTANCE;
+    private static final Map<Project, MinecraftRepo> PROJECT_INSTANCES = Maps.newConcurrentMap();
     private static final String GROUP = "net.minecraft";
     public static final String MANIFEST_URL = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
     public static final String CURRENT_OS = OS.getCurrent().getName();
@@ -74,9 +72,15 @@ public class MinecraftRepo extends BaseRepo {
     }
 
     private static MinecraftRepo getInstance(Project project) {
-        if (INSTANCE == null)
-            INSTANCE = new MinecraftRepo(Utils.getCache(project, "minecraft_repo"), project.getLogger(), project.getGradle().getStartParameter().isOffline());
-        return INSTANCE;
+        if (!PROJECT_INSTANCES.containsKey(project))
+        {
+            PROJECT_INSTANCES.put(
+              project,
+              new MinecraftRepo(Utils.getCache(project, "minecraft_repo"), project.getLogger(), project.getGradle().getStartParameter().isOffline())
+            );
+        }
+
+        return PROJECT_INSTANCES.get(project);
     }
 
     public static void attach(Project project) {

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -33,6 +33,7 @@ import net.minecraftforge.gradle.common.util.VersionJson.Download;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.Project;
+import org.gradle.api.logging.LogLevel;
 
 import javax.annotation.Nonnull;
 
@@ -142,7 +143,16 @@ public class Utils {
 
     public static Path getCacheBase(Project project) {
         File gradleUserHomeDir = project.getGradle().getGradleUserHomeDir();
-        return Paths.get(gradleUserHomeDir.getPath(), "caches", "forge_gradle");
+        return Paths.get(gradleUserHomeDir.getPath(), "caches", "forge_gradle", getPathFromProject(project));
+    }
+
+    public static String getPathFromProject(Project project) {
+        if (project.getParent() == null)
+        {
+            return project.getName();
+        }
+
+        return Paths.get(getPathFromProject(project.getParent()), project.getName()).toString();
     }
 
     public static File getCache(Project project, String... tail) {

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/MCPRepo.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/MCPRepo.java
@@ -90,7 +90,8 @@ import java.util.zip.ZipOutputStream;
  *   Note: It does NOT provide the Obfed named jars for server and client, as that is provided by MinecraftRepo.
  */
 public class MCPRepo extends BaseRepo {
-    private static MCPRepo INSTANCE = null;
+    private static final Map<Project, MCPRepo> PROJECT_INSTANCES = Maps.newConcurrentMap();
+
     private static final String GROUP_MINECRAFT = "net.minecraft";
     private static final String NAMES_MINECRAFT = "^(client|server|joined|mappings_[a-z_]+)$";
     private static final String GROUP_MCP = "de.oceanlabs.mcp";
@@ -118,10 +119,17 @@ public class MCPRepo extends BaseRepo {
     }
 
     private static MCPRepo getInstance(Project project) {
-        if (INSTANCE == null)
-            INSTANCE = new MCPRepo(project, Utils.getCache(project, "mcp_repo"), project.getLogger());
-        return INSTANCE;
+        if (!PROJECT_INSTANCES.containsKey(project))
+        {
+            PROJECT_INSTANCES.put(
+              project,
+              new MCPRepo(project, Utils.getCache(project, "mcp_repo"), project.getLogger())
+              );
+        }
+
+        return PROJECT_INSTANCES.get(project);
     }
+
     public static void attach(Project project) {
         MCPRepo instance = getInstance(project);
         GradleRepositoryAdapter.add(project.getRepositories(), "MCP_DYNAMIC", instance.getCacheRoot(), instance.repo);


### PR DESCRIPTION
Continuing from the debugging me and @Asherslab did in #630, i continued trying to fix the usage of FG3.+ inside IDEA.

## Error description:
While doing this I came across the use case of child projects. Initially all seemed well, projects loaded and dependencies where actually loaded up properly. However as soon as at least one child-project differed from the others (say for example it used a custom access transformer) the current system breaks.

Currently FG generates the required artifacts and sources into its own cache, additionally only one instance of MCPRepo and MinecraftRepo exist (regardless of how many projects FG is applied to in a workspace) and both the cache entries and the Repos are created only for the first project to which FG is applied. So its configuration (basically anything that influences the created deobfuscated minecraft jar, like the access transformer) is used to generate the repos as well as all cache entries. If any project, that comes after, the initial one, has a different configuration, the initially created repo (for the first project, with its configuration) tries to lookup the files, notices it has them in the cache, and returns the already created file. Regardless of the fact that the configuration in the secondary project requires a different artifact to be generated.

## Error resolution:
This PR adds two changes:
 1) It changes the cache base path to include a projects name (and that of its parents)
 2) MinecraftRepo and MCPRepo are now individually created for each project and stored in a concurrent map, to allow for different configuration to generate artifacts properly

## Resolution consequences:
 1) First and foremost, every project now generates its own artifacts in its own cache. This has some significant side-effects, especially when it comes to performance in multi project workspaces. Each project now has to generate its own dependencies, and MC has to be decompiled and deobfuscated for each project individually. Since gradle does not do this in parallel, even if the parallel processing option is enabled, this might take a bit of time depending on the amount of projects in the workspace.
 2) Each project has its own cache (by design), if the cache for one of the projects breaks, it can be easily recovered.

## Why do I need this PR?
Additionally to get FG to work in a multi project per workspace scenario, I actually have a workspace like this. My project called 'BlockOut' actually has its components split apart into several child projects, as such (as of writing) it has 6 projects within one workspace, which have FG applied (it actually contains a lot more projects, but most of them do not need FG so they do not have it). The problem arose, when I could not apply different AT files, or even different configurations and get IDEA to recognize the new changes, so I dug into the Caches and saw to no additional files where generated. Some debugging later and I came up with this solution.

Greets,

Orion