### PR TITLE
Add platform JVM args to data run configs, Fixes #690

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
@@ -529,7 +529,7 @@ public class RunConfig extends GroovyObjectSupport implements Serializable {
     }
 
     public boolean isClient() {
-        boolean isTargetClient = getEnvironment().getOrDefault("target", "").contains("client");
+        boolean isTargetClient = !getEnvironment().getOrDefault("target", "server").contains("server");
 
         return isTargetClient || MCP_CLIENT_MAIN.equals(getMain()) || MC_CLIENT_MAIN.equals(getMain());
     }


### PR DESCRIPTION
Data run configurations need to have the platform specific JVM arguments applied now that the early loading screen is mac compatible. This was never an issue before as none of the other platforms require specific JVM arguments for the game to not crash on startup.