### PR TITLE
Remove deprecated method call TaskContainer.remove(Object)

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/task/JarExec.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/JarExec.java
@@ -99,7 +99,7 @@ public class JarExec extends DefaultTask {
             });
             java.exec();
         } finally {
-            getProject().getTasks().remove(java);
+            java.setEnabled(false);
         }
 
         if (hasLog)

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/ExecuteFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/ExecuteFunction.java
@@ -137,7 +137,7 @@ public class ExecuteFunction implements MCPFunction {
             java.setStandardOutput(log_out);
             java.exec();
         } finally {
-            environment.project.getTasks().remove(java);
+            java.setEnabled(false);
         }
 
         // Return the output file

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/task/TaskReobfuscateJar.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/task/TaskReobfuscateJar.java
@@ -153,7 +153,7 @@ public class TaskReobfuscateJar extends DefaultTask {
 
             output_temp.delete();
         } finally {
-            getProject().getTasks().remove(java);
+            java.setEnabled(false);
         }
     }
 

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -1296,7 +1296,7 @@ public class MinecraftUserRepo extends BaseRepo {
             e.printStackTrace();
             return null;
         } finally {
-            project.getTasks().remove(compile);
+            compile.setEnabled(false);
         }
     }
 

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
@@ -128,7 +128,7 @@ public class Deobfuscator {
             rename.setMappings(names);
             rename.setSignatureRemoval(true);
             rename.apply();
-            project.getTasks().remove(rename);
+            rename.setEnabled(false);
 
             Utils.updateHash(output, HashFunction.SHA1);
             cache.save();


### PR DESCRIPTION
According to [official Gradle docs](https://docs.gradle.org/5.0/release-notes.html) usage of `TaskContainer.remove(Object)` method is deprecated in Gradle 5.0 and starting with Gradle 6.0 is error. Preferred way to replace this method is to use `Task.setEnabled(false)`. 