### PR TITLE
Add Hash Checking for downloading Assets.

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
@@ -61,7 +61,9 @@ public class DownloadAssets extends DefaultTask {
                         getProject().getLogger().lifecycle("Downloading: " + url + " Asset: " + key);
                         FileUtils.copyURLToFile(url, target, 10_000, 5_000);
                         if (!HashFunction.SHA1.hash(target).equals(asset.hash)) {
-                            throw new IOException(key + " Hash failed.");
+                            downloadingFailedURL.add(key);
+                            Utils.delete(target);
+                            getProject().getLogger().error("{} Hash failed.", key);
                         }
                     } catch (IOException e) {
                         downloadingFailedURL.add(key);

--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
@@ -61,7 +61,7 @@ public class DownloadAssets extends DefaultTask {
                         getProject().getLogger().lifecycle("Downloading: " + url + " Asset: " + key);
                         FileUtils.copyURLToFile(url, target, 10_000, 5_000);
                         if (!HashFunction.SHA1.hash(target).equals(asset.hash)) {
-                            throw new IOException(key + " Hash dose march");
+                            throw new IOException(key + " Hash failed.");
                         }
                     } catch (IOException e) {
                         downloadingFailedURL.add(key);

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -64,6 +64,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
+import java.security.DigestInputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -631,5 +634,30 @@ public class Utils {
 
             RunConfigGenerator.createIDEGenRunsTasks(extension, prepareRuns, makeSrcDirs, additionalClientArgs);
         });
+    }
+
+    public static String sha1Code(File file) throws IOException, NoSuchAlgorithmException {
+        FileInputStream fileInputStream = new FileInputStream(file);
+        MessageDigest digest = MessageDigest.getInstance("SHA-1");
+        DigestInputStream digestInputStream = new DigestInputStream(fileInputStream, digest);
+        byte[] bytes = new byte[1024];
+        while (digestInputStream.read(bytes) > 0) ;
+
+        byte[] resultByteArry = digest.digest();
+        return bytesToHexString(resultByteArry);
+    }
+
+    private static String bytesToHexString(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) {
+            int value = b & 0xFF;
+            if (value < 16) {
+                // if value less than 16, then it's hex String will be only
+                // one character, so we need to append a character of '0'
+                sb.append("0");
+            }
+            sb.append(Integer.toHexString(value).toLowerCase());
+        }
+        return sb.toString();
     }
 }

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -64,9 +64,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.security.DigestInputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
@@ -634,30 +631,5 @@ public class Utils {
 
             RunConfigGenerator.createIDEGenRunsTasks(extension, prepareRuns, makeSrcDirs, additionalClientArgs);
         });
-    }
-
-    public static String sha1Code(File file) throws IOException, NoSuchAlgorithmException {
-        FileInputStream fileInputStream = new FileInputStream(file);
-        MessageDigest digest = MessageDigest.getInstance("SHA-1");
-        DigestInputStream digestInputStream = new DigestInputStream(fileInputStream, digest);
-        byte[] bytes = new byte[1024];
-        while (digestInputStream.read(bytes) > 0) ;
-
-        byte[] resultByteArry = digest.digest();
-        return bytesToHexString(resultByteArry);
-    }
-
-    private static String bytesToHexString(byte[] bytes) {
-        StringBuilder sb = new StringBuilder();
-        for (byte b : bytes) {
-            int value = b & 0xFF;
-            if (value < 16) {
-                // if value less than 16, then it's hex String will be only
-                // one character, so we need to append a character of '0'
-                sb.append("0");
-            }
-            sb.append(Integer.toHexString(value).toLowerCase());
-        }
-        return sb.toString();
     }
 }


### PR DESCRIPTION
In some cases, for example in Chinese stupid terrible and under censorship networks,  FG will download broken assets which will cause textures loading warnings and errors.

We should check assets hash before and after it is downloaded.