### PR TITLE
Change the resource downloading url to https.

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
@@ -40,7 +40,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 public class DownloadAssets extends DefaultTask {
-    private static final String RESOURCE_REPO = "http://resources.download.minecraft.net/";
+    private static final String RESOURCE_REPO = "https://resources.download.minecraft.net/";
     private File meta;
 
     @TaskAction


### PR DESCRIPTION
For some ISP like Chengdu Dr. Peng in China, they will cache some HTTP URLs because of lacking bandwidth. That will cause users to download assets that are out of date. Using Https could avoid ISP's cache.