### PR TITLE
Escape '$' sequences found in mapped names in McpNames.

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/McpNames.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/McpNames.java
@@ -198,8 +198,8 @@ public class McpNames {
         StringBuffer buf = new StringBuffer();
         Matcher matcher = SRG_FINDER.matcher(line);
         while (matcher.find()) {
-            // Since '$' is a valid character in identifiers, but we need to NOT treat this as a regex group, escape any occurances
-            matcher.appendReplacement(buf, getMapped(Pattern.quote(matcher.group())));
+            // Since '$' is a valid character in identifiers, but we need to NOT treat this as a regex group, escape any occurrences
+            matcher.appendReplacement(buf, Matcher.quoteReplacement(getMapped(matcher.group())));
         }
         matcher.appendTail(buf);
         return buf.toString();

--- a/src/common/java/net/minecraftforge/gradle/common/util/McpNames.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/McpNames.java
@@ -197,8 +197,10 @@ public class McpNames {
     private String replaceInLine(String line) {
         StringBuffer buf = new StringBuffer();
         Matcher matcher = SRG_FINDER.matcher(line);
-        while (matcher.find())
-            matcher.appendReplacement(buf, getMapped(matcher.group()));
+        while (matcher.find()) {
+            // Since '$' is a valid character in identifiers, but we need to NOT treat this as a regex group, escape any occurances
+            matcher.appendReplacement(buf, getMapped(matcher.group()).replace("$", "\\$"));
+        }
         matcher.appendTail(buf);
         return buf.toString();
     }

--- a/src/common/java/net/minecraftforge/gradle/common/util/McpNames.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/McpNames.java
@@ -199,7 +199,7 @@ public class McpNames {
         Matcher matcher = SRG_FINDER.matcher(line);
         while (matcher.find()) {
             // Since '$' is a valid character in identifiers, but we need to NOT treat this as a regex group, escape any occurances
-            matcher.appendReplacement(buf, getMapped(matcher.group()).replace("$", "\\$"));
+            matcher.appendReplacement(buf, getMapped(Pattern.quote(matcher.group())));
         }
         matcher.appendTail(buf);
         return buf.toString();


### PR DESCRIPTION
PR as requested.

Fixes #720.