### PR TITLE
Strip JAR signatures when using deobfuscating libraries

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -102,7 +102,7 @@ public class Utils {
     public static final String SPECIALSOURCE = "net.md-5:SpecialSource:1.8.3:shaded";
     public static final String SRG2SOURCE =  "net.minecraftforge:Srg2Source:5.+:fatjar";
     public static final String SIDESTRIPPER = "net.minecraftforge:mergetool:1.0.7:fatjar";
-    public static final String INSTALLERTOOLS = "net.minecraftforge:installertools:1.1.7:fatjar";
+    public static final String INSTALLERTOOLS = "net.minecraftforge:installertools:1.1.10:fatjar";
     public static final long ZIPTIME = 628041600000L;
     public static final TimeZone GMT = TimeZone.getTimeZone("GMT");
     public static final String OFFICIAL_MAPPING_USAGE =

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/RenameJarSrg2Mcp.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/RenameJarSrg2Mcp.java
@@ -42,7 +42,7 @@ public class RenameJarSrg2Mcp extends JarExec {
 
     public RenameJarSrg2Mcp() {
         tool = Utils.INSTALLERTOOLS;
-        args = new String[] { "--task", "SRG_TO_MCP", "--input", "{input}", "--output", "{output}", "--mcp", "{mappings}", "--strip-signatures", "{strip}"};
+        args = new String[] { "--task", "SRG_TO_MCP", "--input", "{input}", "--output", "{output}", "--mcp", "{mappings}", "{strip}"};
     }
 
     @Override
@@ -51,9 +51,9 @@ public class RenameJarSrg2Mcp extends JarExec {
         replace.put("{input}", getInput().getAbsolutePath());
         replace.put("{output}", getOutput().getAbsolutePath());
         replace.put("{mappings}", getMappings().getAbsolutePath());
-        replace.put("{strip}", Boolean.toString(getSignatureRemoval()));
+        replace.put("{strip}", getSignatureRemoval()? "--strip-signatures" : "");
 
-        return Arrays.stream(getArgs()).map(arg -> replace.getOrDefault(arg, arg)).collect(Collectors.toList());
+        return Arrays.stream(getArgs()).map(arg -> replace.getOrDefault(arg, arg)).filter(it -> !it.isEmpty()).collect(Collectors.toList());
     }
 
     public boolean getSignatureRemoval() {

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/RenameJarSrg2Mcp.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/RenameJarSrg2Mcp.java
@@ -38,10 +38,11 @@ public class RenameJarSrg2Mcp extends JarExec {
     private Supplier<File> input;
     private File output;
     private Supplier<File> mappings;
+    private boolean signatureRemoval;
 
     public RenameJarSrg2Mcp() {
         tool = Utils.INSTALLERTOOLS;
-        args = new String[] { "--task", "SRG_TO_MCP", "--input", "{input}", "--output", "{output}", "--mcp", "{mappings}"};
+        args = new String[] { "--task", "SRG_TO_MCP", "--input", "{input}", "--output", "{output}", "--mcp", "{mappings}", "--strip-signatures", "{strip}"};
     }
 
     @Override
@@ -50,8 +51,16 @@ public class RenameJarSrg2Mcp extends JarExec {
         replace.put("{input}", getInput().getAbsolutePath());
         replace.put("{output}", getOutput().getAbsolutePath());
         replace.put("{mappings}", getMappings().getAbsolutePath());
+        replace.put("{strip}", Boolean.toString(getSignatureRemoval()));
 
         return Arrays.stream(getArgs()).map(arg -> replace.getOrDefault(arg, arg)).collect(Collectors.toList());
+    }
+
+    public boolean getSignatureRemoval() {
+        return this.signatureRemoval;
+    }
+    public void setSignatureRemoval(boolean value) {
+        this.signatureRemoval = value;
     }
 
     @InputFile

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
@@ -126,6 +126,7 @@ public class Deobfuscator {
             rename.setInput(original);
             rename.setOutput(output);
             rename.setMappings(names);
+            rename.setSignatureRemoval(true);
             rename.apply();
             project.getTasks().remove(rename);
 


### PR DESCRIPTION
The presence of a signature inside a JAR prevents tampering, and so the deobfuscation process of Forge creates an effectively invalid JAR that will cause issues in various cases (e.g. when reobfuscating).
With this PR, ForgeGradle should correctly strip the signatures off of deobfuscated JARs, mitigating the above issues.

Should close MinecraftForge/ForgeGradle#636
See also MinecraftForge/InstallerTools#2

This PR is currently marked as a draft since it requires a bump to the InstallerTools dependency definition inside ForgeGradle itself.

Attempting to replicate the issue linked above gave no result: the JAR got reobfuscated correctly (checked via compiling an example mod and then decompiling it via FernFlower and CPR).