### PR TITLE
Some "working" Gradle 6 support

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/task/JarExec.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/JarExec.java
@@ -42,6 +42,7 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 
 import net.minecraftforge.gradle.common.util.MavenArtifactDownloader;
+import org.gradle.util.GradleVersion;
 
 public class JarExec extends DefaultTask {
     private static final OutputStream NULL = new OutputStream() { @Override public void write(int b) throws IOException { } };
@@ -99,7 +100,11 @@ public class JarExec extends DefaultTask {
             });
             java.exec();
         } finally {
-            getProject().getTasks().remove(java);
+            if (GradleVersion.current().compareTo(GradleVersion.version("6.0.0")) >= 0) {
+                java.setEnabled(false);
+            } else {
+                getProject().getTasks().remove(java);
+            }
         }
 
         if (hasLog)

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/ExecuteFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/ExecuteFunction.java
@@ -35,7 +35,9 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -48,6 +50,7 @@ import java.util.zip.ZipFile;
 public class ExecuteFunction implements MCPFunction {
 
     private static final Pattern REPLACE_PATTERN = Pattern.compile("^\\{(\\w+)\\}$");
+    private static final AtomicInteger counter = new AtomicInteger(1);
 
     protected final File jar;
     protected final String[] jvmArgs;
@@ -120,7 +123,7 @@ public class ExecuteFunction implements MCPFunction {
         jarFile.close();
 
         // Execute command
-        JavaExec java = environment.project.getTasks().create("_", JavaExec.class);
+        JavaExec java = environment.project.getTasks().create("_decompileJar" + new Random().nextInt(), JavaExec.class);
         try (BufferedOutputStream log_out = new BufferedOutputStream(new FileOutputStream(environment.getFile("console.log")))) {
             PrintWriter writer = new PrintWriter(log_out);
             Function<String,String> quote = s -> '"' + s + '"';

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/ExecuteFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/ExecuteFunction.java
@@ -24,6 +24,7 @@ import net.minecraftforge.gradle.common.util.HashStore;
 import net.minecraftforge.gradle.common.util.Utils;
 import net.minecraftforge.gradle.mcp.util.MCPEnvironment;
 import org.gradle.api.tasks.JavaExec;
+import org.gradle.util.GradleVersion;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -137,7 +138,11 @@ public class ExecuteFunction implements MCPFunction {
             java.setStandardOutput(log_out);
             java.exec();
         } finally {
-            environment.project.getTasks().remove(java);
+            if (GradleVersion.current().compareTo(GradleVersion.version("6.0.0")) >= 0) {
+                java.setEnabled(false);
+            } else {
+                environment.project.getTasks().remove(java);
+            }
         }
 
         // Return the output file

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/task/TaskReobfuscateJar.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/task/TaskReobfuscateJar.java
@@ -35,6 +35,7 @@ import com.google.common.io.Files;
 
 import net.minecraftforge.gradle.common.util.MavenArtifactDownloader;
 import net.minecraftforge.gradle.common.util.Utils;
+import org.gradle.util.GradleVersion;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -153,7 +154,11 @@ public class TaskReobfuscateJar extends DefaultTask {
 
             output_temp.delete();
         } finally {
-            getProject().getTasks().remove(java);
+            if (GradleVersion.current().compareTo(GradleVersion.version("6.0.0")) >= 0) {
+                java.setEnabled(false);
+            } else {
+                getProject().getTasks().remove(java);
+            }
         }
     }
 

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/task/TaskReobfuscateJar.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/task/TaskReobfuscateJar.java
@@ -49,6 +49,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
@@ -94,7 +95,7 @@ public class TaskReobfuscateJar extends DefaultTask {
             workDir.mkdirs();
         }
 
-        JavaExec java = getProject().getTasks().create("_", JavaExec.class);
+        JavaExec java = getProject().getTasks().create("_reobfuscateJar_" + getName() + new Random().nextInt(), JavaExec.class);
         try (OutputStream log = new BufferedOutputStream(new FileOutputStream(new File(workDir, "log.txt")))) {
             // Execute command
             java.setArgs(_args);

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -72,6 +72,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.plugins.ExtraPropertiesExtension;
 import org.gradle.api.plugins.JavaPluginConvention;
+import org.gradle.util.GradleVersion;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -1296,7 +1297,11 @@ public class MinecraftUserRepo extends BaseRepo {
             e.printStackTrace();
             return null;
         } finally {
-            project.getTasks().remove(compile);
+            if (GradleVersion.current().compareTo(GradleVersion.version("6.0.0")) >= 0) {
+                compile.setEnabled(false);
+            } else {
+                project.getTasks().remove(compile);
+            }
         }
     }
 

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/HackyJavaCompile.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/HackyJavaCompile.java
@@ -21,18 +21,27 @@
 package net.minecraftforge.gradle.userdev.tasks;
 
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.internal.TaskOutputsInternal;
 import org.gradle.api.internal.tasks.compile.CleaningJavaCompiler;
 import org.gradle.api.internal.tasks.compile.DefaultJavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.compile.JavaCompile;
+import org.gradle.internal.nativeintegration.filesystem.FileSystem;
+import org.gradle.internal.os.OperatingSystem;
+import org.gradle.internal.time.Clock;
+import org.gradle.internal.time.Time;
 import org.gradle.jvm.internal.toolchain.JavaToolChainInternal;
 import org.gradle.language.base.internal.compile.Compiler;
 import org.gradle.language.base.internal.compile.CompilerUtil;
 import org.gradle.util.GradleVersion;
 
+import java.io.File;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.function.LongSupplier;
+import java.util.function.Predicate;
 
 // A terrible hack to use JavaCompile while bypassing
 // Gradle's normal task infrastructure.
@@ -86,7 +95,30 @@ public class HackyJavaCompile extends JavaCompile {
                 }
                 spec.setSourceFiles(getSource());
                 Compiler<JavaCompileSpec> javaCompiler = CompilerUtil.castCompiler(((JavaToolChainInternal) getToolChain()).select(getPlatform()).newCompiler(spec.getClass()));
-                CleaningJavaCompiler compiler = new CleaningJavaCompiler(javaCompiler, getOutputs());
+                final CleaningJavaCompiler compiler;
+                if (GradleVersion.current().compareTo(GradleVersion.version("6.0.0")) >= 0) {
+                    // Welcome to Gradle, we sell Hacks and Hack Accessories
+                    final Class<?> deleterInterface = Class.forName("org.gradle.internal.file.Deleter");
+                    final Constructor<CleaningJavaCompiler> constructor = CleaningJavaCompiler.class.getConstructor(Compiler.class, TaskOutputsInternal.class, deleterInterface);
+                    final Class<?> defaultDeleterClazz = Class.forName("org.gradle.internal.file.impl.DefaultDeleter");
+                    final Constructor<?> defaultDeleterCtor = defaultDeleterClazz.getConstructor(LongSupplier.class,
+                        Predicate.class, Boolean.TYPE);
+                    final Clock clock = Time.clock();
+                    final LongSupplier timeProvider = clock::getCurrentTime;
+                    final FileSystem fileSystem;
+                    try {
+                        final Class<?> fileSystemClass = Class.forName("org.gradle.internal.nativeintegration.services.FileSystems");
+                        final Method getDefaultFileSystem = fileSystemClass.getMethod("getDefault");
+                        fileSystem = (FileSystem) getDefaultFileSystem.invoke(null);
+                    } catch (IllegalAccessException | IllegalArgumentException | Error | InvocationTargetException | NoSuchMethodException | ClassNotFoundException e) {
+                        throw new UnsupportedOperationException("Could not get the Gradle FileSystem object", e);
+                    }
+                    final Predicate<? super File> isSymLink = fileSystem::isSymlink;
+                    final Object deleter = defaultDeleterCtor.newInstance(timeProvider, isSymLink, OperatingSystem.current().isWindows());
+                    compiler = constructor.newInstance(javaCompiler, getOutputs(), deleter);
+                } else {
+                    compiler = new CleaningJavaCompiler(javaCompiler, getOutputs());
+                }
                 final WorkResult execute = compiler.execute(spec);
                 setDidWork(execute.getDidWork());
             } catch (Exception e) {

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
@@ -26,6 +26,7 @@ import net.minecraftforge.gradle.userdev.tasks.RenameJarSrg2Mcp;
 
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.Project;
+import org.gradle.util.GradleVersion;
 import org.w3c.dom.Document;
 import org.w3c.dom.NodeList;
 import org.xml.sax.SAXException;
@@ -128,7 +129,11 @@ public class Deobfuscator {
             rename.setMappings(names);
             rename.setSignatureRemoval(true);
             rename.apply();
-            project.getTasks().remove(rename);
+            if (GradleVersion.current().compareTo(GradleVersion.version("6.0.0")) >= 0) {
+                rename.setEnabled(false);
+            } else {
+                project.getTasks().remove(rename);
+            }
 
             Utils.updateHash(output, HashFunction.SHA1);
             cache.save();


### PR DESCRIPTION
[Artifactural](https://github.com/MinecraftForge/Artifactural/pull/2) | **ForgeGradle**

This adds on some hackiness to bridge support for Gradle 6.x where changes to Gradle are referenced in the commit adding the workarounds. This still functions in Gradle 4.9/5.x, but specifically does allow for Gradle 6.x to start resolving the project.

There is an odd effect that `net.minecraft:mappings-snapshot:<version>_<at>` is not being resolved correctly, but as that is a resolution issue on the IDE (IntelliJ), it does not appear to affect dependency building and project management any other way. When I get to being able to put more time into that, I will. For now, this just focuses on getting FG to work with newer versions of Gradle where feasible.

Please note that *Artifactural* is needing an update as well, and is linked above for its own changes (since it extends internal gradle repository interfaces that have changed in Gradle 6).