### PR TITLE
Gradle has removed http support.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14-bin.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-3.0-bin.zip


### PR DESCRIPTION
We need a gradle version higher than 3.0 to get working ForgeGradle for Minecraft 1.7.10-1614 or other old versions wich are constantly used today.