### PR TITLE
Fix HackyCompile for Gradle 5.1

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/HackyJavaCompile.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/HackyJavaCompile.java
@@ -52,10 +52,10 @@ public class HackyJavaCompile extends JavaCompile {
         // Normally, the output history is set by Gradle. Since we're bypassing
         // the normal gradle task infrastructure, we need to do it ourselves.
 
-        // TaskExecutionHistory is removed in 5.1.0, so we only try to set it
-        // on versions below 5.1.0
+        // TaskExecutionHistory is removed in 5.1, so we only try to set it
+        // on versions below 5.1
 
-        if (GradleVersion.current().compareTo(GradleVersion.version("5.1.0")) < 0) {
+        if (GradleVersion.current().compareTo(GradleVersion.version("5.1")) < 0) {
             try {
                 Class<?> taskExectionHistory = Class.forName("org.gradle.api.internal.TaskExecutionHistory");
                 Method setHistory = this.getOutputs().getClass().getMethod("setHistory", taskExectionHistory);


### PR DESCRIPTION
This was fixed for version 5.1+, but it seems that "5.1.0" does not trigger when using Gradle version 5.1
(The compare puts "5.1" as a lower version than "5.1.0")

This pull request adresses this issue.