### PR TITLE
Check local install for assets and client.jar. Hash all assets. Closes #684 #701 #706

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
@@ -20,6 +20,7 @@
 
 package net.minecraftforge.gradle.common.task;
 
+import net.minecraftforge.gradle.common.util.HashFunction;
 import net.minecraftforge.gradle.common.util.Utils;
 import net.minecraftforge.gradle.common.util.VersionJson;
 import org.apache.commons.io.FileUtils;
@@ -48,21 +49,32 @@ public class DownloadAssets extends DefaultTask {
         AssetIndex index = Utils.loadJson(getIndex(), AssetIndex.class);
         List<String> keys = new ArrayList<>(index.objects.keySet());
         Collections.sort(keys);
-        ExecutorService executorService = Executors.newFixedThreadPool(16);
-        CopyOnWriteArrayList<String> downloadingFailedURL = new CopyOnWriteArrayList<>();
+        File assetsPath = new File(Utils.getMCDir(), "/assets/objects");
+        ExecutorService executorService = Executors.newFixedThreadPool(8);
+        CopyOnWriteArrayList<String> failedDownloads = new CopyOnWriteArrayList<>();
         for (String key : keys) {
             Asset asset = index.objects.get(key);
             File target = Utils.getCache(getProject(), "assets", "objects", asset.getPath());
-            if (!target.exists()) {
+            if (!target.exists() || !HashFunction.SHA1.hash(target).equals(asset.hash)) {
                 URL url = new URL(RESOURCE_REPO + asset.getPath());
                 Runnable copyURLtoFile = () -> {
                     try {
-                        getProject().getLogger().lifecycle("Downloading: " + url + " Asset: " + key);
-                        FileUtils.copyURLToFile(url, target, 10_000, 5_000);
-
+                        File localFile = FileUtils.getFile(assetsPath + File.separator + asset.getPath());
+                        if (localFile.exists()) {
+                            getProject().getLogger().lifecycle("Copying local object: " + asset.getPath() + " Asset: " + key);
+                            FileUtils.copyFile(localFile, target);
+                        } else {
+                            getProject().getLogger().lifecycle("Downloading: " + url + " Asset: " + key);
+                            FileUtils.copyURLToFile(url, target, 10_000, 5_000);
+                        }
+                        if (!HashFunction.SHA1.hash(target).equals(asset.hash)) {
+                            failedDownloads.add(key);
+                            Utils.delete(target);
+                            getProject().getLogger().error("{} Hash failed.", key);
+                        }
                     } catch (IOException e) {
-                        downloadingFailedURL.add(key);
-                        getProject().getLogger().error("{} downloading fails.", key);
+                        failedDownloads.add(key);
+                        getProject().getLogger().error("{} Failed.", key);
                         e.printStackTrace();
                     }
                 };
@@ -71,12 +83,12 @@ public class DownloadAssets extends DefaultTask {
         }
         executorService.shutdown();
         executorService.awaitTermination(8, TimeUnit.HOURS);
-        if (!downloadingFailedURL.isEmpty()) {
+        if (!failedDownloads.isEmpty()) {
             String errorMessage = "";
-            for (String key : downloadingFailedURL) {
-                errorMessage = errorMessage + "Downloading failed Asset: " + key + "\n";
+            for (String key : failedDownloads) {
+                errorMessage += "Failed to get asset: " + key + "\n";
             }
-            errorMessage = errorMessage + "Don't panic. There are just some assets downloading fails, Maybe you should try to run again the task which you just ran.";
+            errorMessage += "Some assets failed to download or validate, try running the task again.";
             throw new RuntimeException(errorMessage);
         }
     }

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -632,4 +632,17 @@ public class Utils {
             RunConfigGenerator.createIDEGenRunsTasks(extension, prepareRuns, makeSrcDirs, additionalClientArgs);
         });
     }
+
+    public static File getMCDir()
+    {
+        switch (VersionJson.OS.getCurrent()) {
+            case OSX:
+                return new File(System.getProperty("user.home") + "/Library/Application Support/minecraft");
+            case WINDOWS:
+                return new File(System.getenv("APPDATA") + "\\.minecraft");
+            case LINUX:
+            default:
+                return new File(System.getProperty("user.home") + "/.minecraft");
+        }
+    }
 }

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractDownloadMCFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractDownloadMCFunction.java
@@ -45,7 +45,8 @@ public abstract class AbstractDownloadMCFunction extends AbstractFileDownloadFun
             JsonObject artifactInfo = json.getAsJsonObject("downloads").getAsJsonObject(artifact);
             String url = artifactInfo.get("url").getAsString();
             HashValue hash = HashValue.parse(artifactInfo.get("sha1").getAsString());
-            return new DownloadInfo(url, hash);
+            String version = json.getAsJsonObject().get("id").getAsString();
+            return new DownloadInfo(url, hash, "jar", version, artifact);
         } catch (IOException ex) {
             throw new RuntimeException(ex);
         }

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractFileDownloadFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractFileDownloadFunction.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.FileUtils;
 import org.gradle.internal.hash.HashUtil;
 import org.gradle.internal.hash.HashValue;
 
+import javax.annotation.Nullable;
 import java.io.File;
 import java.net.URL;
 import java.util.function.Function;
@@ -41,7 +42,7 @@ public abstract class AbstractFileDownloadFunction implements MCPFunction {
     }
 
     public AbstractFileDownloadFunction(String defaultOutput, String url) {
-        this(env -> defaultOutput, env -> new DownloadInfo(url, null));
+        this(env -> defaultOutput, env -> new DownloadInfo(url, null, "unknown", null, null));
     }
 
     @Override
@@ -55,7 +56,15 @@ public abstract class AbstractFileDownloadFunction implements MCPFunction {
         if (info.hash != null && output.exists() && HashUtil.sha1(output).equals(info.hash)) {
             return output; // If the hash matches, don't download again
         }
-        FileUtils.copyURLToFile(new URL(info.url), download);
+        // Check if file exists in local installer cache
+        if (info.type.equals("jar") && info.side.equals("client")) {
+            File localPath = new File(Utils.getMCDir() + File.separator + "versions" + File.separator + info.version + File.separator + info.version + ".jar");
+            if (HashUtil.sha1(localPath).equals(info.hash)) {
+                FileUtils.copyFile(localPath, download);
+            }
+        } else {
+            FileUtils.copyURLToFile(new URL(info.url), download);
+        }
 
         if (output != download) {
             if (FileUtils.contentEquals(output, download)) {
@@ -73,10 +82,17 @@ public abstract class AbstractFileDownloadFunction implements MCPFunction {
 
         private final String url;
         private final HashValue hash;
+        private final String type;
+        private final String version;
+        private final String side;
 
-        public DownloadInfo(String url, HashValue hash) {
+        public DownloadInfo(String url, @Nullable HashValue hash, String type, @Nullable String version, @Nullable String side) {
             this.url = url;
             this.hash = hash;
+            this.type = type;
+            this.version = version;
+            this.side = side;
+
         }
 
     }

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/DownloadVersionJSONFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/DownloadVersionJSONFunction.java
@@ -48,7 +48,7 @@ public class DownloadVersionJSONFunction extends AbstractFileDownloadFunction {
             for (JsonElement e : json.getAsJsonArray("versions")) {
                 String v = e.getAsJsonObject().get("id").getAsString();
                 if (v.equals(environment.getMinecraftVersion().toString())) {
-                    return new DownloadInfo(e.getAsJsonObject().get("url").getAsString(), null);
+                    return new DownloadInfo(e.getAsJsonObject().get("url").getAsString(), null,"json", v, null);
                 }
             }
         } catch (IOException ex) {


### PR DESCRIPTION
This PR implements #684 #701 #706, the latter two by @FledgeXu.

I fixed some typos/clarity issues and also reduced the threads for asset downloading from 16 to 8.

Testing would be appreciated.