### PR TITLE
Add timeout to copyURLToFile.

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
@@ -58,7 +58,7 @@ public class DownloadAssets extends DefaultTask {
                 Runnable copyURLtoFile = () -> {
                     try {
                         getProject().getLogger().lifecycle("Downloading: " + url + " Asset: " + key);
-                        FileUtils.copyURLToFile(url, target, 10_000, 5_000);
+                        FileUtils.copyURLToFile(url, target, Utils.CONNECTION_TIMEOUT, Utils.READ_TIMEOUT);
 
                     } catch (IOException e) {
                         downloadingFailedURL.add(key);

--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadMCMeta.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadMCMeta.java
@@ -20,6 +20,7 @@
 
 package net.minecraftforge.gradle.common.task;
 
+import net.minecraftforge.gradle.common.util.Utils;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
@@ -50,7 +51,7 @@ public class DownloadMCMeta extends DefaultTask {
         try (InputStream manin = new URL(MANIFEST_URL).openStream()) {
             URL url = GSON.fromJson(new InputStreamReader(manin), ManifestJson.class).getUrl(getMCVersion());
             if (url != null) {
-                FileUtils.copyURLToFile(url, getOutput());
+                FileUtils.copyURLToFile(url, getOutput(), Utils.CONNECTION_TIMEOUT, Utils.READ_TIMEOUT);
             } else {
                 throw new RuntimeException("Missing version from manifest: " + getMCVersion());
             }

--- a/src/common/java/net/minecraftforge/gradle/common/util/MinecraftRepo.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MinecraftRepo.java
@@ -152,7 +152,7 @@ public class MinecraftRepo extends BaseRepo {
         net.minecraftforge.gradle.common.util.Artifact mcp = net.minecraftforge.gradle.common.util.Artifact.from("de.oceanlabs.mcp:mcp_config:" + version + "@zip");
         File zip = cache("versions", version, "mcp.zip");
         if (!zip.exists()) {
-            FileUtils.copyURLToFile(new URL(Utils.FORGE_MAVEN + mcp.getPath()), zip);
+            FileUtils.copyURLToFile(new URL(Utils.FORGE_MAVEN + mcp.getPath()), zip, Utils.CONNECTION_TIMEOUT, Utils.READ_TIMEOUT);
             Utils.updateHash(zip);
         }
         return zip;
@@ -259,7 +259,7 @@ public class MinecraftRepo extends BaseRepo {
 
         Download dl = json.downloads.get(key);
         if (!target.exists() || !HashFunction.SHA1.hash(target).equals(dl.sha1)) {
-            FileUtils.copyURLToFile(dl.url, target);
+            FileUtils.copyURLToFile(dl.url, target, Utils.CONNECTION_TIMEOUT, Utils.READ_TIMEOUT);
             Utils.updateHash(target, HashFunction.SHA1);
         }
         return target;

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -110,6 +110,8 @@ public class Utils {
           + "REFERENCE purposes. Please avoid publishing any source code referencing these mappings. A full copy of "
           + "the license can be found at the top of the mapping file itself and in the 19w36a snapshot article at: "
           + "https://www.minecraft.net/en-us/article/minecraft-snapshot-19w36a.";
+    public static final int CONNECTION_TIMEOUT = 40_000;
+    public static final int READ_TIMEOUT = 4_000;
 
     public static void extractFile(ZipFile zip, String name, File output) throws IOException {
         extractFile(zip, zip.getEntry(name), output);
@@ -221,7 +223,7 @@ public class Utils {
                 target.getParentFile().mkdirs();
             }
 
-            FileUtils.copyURLToFile(dl.url, target);
+            FileUtils.copyURLToFile(dl.url, target, Utils.CONNECTION_TIMEOUT, Utils.READ_TIMEOUT);
         }
         return target;
     }

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractFileDownloadFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractFileDownloadFunction.java
@@ -63,7 +63,7 @@ public abstract class AbstractFileDownloadFunction implements MCPFunction {
             if (localPath.exists() && HashUtil.sha1(localPath).equals(info.hash)) {
                 FileUtils.copyFile(localPath, download);
             } else {
-                FileUtils.copyURLToFile(new URL(info.url), download);
+                FileUtils.copyURLToFile(new URL(info.url), download, Utils.CONNECTION_TIMEOUT, Utils.READ_TIMEOUT);
             }
         } else {
             FileUtils.copyURLToFile(new URL(info.url), download, Utils.CONNECTION_TIMEOUT, Utils.READ_TIMEOUT);

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractFileDownloadFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractFileDownloadFunction.java
@@ -55,7 +55,7 @@ public abstract class AbstractFileDownloadFunction implements MCPFunction {
         if (info.hash != null && output.exists() && HashUtil.sha1(output).equals(info.hash)) {
             return output; // If the hash matches, don't download again
         }
-        FileUtils.copyURLToFile(new URL(info.url), download);
+        FileUtils.copyURLToFile(new URL(info.url), download, Utils.CONNECTION_TIMEOUT, Utils.READ_TIMEOUT);
 
         if (output != download) {
             if (FileUtils.contentEquals(output, download)) {


### PR DESCRIPTION
According to [document](https://commons.apache.org/proper/commons-io/javadocs/api-2.5/src-html/org/apache/commons/io/FileUtils.html#line.1477):
> Warning: this method does not set a connection or read timeout and thus might block forever. Use {@link #copyURLToFile(URL, File, int, int)} with reasonable timeouts to prevent this.

We should use `copyURLToFile(URL, File, int, int)` instead of `copyURLToFile(URL, File)` to avoid forever blocked download.