### PR TITLE
Allow disabling forced System.exit for run config tasks

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
@@ -61,6 +61,7 @@ public class RunConfig extends GroovyObjectSupport implements Serializable {
     private List<SourceSet> sources;
     private List<RunConfig> parents, children;
     private List<String> args, jvmArgs;
+    private boolean forceExit = true;
 
     private Map<String, String> env, props, tokens;
 
@@ -257,6 +258,18 @@ public class RunConfig extends GroovyObjectSupport implements Serializable {
         }
 
         return workDir;
+    }
+
+    public void forceExit(boolean forceExit) {
+        this.setForceExit(forceExit);
+    }
+
+    public void setForceExit(boolean forceExit) {
+        this.forceExit = forceExit;
+    }
+
+    public boolean getForceExit() {
+        return this.forceExit;
     }
 
     public NamedDomainObjectContainer<ModConfig> mods(@SuppressWarnings("rawtypes") Closure closure) {

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
@@ -202,7 +202,9 @@ public abstract class RunConfigGenerator
             runConfig.getAllSources().stream().map(SourceSet::getRuntimeClasspath).forEach(task::classpath);
 
             // Stop after this run task so it doesn't try to execute the run tasks, and their dependencies, of sub projects
-            task.doLast(t -> System.exit(0)); // TODO: Find better way to stop gracefully
+            if (runConfig.getForceExit()) {
+                task.doLast(t -> System.exit(0)); // TODO: Find better way to stop gracefully
+            }
         });
     }
 


### PR DESCRIPTION
Allow disabling the forced `System.exit` workaround at the end of run tasks, as it causes Gradle to think the task failed, making it unsuitable for use in e.g. CI.
To disable / configure this behavior run configurations can specify `forceExit false`.