### PR TITLE
Properly cache deobfMcMCP to improve performance

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -300,6 +300,13 @@ public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePl
     {
         madeDecompTasks = true; // to guard against stupid programmers
 
+        final Object deobfBinJar = chooseDeobfOutput(globalPattern, localPattern, "Bin", "");
+        final Object deobfDecompJar = chooseDeobfOutput(globalPattern, localPattern, "", "srgBin");
+        final Object decompJar = chooseDeobfOutput(globalPattern, localPattern, "", "decomp");
+        final Object postDecompJar = chooseDeobfOutput(globalPattern, localPattern, "", "decompFixed");
+        final Object remapped = chooseDeobfOutput(globalPattern, localPattern, "Src", "sources");
+        final Object recompiledJar = chooseDeobfOutput(globalPattern, localPattern, "Src", "");
+
         final DeobfuscateJar deobfBin = makeTask(TASK_DEOBF_BIN, DeobfuscateJar.class);
         {
             deobfBin.setSrg(delayedFile(SRG_NOTCH_TO_MCP));
@@ -309,15 +316,9 @@ public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePl
             deobfBin.setMethodCsv(delayedFile(CSV_METHOD));
             deobfBin.setApplyMarkers(false);
             deobfBin.setInJar(inputJar);
-            deobfBin.setOutJar(chooseDeobfOutput(globalPattern, localPattern, "Bin", ""));
+            deobfBin.setOutJar(deobfBinJar);
             deobfBin.dependsOn(inputTask, TASK_GENERATE_SRGS, TASK_EXTRACT_DEP_ATS, TASK_DD_COMPILE, TASK_DD_PROVIDED);
         }
-
-        final Object deobfDecompJar = chooseDeobfOutput(globalPattern, localPattern, "", "srgBin");
-        final Object decompJar = chooseDeobfOutput(globalPattern, localPattern, "", "decomp");
-        final Object postDecompJar = chooseDeobfOutput(globalPattern, localPattern, "", "decompFixed");
-        final Object remapped = chooseDeobfOutput(globalPattern, localPattern, "Src", "sources");
-        final Object recompiledJar = chooseDeobfOutput(globalPattern, localPattern, "Src", "");
 
         final DeobfuscateJar deobfDecomp = makeTask(TASK_DEOBF, DeobfuscateJar.class);
         {
@@ -425,10 +426,11 @@ public abstract class UserBasePlugin<T extends UserBaseExtension> extends BasePl
                     return;
 
                 // the recompiled jar exists, or the decomp task is part of the build
+                boolean isDeobf = project.file(deobfBinJar).exists() || project.getGradle().getStartParameter().getTaskNames().contains(TASK_SETUP_DECOMP);
                 boolean isDecomp = project.file(recompiledJar).exists() || project.getGradle().getStartParameter().getTaskNames().contains(TASK_SETUP_DECOMP);
 
                 // set task dependencies
-                if (!isDecomp)
+                if (!isDeobf)
                 {
                     project.getTasks().getByName("compileJava").dependsOn(UserConstants.TASK_DEOBF_BIN);
                     project.getTasks().getByName("compileApiJava").dependsOn(UserConstants.TASK_DEOBF_BIN);


### PR DESCRIPTION
Currently, when a project is being built with the use of ForgeGradle-2.3-SNAPSHOT, it is checked whether the project has been setup with `setupDecompWorkspace`. Unless that happens to be the case, the task `deobfMcMCP` is delegated for execution, along with the tasks it depends on.

During the execution phase of the Gradle lifecycle, the mentioned tasks may be marked as `SKIPPED` if they have already been performed earlier and their results have been cached for the project. However, it seems that merely determining these facts at this point may take Gradle 10 seconds or more - scaling to quite a lot of time, and, presumably, processing power as well.

This pull request aims to fix the described issue by making ForgeGradle check for the existence of the output of the `deobfMcMCP` task, instead of the entire decompiled workspace, before the execution phase starts. I attach a small comparison of the practical performance of the two methods on the same machine, each starting with a clean build of a small project, followed by two cached ones:

* [Old](https://pastebin.com/raw/4zLEpcyU): Clean build **44s**, cached builds **13s** and **12s**, respectively, for a cached average of **12.5s**;
* [New](https://pastebin.com/raw/VKGFSQPe): Clean build **31s**, cached builds **3s** and **2s**, respectively, for a cached average of **2.5s**.

(The seemingly improved clean build times are probably incidental, perhaps dependent on my network speed or some Gradle daemon intrinsics, however the improvement that follows for the cached builds is fully reproducible on my system, for all projects that I have thus far tested.)