### PR TITLE
Fix classes javadoc breakage

### DIFF
--- a/.github/support.yml
+++ b/.github/support.yml
@@ -1,0 +1,16 @@
+# Configuration for support-requests - https://github.com/dessant/support-requests
+
+# Label used to mark issues as support requests
+supportLabel: Forum
+# Comment to post on issues marked as support requests. Add a link
+# to a support page, or set to `false` to disable
+supportComment: >
+  👋 We use the issue tracker exclusively for final bug reports and feature requests.
+  However, this issue appears to be better suited for the
+  [Forge Modder Support Forums](https://www.minecraftforge.net/forum/forum/70-modder-support/).
+  Please create a new topic on the Modder Support forum with this issue, and the conversation can
+  continue there.
+# Whether to close issues marked as support requests
+close: true
+# Whether to lock issues marked as support requests
+lock: true

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -83,7 +83,7 @@ public class Utils {
                                                           //manifest doesn't include sha1's so we use this for the per-version json as well.
     public static final String FORGE_MAVEN = "https://files.minecraftforge.net/maven/";
     public static final String BINPATCHER =  "net.minecraftforge:binarypatcher:1.+:fatjar";
-    public static final String ACCESSTRANSFORMER = "net.minecraftforge:accesstransformers:0.14.+:fatjar";
+    public static final String ACCESSTRANSFORMER = "net.minecraftforge:accesstransformers:1.0.+:fatjar";
     public static final String SPECIALSOURCE = "net.md-5:SpecialSource:1.8.3:shaded";
     public static final String SRG2SOURCE =  "net.minecraftforge:Srg2Source:5.+:fatjar";
     public static final String SIDESTRIPPER = "net.minecraftforge:mergetool:1.0.7:fatjar";

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/MCPRepo.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/MCPRepo.java
@@ -381,7 +381,7 @@ public class MCPRepo extends BaseRepo {
         McpNames map = mapCache.get(name);
         String hash = HashFunction.SHA1.hash(data);
         if (map == null || !hash.equals(map.hash)) {
-            map = McpNames.load(data);
+            map = McpNames.load(data, project.getLogger());
             mapCache.put(name, map);
         }
         return map;

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -819,7 +819,7 @@ public class MinecraftUserRepo extends BaseRepo {
         McpNames map = mapCache.get(name);
         String hash = HashFunction.SHA1.hash(data);
         if (map == null || !hash.equals(map.hash)) {
-            map = McpNames.load(data);
+            map = McpNames.load(data, project.getLogger());
             mapCache.put(name, map);
         }
         return map;
@@ -1010,7 +1010,7 @@ public class MinecraftUserRepo extends BaseRepo {
         if (cache.isSame() && sources.exists()) {
             debug("    Cache hit");
         } else if (sources.exists() || generate) {
-            McpNames map = McpNames.load(names);
+            McpNames map = McpNames.load(names, project.getLogger());
 
             if (!sources.getParentFile().exists())
                 sources.getParentFile().mkdirs();

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/GenerateSRG.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/GenerateSRG.java
@@ -48,7 +48,7 @@ public class GenerateSRG extends DefaultTask {
 
         MappingFile obf_to_srg = MappingFile.load(srg);
         MappingFile ret = new MappingFile();
-        McpNames map = McpNames.load(names);
+        McpNames map = McpNames.load(names, getLogger());
         obf_to_srg.getPackages().forEach(e -> ret.addPackage(e.getMapped(), e.getMapped()));
         obf_to_srg.getClasses().forEach(cls -> {
            ret.addClass(cls.getMapped(), cls.getMapped());

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
@@ -138,7 +138,6 @@ public class Deobfuscator {
 
     public File deobfSources(File original, String mappings, String... cachePath) throws IOException {
         project.getLogger().debug("Deobfuscating sources file {} with mappings {}", original.getName(), mappings);
-
         File names = findMapping(mappings);
         if (names == null || !names.exists()) {
             return null;
@@ -163,7 +162,7 @@ public class Deobfuscator {
                     zout.putNextEntry(Utils.getStableEntry(_old.getName()));
 
                     if (_old.getName().endsWith(".java")) {
-                        String mapped = map.rename(zin, true);
+                        String mapped = map.rename(zin, false);
                         IOUtils.write(mapped, zout);
                     } else {
                         IOUtils.copy(zin, zout);

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
@@ -154,7 +154,7 @@ public class Deobfuscator {
                 .add("orig", original);
 
         if (!cache.isSame() || !output.exists()) {
-            McpNames map = McpNames.load(names);
+            McpNames map = McpNames.load(names, project.getLogger());
 
             try (ZipInputStream zin = new ZipInputStream(new FileInputStream(input));
                  ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(output))) {


### PR DESCRIPTION
Fix bug in previous PR ( #617 )

We previously failed hard when we couldn't keep track of indentation. Now we just fail softly and warn the user that there is likely an issue with class javadoc comments.

We could also use "debug" or "info" instead of "warn" for the logger or just stop adding class javadocs when it fails, instead of trying to recover
