### PR TITLE
Fix the problem when local assets file broke, FG will  be stuck.

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
@@ -50,7 +50,7 @@ public class DownloadAssets extends DefaultTask {
         List<String> keys = new ArrayList<>(index.objects.keySet());
         Collections.sort(keys);
         File assetsPath = new File(Utils.getMCDir(), "/assets/objects");
-        ExecutorService executorService = Executors.newFixedThreadPool(8);
+        ExecutorService executorService = Executors.newFixedThreadPool(Math.min(16, Math.max(Runtime.getRuntime().availableProcessors() / 2, 1)));
         CopyOnWriteArrayList<String> failedDownloads = new CopyOnWriteArrayList<>();
         for (String key : keys) {
             Asset asset = index.objects.get(key);
@@ -60,7 +60,7 @@ public class DownloadAssets extends DefaultTask {
                 Runnable copyURLtoFile = () -> {
                     try {
                         File localFile = FileUtils.getFile(assetsPath + File.separator + asset.getPath());
-                        if (localFile.exists()) {
+                        if (localFile.exists() && HashFunction.SHA1.hash(localFile).equals(asset.hash)) {
                             getProject().getLogger().lifecycle("Copying local object: " + asset.getPath() + " Asset: " + key);
                             FileUtils.copyFile(localFile, target);
                         } else {


### PR DESCRIPTION
[Original Problem (Chinese)](https://v2mcdev.com/t/topic/825)

## There is a problem:
 1. ForgeGradle will check if the local assets exist. If these files exist, FG does not do hash checks and just uses them.
 2. Many third-party launchers will use the same local assets dictionary and they do not do hash check too when they download assets.
 3. When FG meets these broken local assets files, FG will be stuck.

The fix is easy, We just need do hash checks before copying files.

Btw, I changed the thread pools' size, Now Thread pools will automatically change according to your computer's process.