### PR TITLE
Scan Minecraft official launcher's cache, before download Client.jar

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -632,4 +632,16 @@ public class Utils {
             RunConfigGenerator.createIDEGenRunsTasks(extension, prepareRuns, makeSrcDirs, additionalClientArgs);
         });
     }
+
+    public static String getMinecraftDict() {
+        switch (VersionJson.OS.getCurrent()) {
+            case OSX:
+                return System.getProperty("user.home") + "/Library/Application Support";
+            case WINDOWS:
+                return "";
+            case LINUX:
+                return "";
+        }
+        return "";
+    }
 }

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -636,11 +636,11 @@ public class Utils {
     public static String getMinecraftDict() {
         switch (VersionJson.OS.getCurrent()) {
             case OSX:
-                return System.getProperty("user.home") + "/Library/Application Support";
+                return System.getProperty("user.home") + "/Library/Application Support/minecraft";
             case WINDOWS:
                 return "";
             case LINUX:
-                return "";
+                return System.getProperty("user.home") + "/.minecraft";
         }
         return "";
     }

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -634,11 +634,12 @@ public class Utils {
     }
 
     public static String getMinecraftDict() {
+        //Maybe move this to static value is a better choice?
         switch (VersionJson.OS.getCurrent()) {
             case OSX:
                 return System.getProperty("user.home") + "/Library/Application Support/minecraft";
             case WINDOWS:
-                return "";
+                return System.getenv("APPDATA") + "\\.minecraft";
             case LINUX:
                 return System.getProperty("user.home") + "/.minecraft";
         }

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractDownloadMCFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractDownloadMCFunction.java
@@ -45,7 +45,8 @@ public abstract class AbstractDownloadMCFunction extends AbstractFileDownloadFun
             JsonObject artifactInfo = json.getAsJsonObject("downloads").getAsJsonObject(artifact);
             String url = artifactInfo.get("url").getAsString();
             HashValue hash = HashValue.parse(artifactInfo.get("sha1").getAsString());
-            return new DownloadInfo(url, hash);
+            String version = json.getAsJsonObject().get("id").getAsString();
+            return new DownloadInfo(url, hash, "jar", version, artifact);
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractFileDownloadFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractFileDownloadFunction.java
@@ -42,7 +42,7 @@ public abstract class AbstractFileDownloadFunction implements MCPFunction {
     }
 
     public AbstractFileDownloadFunction(String defaultOutput, String url) {
-        this(env -> defaultOutput, env -> new DownloadInfo(url, null, null, null, null));
+        this(env -> defaultOutput, env -> new DownloadInfo(url, null, "unknown", null, null));
     }
 
     @Override
@@ -56,7 +56,8 @@ public abstract class AbstractFileDownloadFunction implements MCPFunction {
         if (info.hash != null && output.exists() && HashUtil.sha1(output).equals(info.hash)) {
             return output; // If the hash matches, don't download again
         }
-        if (info.type != null && info.type.equals("jar") && info.side.equals("client")) {
+        // Before download Client.jar, we should check out official launcher's cache to avoid unnecessary download.
+        if (info.type.equals("jar") && info.side.equals("client")) {
             String cachePath = Utils.getMinecraftDict()  + File.separator + "versions" + File.separator + info.version + File.separator + info.version + ".jar";
             File cacheJar = new File(cachePath);
             if (HashUtil.sha1(cacheJar).equals(info.hash)) {
@@ -86,7 +87,7 @@ public abstract class AbstractFileDownloadFunction implements MCPFunction {
         private final String version;
         private final String side;
 
-        public DownloadInfo(String url, @Nullable HashValue hash, @Nullable String type, @Nullable String version, @Nullable String side) {
+        public DownloadInfo(String url, @Nullable HashValue hash, String type, @Nullable String version, @Nullable String side) {
             this.url = url;
             this.hash = hash;
             this.type = type;

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractFileDownloadFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractFileDownloadFunction.java
@@ -57,7 +57,7 @@ public abstract class AbstractFileDownloadFunction implements MCPFunction {
             return output; // If the hash matches, don't download again
         }
         if (info.type != null && info.type.equals("jar") && info.side.equals("client")) {
-            String cachePath = Utils.getMinecraftDict() + File.separator + "minecraft" + File.separator + "versions" + File.separator + info.version + File.separator + info.version + ".jar";
+            String cachePath = Utils.getMinecraftDict()  + File.separator + "versions" + File.separator + info.version + File.separator + info.version + ".jar";
             File cacheJar = new File(cachePath);
             if (HashUtil.sha1(cacheJar).equals(info.hash)) {
                 FileUtils.copyFile(cacheJar, download);

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/DownloadVersionJSONFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/DownloadVersionJSONFunction.java
@@ -48,7 +48,7 @@ public class DownloadVersionJSONFunction extends AbstractFileDownloadFunction {
             for (JsonElement e : json.getAsJsonArray("versions")) {
                 String v = e.getAsJsonObject().get("id").getAsString();
                 if (v.equals(environment.getMinecraftVersion().toString())) {
-                    return new DownloadInfo(e.getAsJsonObject().get("url").getAsString(), null);
+                    return new DownloadInfo(e.getAsJsonObject().get("url").getAsString(), null,"json", v, null);
                 }
             }
         } catch (IOException ex) {


### PR DESCRIPTION
This PR lets ForgeGradle scan the Official Launcher's cache before download `client.jar` to avoid unnecessarily downloading.

I have already tested it on Windows, Linux, and macOS.