### PR TITLE
Added fg.deobf source-loading support

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/DependencyManagementExtension.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/DependencyManagementExtension.java
@@ -41,9 +41,25 @@ public class DependencyManagementExtension extends GroovyObjectSupport {
         return deobf(dependency, null);
     }
 
-    public Dependency deobf(Object dependency, Closure<?> configure){
+    public Dependency deobf(Object dependency, Closure<?> configure) {
+        return deobf(dependency, false, configure);
+    }
+
+    @SuppressWarnings("unused")
+    public Dependency deobf(Object dependency, boolean requestSources) {
+        return deobf(dependency, requestSources, null);
+    }
+
+    public Dependency deobf(Object dependency, boolean requestSources, Closure<?> configure) {
         Dependency baseDependency = project.getDependencies().create(dependency, configure);
         project.getConfigurations().getByName(UserDevPlugin.OBF).getDependencies().add(baseDependency);
+
+        if (requestSources) {
+            project.getLogger().debug("Requested to load sources for dependency {}", dependency);
+
+            Dependency sourceDependency = project.getDependencies().create(baseDependency.getGroup() + ":" + baseDependency.getName() + ":" + baseDependency.getVersion() + ":sources", configure);
+            project.getConfigurations().getByName(UserDevPlugin.OBF).getDependencies().add(sourceDependency);
+        }
 
         return remapper.remap(baseDependency);
     }

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/util/DeobfuscatingRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/util/DeobfuscatingRepo.java
@@ -21,9 +21,15 @@
 package net.minecraftforge.gradle.userdev.util;
 
 import com.amadornes.artifactural.api.artifact.ArtifactIdentifier;
-import net.minecraftforge.gradle.common.util.*;
+import net.minecraftforge.gradle.common.util.Artifact;
+import net.minecraftforge.gradle.common.util.BaseRepo;
+import net.minecraftforge.gradle.common.util.Utils;
 import org.gradle.api.Project;
-import org.gradle.api.artifacts.*;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ResolvedArtifact;
+import org.gradle.api.artifacts.ResolvedConfiguration;
+import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.internal.resolve.ArtifactNotFoundException;
 
 import java.io.File;
 import java.io.IOException;
@@ -126,7 +132,15 @@ public class DeobfuscatingRepo extends BaseRepo {
     }
 
     private File findSource(Artifact artifact, String mapping) throws IOException {
-        Optional<File> orig = findArtifactFile(artifact);
+        Optional<File> orig;
+
+        try {
+            orig = findArtifactFile(artifact);
+        } catch (ArtifactNotFoundException e) {
+            // Missing sources aren't important, ignore
+            return null;
+        }
+
         if (!orig.isPresent()) {
             return null;
         }

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
@@ -23,7 +23,6 @@ package net.minecraftforge.gradle.userdev.util;
 import net.minecraftforge.gradle.common.util.*;
 import net.minecraftforge.gradle.mcp.MCPRepo;
 import net.minecraftforge.gradle.userdev.tasks.RenameJarSrg2Mcp;
-
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.Project;
 import org.w3c.dom.Document;
@@ -157,7 +156,7 @@ public class Deobfuscator {
         if (!cache.isSame() || !output.exists()) {
             McpNames map = McpNames.load(names);
 
-            try (ZipInputStream zin = new ZipInputStream(new FileInputStream(input));
+            try (ZipInputStream zin = new ZipInputStream(new FileInputStream(original));
                  ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(output))) {
                 ZipEntry _old;
                 while ((_old = zin.getNextEntry()) != null) {


### PR DESCRIPTION
* Based on tterrag works
fg.deobf now provides boolean parameter, which represents if sources should be also loaded (actually, it just _tries_ to be loaded). By default it is set to false, so it wouldn't be able to break something.
Tested with the dependencies from reports in discord, which have led to reverting tterrag's commit. No errors found.