### PR TITLE
Scan Minecraft install location for assets before downloading.

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
@@ -45,12 +45,12 @@ public class DownloadAssets extends DefaultTask {
         AssetIndex index = Utils.loadJson(getIndex(), AssetIndex.class);
         List<String> keys = new ArrayList<>(index.objects.keySet());
         Collections.sort(keys);
-        File assetsPath = new File(Utils.getMCDir(), "\\assets\\objects");
+        File assetsPath = new File(Utils.getMCDir(), "/assets/objects");
         for (String key : keys) {
             Asset asset = index.objects.get(key);
             File target = Utils.getCache(getProject(), "assets", "objects", asset.getPath());
             if (!target.exists()) {
-                File localFile = FileUtils.getFile(assetsPath + "\\" + asset.getPath());
+                File localFile = FileUtils.getFile(assetsPath + "/" + asset.getPath());
                 if (localFile.exists()) {
                     getProject().getLogger().lifecycle("Copying local object: " + asset.getPath() + " Asset: " + key);
                     FileUtils.copyFile(localFile, target);

--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
@@ -37,7 +37,7 @@ import net.minecraftforge.gradle.common.util.Utils;
 import net.minecraftforge.gradle.common.util.VersionJson;
 
 public class DownloadAssets extends DefaultTask {
-    private static final String RESOURCE_REPO = "http://resources.download.minecraft.net/";
+    private static final String RESOURCE_REPO = "https://resources.download.minecraft.net/";
     private File meta;
 
     @TaskAction
@@ -45,10 +45,28 @@ public class DownloadAssets extends DefaultTask {
         AssetIndex index = Utils.loadJson(getIndex(), AssetIndex.class);
         List<String> keys = new ArrayList<>(index.objects.keySet());
         Collections.sort(keys);
+        // TODO: Test and implement path for other OSs
+        String assetsPath;
+        switch(VersionJson.OS.getCurrent()) {
+            case WINDOWS: assetsPath = FileUtils.getUserDirectoryPath() + "\\AppData\\Roaming\\.minecraft\\assets\\objects";
+                break;
+            case OSX:
+            case LINUX:
+            case UNKNOWN:
+            default: assetsPath = null;
+        }
         for (String key : keys) {
             Asset asset = index.objects.get(key);
             File target = Utils.getCache(getProject(), "assets", "objects", asset.getPath());
             if (!target.exists()) {
+                if (assetsPath != null) {
+                    File localFile = FileUtils.getFile(assetsPath + "\\" + asset.getPath());
+                    if (localFile.exists()) {
+                        getProject().getLogger().lifecycle("Copying local object: " + asset.getPath() + " Asset: " + key);
+                        FileUtils.copyFile(localFile, target);
+                        continue;
+                    }
+                }
                 URL url = new URL(RESOURCE_REPO + asset.getPath());
                 getProject().getLogger().lifecycle("Downloading: " + url + " Asset: " + key);
                 FileUtils.copyURLToFile(url, target);

--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
@@ -45,27 +45,16 @@ public class DownloadAssets extends DefaultTask {
         AssetIndex index = Utils.loadJson(getIndex(), AssetIndex.class);
         List<String> keys = new ArrayList<>(index.objects.keySet());
         Collections.sort(keys);
-        // TODO: Test and implement path for other OSs
-        String assetsPath;
-        switch(VersionJson.OS.getCurrent()) {
-            case WINDOWS: assetsPath = FileUtils.getUserDirectoryPath() + "\\AppData\\Roaming\\.minecraft\\assets\\objects";
-                break;
-            case OSX:
-            case LINUX:
-            case UNKNOWN:
-            default: assetsPath = null;
-        }
+        File assetsPath = new File(Utils.getMCDir(), "\\assets\\objects");
         for (String key : keys) {
             Asset asset = index.objects.get(key);
             File target = Utils.getCache(getProject(), "assets", "objects", asset.getPath());
             if (!target.exists()) {
-                if (assetsPath != null) {
-                    File localFile = FileUtils.getFile(assetsPath + "\\" + asset.getPath());
-                    if (localFile.exists()) {
-                        getProject().getLogger().lifecycle("Copying local object: " + asset.getPath() + " Asset: " + key);
-                        FileUtils.copyFile(localFile, target);
-                        continue;
-                    }
+                File localFile = FileUtils.getFile(assetsPath + "\\" + asset.getPath());
+                if (localFile.exists()) {
+                    getProject().getLogger().lifecycle("Copying local object: " + asset.getPath() + " Asset: " + key);
+                    FileUtils.copyFile(localFile, target);
+                    continue;
                 }
                 URL url = new URL(RESOURCE_REPO + asset.getPath());
                 getProject().getLogger().lifecycle("Downloading: " + url + " Asset: " + key);

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -637,12 +637,14 @@ public class Utils {
     public static File getMCDir()
     {
         String userHomeDir = System.getProperty("user.home", ".");
-        String osType = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
         String mcDir = ".minecraft";
-        if (osType.contains("win") && System.getenv("APPDATA") != null)
-            return new File(System.getenv("APPDATA"), mcDir);
-        else if (osType.contains("mac"))
-            return new File(new File(new File(userHomeDir, "Library"),"Application Support"),"minecraft");
-        return new File(userHomeDir, mcDir);
+        File directory = new File(userHomeDir, mcDir);
+        switch (VersionJson.OS.getCurrent()) {
+            case WINDOWS: if (System.getenv("APPDATA") != null) directory = new File(System.getenv("APPDATA"), mcDir);
+            break;
+            case OSX: directory = new File(new File(new File(userHomeDir, "Library"),"Application Support"),"minecraft");
+            break;
+        }
+        return directory;
     }
 }

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -73,6 +73,7 @@ import java.util.Date;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.Callable;
@@ -631,5 +632,17 @@ public class Utils {
 
             RunConfigGenerator.createIDEGenRunsTasks(extension, prepareRuns, makeSrcDirs, additionalClientArgs);
         });
+    }
+
+    public static File getMCDir()
+    {
+        String userHomeDir = System.getProperty("user.home", ".");
+        String osType = System.getProperty("os.name").toLowerCase(Locale.ENGLISH);
+        String mcDir = ".minecraft";
+        if (osType.contains("win") && System.getenv("APPDATA") != null)
+            return new File(System.getenv("APPDATA"), mcDir);
+        else if (osType.contains("mac"))
+            return new File(new File(new File(userHomeDir, "Library"),"Application Support"),"minecraft");
+        return new File(userHomeDir, mcDir);
     }
 }


### PR DESCRIPTION
This PR makes ForgeGradle scan the common install directory for Minecraft to pull assets from it before defaulting back to downloading them.

I have also changed the download location to use HTTPS.

Since I am unable to test on other OSs, others will have to implement the paths required for them if they want this functionality.