### PR TITLE
Read gradle delegation setting from project metadata.

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
@@ -68,7 +68,7 @@ public abstract class RunConfigGenerator
         final Map<String, Triple<List<Object>, File, RunConfigGenerator>> ideConfigurationGenerators = ImmutableMap.<String, Triple<List<Object>, File, RunConfigGenerator>>builder()
                 .put("genIntellijRuns", ImmutableTriple.of(Collections.singletonList(prepareRuns.get()),
                         new File(project.getRootProject().getRootDir(), ".idea/runConfigurations"),
-                        new IntellijRunGenerator()))
+                        new IntellijRunGenerator(project.getRootProject())))
                 .put("genEclipseRuns", ImmutableTriple.of(ImmutableList.of(prepareRuns.get(), makeSourceDirs.get()),
                         project.getProjectDir(),
                         new EclipseRunGenerator()))


### PR DESCRIPTION
I through a combination of incorrect assumptions and invalid testing, I had the impression that the gradle delegation mode still used the same output paths. This is not the case, so I had to introduce logic to try to figure it out.