### PR TITLE
Add multithread download for downloadAssets.

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
@@ -76,7 +76,7 @@ public class DownloadAssets extends DefaultTask {
             for (String key : downloadingFailedURL) {
                 errorMessage = errorMessage + "Downloading failed Asset: " + key + "\n";
             }
-            errorMessage = errorMessage + "Don't be panic. There are just some assets downloading fails, Maybe you should try to run again the task which you just ran.";
+            errorMessage = errorMessage + "Don't panic. There are just some assets downloading fails, Maybe you should try to run again the task which you just ran.";
             throw new RuntimeException(errorMessage);
         }
     }


### PR DESCRIPTION
Downloading assets from Minecraft is always a task that needs a lot of time. However, Minecraft's assets are small and independent files that suit for multithread downloading. This PR adds the multithread downloading to `downloadAssets` task.