### PR TITLE
Fix license in FG_1.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,8 +161,8 @@ uploadArchives {
 
                         licenses {
                             license {
-                                name 'Eclipse Public License (EPL), Version 1.0'
-                                url 'http://www.eclipse.org/legal/epl-v10.html'
+			        name 'Lesser GNU Public License, Version 2.1'
+                                url 'https://www.gnu.org/licenses/lgpl-2.1.html'
                                 distribution 'repo'
                             }
                         }

--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,7 @@ uploadArchives {
 
                         licenses {
                             license {
-			        name 'Lesser GNU Public License, Version 2.1'
+                                name 'Lesser GNU Public License, Version 2.1'
                                 url 'https://www.gnu.org/licenses/lgpl-2.1.html'
                                 distribution 'repo'
                             }


### PR DESCRIPTION
ForgeGradle was re-licensed to LGPL in d57f4a2 but the pom file still says this FG is licensed under EPL. This fixes this problem