### PR TITLE
Support third party mappings channels

### DIFF
--- a/src/mcp/java/net/minecraftforge/gradle/mcp/MCPRepo.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/MCPRepo.java
@@ -368,13 +368,14 @@ public class MCPRepo extends BaseRepo {
 
         if ("official".equals(channel)) {
             return findOfficialMapping(version);
-        } else if ("snapshot".equals(channel) || "snapshot_nodoc".equals(channel) || "stable".equals(channel) || "stable_nodoc".equals(channel)) { //MCP
+        } else { // MCP or unknown, assume MCP format
+            if (!("snapshot".equals(channel) || "snapshot_nodoc".equals(channel) || "stable".equals(channel) || "stable_nodoc".equals(channel))) {
+                log.warn("Unknown mapping provider, assuming third party mappings");
+            }
             String desc = "de.oceanlabs.mcp:mcp_" + channel + ":" + version + "@zip";
             debug("    Mapping: " + desc);
             return MavenArtifactDownloader.manual(project, desc, false);
         }
-        //TODO? Yarn/Other crowdsourcing?
-        throw new IllegalArgumentException("Unknown mapping provider: " + mapping);
     }
 
     private McpNames loadMCPNames(String name, File data) throws IOException {


### PR DESCRIPTION
Removes the pointless limitation on mapping providers. Will now simply warn for "unknown" channels, but still attempt a maven lookup for them. This allows third party sources to provide mcp artifacts for custom channels. Effectively implements the TODO, assuming whatever other project provides a maven artifact matching the MCP format.