### PR TITLE
Adding the Forge-Maven earlier in the Project setup phase.

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -257,6 +257,10 @@ public class UserDevPlugin implements Plugin<Project> {
                 minecraft.getDependencies().add(ext);
             }
 
+            project.getRepositories().maven(e -> {
+                e.setUrl(Utils.FORGE_MAVEN);
+            });
+
             if (!internalObfConfiguration.getDependencies().isEmpty()) {
                 deobfrepo = new DeobfuscatingRepo(project, internalObfConfiguration, deobfuscator);
                 if (deobfrepo.getResolvedOrigin() == null) {
@@ -272,9 +276,6 @@ public class UserDevPlugin implements Plugin<Project> {
                     .add(MCPRepo.create(project))
                     .add(MinecraftRepo.create(project)) //Provides vanilla extra/slim/data jars. These don't care about OBF names.
                     .attach(project);
-            project.getRepositories().maven(e -> {
-                e.setUrl(Utils.FORGE_MAVEN);
-            });
             project.getRepositories().maven(e -> {
                 e.setUrl(Utils.MOJANG_MAVEN);
                 e.metadataSources(src -> src.artifact());


### PR DESCRIPTION
This adds the Forge-Maven repository earlier in the setup phase.

We run an early attempt to pre-resolves artifacts which we later need to deobfuscate, as defined with `fg.deobf` this however requires all the repositories in which mods that need to be deobfuscated exist to be registered.
By default FG3 adds the Forge-Maven repository to the repositories list, as such the modder would not need to add this repository himself, however that was not the case for when he or she tried to use and deobfuscate mods on that repository. Since then it was added after the pre-resolve step. This is ofcourse not entirely out of spec, since Gradle specifies that the user should add repositories for each of his dependencies himself, and it would also have fixed this. However it would not be very convenient, since FG3 already adds it itself anyway.

To fix this issue this PR pulls the registration of the Forge-Maven repository to before the pre-resolve and this now works properly.

Tested with several mods that exist on the Forge-Maven repository as dependencies.
The following `build.gradle` demonstrates the problem: https://gist.github.com/OrionDevelopment/57e954cffae5f0b142f0a552805d38ee it breaks if used with the current release, but works if these patches are applied.