### PR TITLE
Added support.yml

### DIFF
--- a/.github/support.yml
+++ b/.github/support.yml
@@ -1,0 +1,16 @@
+# Configuration for support-requests - https://github.com/dessant/support-requests
+
+# Label used to mark issues as support requests
+supportLabel: Forum
+# Comment to post on issues marked as support requests. Add a link
+# to a support page, or set to `false` to disable
+supportComment: >
+  👋 We use the issue tracker exclusively for final bug reports and feature requests.
+  However, this issue appears to be better suited for the
+  [Forge Modder Support Forums](https://www.minecraftforge.net/forum/forum/70-modder-support/).
+  Please create a new topic on the Modder Support forum with this issue, and the conversation can
+  continue there.
+# Whether to close issues marked as support requests
+close: true
+# Whether to lock issues marked as support requests
+lock: true


### PR DESCRIPTION
This enables the Forum tag auto-closing and locking Issues and PRs, assuming the bot is watching the ForgeGradle repo