### PR TITLE
Stop double build from IntelliJ run configurations (see #703)

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
@@ -169,7 +169,7 @@ public abstract class RunConfigGenerator
 
         TaskProvider<Task> prepareRun = project.getTasks().register("prepare" + Utils.capitalize(runConfig.getTaskName()), Task.class, task -> {
             task.setGroup(RunConfig.RUNS_GROUP);
-            task.dependsOn(prepareRuns, runConfig.getAllSources().stream().map(SourceSet::getClassesTaskName).toArray());
+            task.dependsOn(prepareRuns);
 
             File workDir = new File(runConfig.getWorkingDirectory());
 
@@ -180,7 +180,7 @@ public abstract class RunConfigGenerator
 
         return project.getTasks().register(runConfig.getTaskName(), JavaExec.class, task -> {
             task.setGroup(RunConfig.RUNS_GROUP);
-            task.dependsOn(prepareRun.get());
+            task.dependsOn(runConfig.getAllSources().stream().map(SourceSet::getClassesTaskName).toArray(), prepareRun.get());
 
             File workDir = new File(runConfig.getWorkingDirectory());
 


### PR DESCRIPTION
Fixes #703
I don't know how this is going to work with Eclipse and VSCode, but it seems that these also run the compiler twice before running. PLEASE VERIFY BEFORE MERGING!