### PR TITLE
Fix corruption of Unicode characters on Windows systems

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'org.ajoberstar.grgit' version '3.0.0'
     id 'com.github.ben-manes.versions' version '0.20.0'
   //id 'com.github.johnrengelman.shadow' version '2.0.4'
+    id 'de.thetaphi.forbiddenapis' version '3.1'
 }
 
 apply plugin: 'java'
@@ -128,4 +129,10 @@ publishing {
             }
         }
     }
+}
+
+forbiddenApis {
+    // Would add 'jdk-reflection' too but HackyJavaCompile currently requires it.
+    bundledSignatures = [ 'jdk-unsafe', 'jdk-deprecated', 'jdk-non-portable', 'commons-io-unsafe-2.4' ]
+    ignoreFailures = false
 }

--- a/src/common/java/net/minecraftforge/gradle/common/config/Config.java
+++ b/src/common/java/net/minecraftforge/gradle/common/config/Config.java
@@ -24,6 +24,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 
 import net.minecraftforge.gradle.common.util.Utils;
 
@@ -31,7 +32,7 @@ public class Config {
     public int spec;
 
     public static int getSpec(InputStream stream) throws IOException {
-        return Utils.GSON.fromJson(new InputStreamReader(stream), Config.class).spec;
+        return Utils.GSON.fromJson(new InputStreamReader(stream, StandardCharsets.UTF_8), Config.class).spec;
     }
     public static int getSpec(byte[] data) throws IOException {
         return getSpec(new ByteArrayInputStream(data));

--- a/src/common/java/net/minecraftforge/gradle/common/diff/ContextualPatch.java
+++ b/src/common/java/net/minecraftforge/gradle/common/diff/ContextualPatch.java
@@ -57,6 +57,7 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -155,7 +156,7 @@ public final class ContextualPatch {
     }
 
     private void init() throws IOException {
-        patchReader = new BufferedReader(new InputStreamReader(patchFile.openStream()));
+        patchReader = new BufferedReader(new InputStreamReader(patchFile.openStream(), StandardCharsets.UTF_8));
         if (!patchFile.requiresFurtherProcessing()) return;
         String encoding = "ISO-8859-1";
         String line = patchReader.readLine();

--- a/src/common/java/net/minecraftforge/gradle/common/diff/LocalContext.java
+++ b/src/common/java/net/minecraftforge/gradle/common/diff/LocalContext.java
@@ -3,6 +3,7 @@ package net.minecraftforge.gradle.common.diff;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 class LocalContext implements PatchContextProvider {
@@ -29,7 +30,7 @@ class LocalContext implements PatchContextProvider {
     @Override
     public void setFailed(ContextualPatch.SinglePatch patch, List<String> lines) throws IOException {
         if (lines.isEmpty()) return;
-        try (PrintWriter p = new PrintWriter(new FileOutputStream(patch.targetFile + ".rej"))) {
+        try (PrintWriter p = new PrintWriter(patch.targetFile + ".rej", StandardCharsets.UTF_8.name())) {
             for (String line : lines) {
                 p.println(line);
             }

--- a/src/common/java/net/minecraftforge/gradle/common/task/ArchiveChecksum.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/ArchiveChecksum.java
@@ -29,12 +29,8 @@ import com.google.common.collect.Maps;
 import com.google.common.hash.Hashing;
 import com.google.common.hash.HashingInputStream;
 
-import java.io.BufferedWriter;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 import java.util.Map;
 import java.util.function.Supplier;
@@ -88,7 +84,7 @@ public class ArchiveChecksum extends DefaultTask {
             }
         }
 
-        try(PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(getOutput())))) {
+        try(PrintWriter out = new PrintWriter(getOutput(), StandardCharsets.UTF_8.name())) {
             checksums.forEach((name, hash) -> {
                 out.write(hash);
                 out.write(' ');

--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadMCMeta.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadMCMeta.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 public class DownloadMCMeta extends DefaultTask {
     private static final String MANIFEST_URL = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
@@ -48,7 +49,7 @@ public class DownloadMCMeta extends DefaultTask {
     @TaskAction
     public void downloadMCMeta() throws IOException {
         try (InputStream manin = new URL(MANIFEST_URL).openStream()) {
-            URL url = GSON.fromJson(new InputStreamReader(manin), ManifestJson.class).getUrl(getMCVersion());
+            URL url = GSON.fromJson(new InputStreamReader(manin, StandardCharsets.UTF_8), ManifestJson.class).getUrl(getMCVersion());
             if (url != null) {
                 FileUtils.copyURLToFile(url, getOutput());
             } else {

--- a/src/common/java/net/minecraftforge/gradle/common/task/ExtractMCPData.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/ExtractMCPData.java
@@ -25,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.function.Supplier;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -60,7 +61,8 @@ public class ExtractMCPData extends DefaultTask {
             }
             int spec = Config.getSpec(zip.getInputStream(entry));
             if (spec == 1) {
-                MCPConfigV1 cfg = GSON.fromJson(new InputStreamReader(zip.getInputStream(entry)), MCPConfigV1.class);
+                MCPConfigV1 cfg = GSON.fromJson(
+                        new InputStreamReader(zip.getInputStream(entry), StandardCharsets.UTF_8), MCPConfigV1.class);
                 String path = cfg.getData(key.split("/"));
                 if (path == null && "statics".equals(key)) { //TODO: Remove when I next push MCPConfig
                     path = "config/static_methods.txt";

--- a/src/common/java/net/minecraftforge/gradle/common/task/JarExec.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/JarExec.java
@@ -20,18 +20,17 @@
 
 package net.minecraftforge.gradle.common.task;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintWriter;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import java.util.jar.Attributes;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
 
+import com.google.common.io.CharStreams;
+import com.google.common.io.Files;
+import org.apache.commons.io.output.NullWriter;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Input;
@@ -71,7 +70,7 @@ public class JarExec extends DefaultTask {
 
         JavaExec java = getProject().getTasks().create("_java_exec_" + index++ + "_", JavaExec.class);
         try (OutputStream log = hasLog ? new BufferedOutputStream(new FileOutputStream(logFile)) : NULL) {
-            PrintWriter printer = new PrintWriter(log, true);
+            PrintWriter printer = new PrintWriter(new OutputStreamWriter(log, StandardCharsets.UTF_8), true);
             // Execute command
             java.setArgs(filterArgs());
             printer.println("Args: " + java.getArgs().stream().map(m -> '"' + m +'"').collect(Collectors.joining(", ")));

--- a/src/common/java/net/minecraftforge/gradle/common/util/HashFunction.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/HashFunction.java
@@ -43,7 +43,7 @@ public enum HashFunction {
 
     private HashFunction(String algo, int length) {
         this.algo = algo;
-        this.pad = String.format("%0" + length + "d", 0);
+        this.pad = String.format(Locale.ROOT, "%0" + length + "d", 0);
     }
 
     public String getExtension() {

--- a/src/common/java/net/minecraftforge/gradle/common/util/HashStore.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/HashStore.java
@@ -26,6 +26,7 @@ import org.gradle.internal.hash.HashUtil;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -88,7 +89,7 @@ public class HashStore {
         this.target = file;
         oldHashes.clear();
         if(!file.exists()) return this;
-        for (String line : FileUtils.readLines(file)) {
+        for (String line : FileUtils.readLines(file, StandardCharsets.UTF_8)) {
             String[] split = line.split("=");
             oldHashes.put(split[0], split[1]);
         }
@@ -153,7 +154,10 @@ public class HashStore {
         save(target);
     }
     public void save(File file) throws IOException {
-        FileUtils.writeByteArrayToFile(file, newHashes.entrySet().stream().map(e -> e.getKey() + "=" + e.getValue()).collect(Collectors.joining("\n")).getBytes());
+        FileUtils.writeByteArrayToFile(file, newHashes.entrySet().stream()
+                .map(e -> e.getKey() + "=" + e.getValue())
+                .collect(Collectors.joining("\n"))
+                .getBytes(StandardCharsets.UTF_8));
     }
 
     private String getPath(File file) {

--- a/src/common/java/net/minecraftforge/gradle/common/util/JavaVersionParser.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/JavaVersionParser.java
@@ -21,6 +21,7 @@ import com.google.common.primitives.Ints;
 
 import javax.annotation.Nullable;
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -42,7 +43,7 @@ public class JavaVersionParser {
     private static String UPDATE_NUMBER_PATTERN = "\\d+";
 
     // Forge: Changed to make only one part required, OpenJDK publishes a version with just '9'
-    private static Pattern VERSION_REGEX = Pattern.compile(String.format("(%s)(?:\\.(%s)\\.(%s))?(?:_(%s))?.*",
+    private static Pattern VERSION_REGEX = Pattern.compile(String.format(Locale.ROOT, "(%s)(?:\\.(%s)\\.(%s))?(?:_(%s))?.*",
             MAJOR_VERSION_FAMILY_PATTERN, MAJOR_VERSION_PATTERN, MAINTENANCE_NUMBER_PATTERN, UPDATE_NUMBER_PATTERN));
 
     private static final JavaVersion currentJavaVersion = parseJavaVersion(System.getProperty(JAVA_VERSION_PROPERTY));
@@ -147,7 +148,7 @@ public class JavaVersionParser {
          * @return Major version string if available. Examples include '1.6', '1.7', '1.8'
          */
         public String getMajorVersionString() {
-            return String.format("%d.%d", this.majorVersionFamily, this.majorVersion);
+            return String.format(Locale.ROOT, "%d.%d", this.majorVersionFamily, this.majorVersion);
         }
 
         /**

--- a/src/common/java/net/minecraftforge/gradle/common/util/MappingFile.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MappingFile.java
@@ -25,12 +25,8 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -45,7 +41,7 @@ public class MappingFile {
         SRG, CSRG, TSRG, PG;
         public static Format get(String value) {
             try {
-                return Format.valueOf(value.toUpperCase());
+                return Format.valueOf(value.toUpperCase(Locale.ROOT));
             } catch (IllegalArgumentException e) {
                 return null;
             }
@@ -62,7 +58,10 @@ public class MappingFile {
     }
     public static MappingFile load(InputStream input) throws IOException {
         MappingFile ret = new MappingFile();
-        List<String> lines = IOUtils.readLines(input).stream().map(line -> (line + '#').split("#")[0].replaceFirst("\\s++$", "")).filter(l -> !l.isEmpty()).collect(Collectors.toList());
+        List<String> lines = IOUtils.readLines(input, StandardCharsets.UTF_8).stream()
+                .map(line -> (line + '#').split("#")[0].replaceFirst("\\s++$", ""))
+                .filter(l -> !l.isEmpty())
+                .collect(Collectors.toList());
         String firstLine = lines.get(0);
         String test = firstLine.split(" ")[0];
         if ("PK:".equals(test) || "CL:".equals(test) || "FD:".equals(test) || "MD:".equals(test)) { //SRG
@@ -212,7 +211,7 @@ public class MappingFile {
 
         try (FileOutputStream out = new FileOutputStream(file)){
             for (String line : lines) {
-                out.write(line.getBytes());
+                out.write(line.getBytes(StandardCharsets.UTF_8));
                 out.write('\n');
             }
         }

--- a/src/common/java/net/minecraftforge/gradle/common/util/McpNames.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/McpNames.java
@@ -70,7 +70,7 @@ public class McpNames {
             for (ZipEntry entry : entries) {
                 CsvReader reader = new CsvReader();
                 reader.setContainsHeader(true);
-                CsvContainer csv = reader.read(new InputStreamReader(zip.getInputStream(entry)));
+                CsvContainer csv = reader.read(new InputStreamReader(zip.getInputStream(entry), StandardCharsets.UTF_8));
                 for (CsvRow row : csv.getRows()) {
                     String searge = row.getField("searge");
                     if (searge == null)

--- a/src/common/java/net/minecraftforge/gradle/common/util/MinecraftRepo.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MinecraftRepo.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
@@ -236,7 +237,7 @@ public class MinecraftRepo extends BaseRepo {
             if (ret == null) {
                 return null;
             }
-            FileUtils.writeByteArrayToFile(pom, ret.getBytes());
+            FileUtils.writeByteArrayToFile(pom, ret.getBytes(StandardCharsets.UTF_8));
             cache.save();
             Utils.updateHash(pom);
         }

--- a/src/common/java/net/minecraftforge/gradle/common/util/POMBuilder.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/POMBuilder.java
@@ -34,6 +34,8 @@ import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -127,11 +129,11 @@ public class POMBuilder {
         transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
         DOMSource source = new DOMSource(doc);
 
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        StreamResult result = new StreamResult(baos);
+        StringWriter writer = new StringWriter();
+        StreamResult result = new StreamResult(writer);
         transformer.transform(source, result);
 
-        return new String(baos.toByteArray());
+        return writer.toString();
     }
 
     private static void set(Document doc, Element parent, String name, String value) {

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -20,12 +20,7 @@
 
 package net.minecraftforge.gradle.common.util;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonIOException;
-import com.google.gson.JsonSyntaxException;
+import com.google.gson.*;
 
 import groovy.lang.Closure;
 import net.minecraftforge.gradle.common.config.MCPConfigV1;
@@ -64,17 +59,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.TimeZone;
+import java.util.*;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -226,13 +211,16 @@ public class Utils {
         return target;
     }
 
+    public static JsonObject loadJson(File target) throws IOException {
+        return loadJson(target, JsonObject.class);
+    }
     public static <T> T loadJson(File target, Class<T> clz) throws IOException {
         try (InputStream in = new FileInputStream(target)) {
-            return GSON.fromJson(new InputStreamReader(in), clz);
+            return GSON.fromJson(new InputStreamReader(in, StandardCharsets.UTF_8), clz);
         }
     }
     public static <T> T loadJson(InputStream in, Class<T> clz) throws IOException {
-        return GSON.fromJson(new InputStreamReader(in), clz);
+        return GSON.fromJson(new InputStreamReader(in, StandardCharsets.UTF_8), clz);
     }
 
     public static void updateHash(File target) throws IOException {
@@ -243,7 +231,7 @@ public class Utils {
             File cache = new File(target.getAbsolutePath() + "." + function.getExtension());
             if (target.exists()) {
                 String hash = function.hash(target);
-                Files.write(cache.toPath(), hash.getBytes());
+                Files.write(cache.toPath(), hash.getBytes(StandardCharsets.UTF_8));
             } else if (cache.exists()) {
                 cache.delete();
             }
@@ -321,12 +309,11 @@ public class Utils {
         }
     }
 
-
     public static <T> T fromJson(InputStream stream, Class<T> classOfT) throws JsonSyntaxException, JsonIOException {
-        return GSON.fromJson(new InputStreamReader(stream), classOfT);
+        return GSON.fromJson(new InputStreamReader(stream, StandardCharsets.UTF_8), classOfT);
     }
     public static <T> T fromJson(byte[] data, Class<T> classOfT) throws JsonSyntaxException, JsonIOException {
-        return GSON.fromJson(new InputStreamReader(new ByteArrayInputStream(data)), classOfT);
+        return GSON.fromJson(new InputStreamReader(new ByteArrayInputStream(data), StandardCharsets.UTF_8), classOfT);
     }
 
     public static boolean downloadEtag(URL url, File output, boolean offline) throws IOException {
@@ -382,7 +369,7 @@ public class Utils {
     }
 
     public static boolean downloadFile(URL url, File output, boolean deleteOn404) {
-        String proto = url.getProtocol().toLowerCase();
+        String proto = url.getProtocol().toLowerCase(Locale.ROOT);
 
         try {
             if ("http".equals(proto) || "https".equals(proto)) {
@@ -437,7 +424,7 @@ public class Utils {
     }
 
     public static String downloadString(URL url) throws IOException {
-        String proto = url.getProtocol().toLowerCase();
+        String proto = url.getProtocol().toLowerCase(Locale.ROOT);
 
         if ("http".equals(proto) || "https".equals(proto)) {
             HttpURLConnection con = connectHttpWithRedirects(url);
@@ -497,15 +484,17 @@ public class Utils {
 
     @Nonnull
     public static final String capitalize(@Nonnull final String toCapitalize) {
-        return toCapitalize.length() > 1 ? toCapitalize.substring(0, 1).toUpperCase() + toCapitalize.substring(1) : toCapitalize;
+        return toCapitalize.length() > 1 ?
+                toCapitalize.substring(0, 1).toUpperCase(Locale.ROOT) + toCapitalize.substring(1) :
+                toCapitalize;
     }
 
     public static void checkJavaRange( @Nullable JavaVersionParser.JavaVersion minVersionInclusive, @Nullable JavaVersionParser.JavaVersion maxVersionExclusive) {
         JavaVersionParser.JavaVersion currentJavaVersion = JavaVersionParser.getCurrentJavaVersion();
         if (minVersionInclusive != null && currentJavaVersion.compareTo(minVersionInclusive) < 0)
-            throw new RuntimeException(String.format("Found java version %s. Minimum required is %s.", currentJavaVersion, minVersionInclusive));
+            throw new RuntimeException(String.format(Locale.ROOT, "Found java version %s. Minimum required is %s.", currentJavaVersion, minVersionInclusive));
         if (maxVersionExclusive != null && currentJavaVersion.compareTo(maxVersionExclusive) >= 0)
-            throw new RuntimeException(String.format("Found java version %s. Versions %s and newer are not supported yet.", currentJavaVersion, maxVersionExclusive));
+            throw new RuntimeException(String.format(Locale.ROOT, "Found java version %s. Versions %s and newer are not supported yet.", currentJavaVersion, maxVersionExclusive));
     }
 
     public static void checkJavaVersion() {
@@ -530,7 +519,7 @@ public class Utils {
             conn.connect();
             conn.getResponseCode();
         } catch (SSLException e) {
-            throw new RuntimeException(String.format("Failed to validate certificate for %s, Most likely cause is an outdated JDK. Try updating at https://adoptopenjdk.net/ " +
+            throw new RuntimeException(String.format(Locale.ROOT, "Failed to validate certificate for %s, Most likely cause is an outdated JDK. Try updating at https://adoptopenjdk.net/ " +
                     "To disable this check re-run with -Dnet.minecraftforge.gradle.test_certs=false", url), e);
         } catch (IOException e) {
             //Normal connection failed, not the point of this test so ignore

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
@@ -49,10 +49,8 @@ import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.*;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
-import java.io.File;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.Writer;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -241,7 +239,7 @@ public abstract class RunConfigGenerator
     {
         final Stream<String> propStream = Stream.concat(
                 runConfig.getProperties().entrySet().stream()
-                    .map(kv -> String.format("-D%s=%s", kv.getKey(), runConfig.replace(updatedTokens, kv.getValue()))),
+                    .map(kv -> String.format(Locale.ROOT, "-D%s=%s", kv.getKey(), runConfig.replace(updatedTokens, kv.getValue()))),
                 runConfig.getJvmArgs().stream()).map(RunConfigGenerator::fixupArg);
         if (runConfig.isClient()) {
             return Stream.concat(propStream, additionalClientArgs.stream());
@@ -299,12 +297,9 @@ public abstract class RunConfigGenerator
                 runConfigs.add(createRunConfiguration(project, runConfig, additionalClientArgs));
             });
             rootObject.add("configurations", runConfigs);
-            Writer writer;
-            try {
-                writer = new FileWriter(new File(runConfigurationsDir, "launch.json"));
+            try(Writer writer = new PrintWriter(new File(runConfigurationsDir, "launch.json"),StandardCharsets.UTF_8.name())) {
                 Gson gson = new GsonBuilder().setPrettyPrinting().create();
-                writer.write(gson.toJson(rootObject));
-                writer.close();
+                gson.toJson(rootObject, writer);
             } catch (IOException e) {
                 e.printStackTrace();
             }

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/MCPRepo.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/MCPRepo.java
@@ -54,11 +54,8 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 import java.util.zip.ZipOutputStream;
 
 /**
@@ -272,7 +269,7 @@ public class MCPRepo extends BaseRepo {
             String ret = builder.tryBuild();
             if (ret == null)
                 return null;
-            FileUtils.writeByteArrayToFile(pom, ret.getBytes());
+            FileUtils.writeByteArrayToFile(pom, ret.getBytes(StandardCharsets.UTF_8));
             cache.save();
             Utils.updateHash(pom, HashFunction.SHA1);
         }
@@ -330,7 +327,7 @@ public class MCPRepo extends BaseRepo {
     }
 
     private File findRenames(String classifier, MappingFile.Format format, String version, boolean toObf) throws IOException {
-        String ext = format.name().toLowerCase();
+        String ext = format.name().toLowerCase(Locale.ROOT);
         //File names = findNames(version));
         File mcp = getMCP(version);
         if (mcp == null)
@@ -381,7 +378,7 @@ public class MCPRepo extends BaseRepo {
 
     @SuppressWarnings("unused")
     private File findRenames(String classifier, MappingFile.Format format, String version, String mapping, boolean obf, boolean reverse) throws IOException {
-        String ext = format.name().toLowerCase();
+        String ext = format.name().toLowerCase(Locale.ROOT);
         File names = findNames(version);
         File mcp = getMCP(version);
         if (mcp == null || names == null)
@@ -552,11 +549,11 @@ public class MCPRepo extends BaseRepo {
                  ZipOutputStream out = new ZipOutputStream(fos)) {
 
                 out.putNextEntry(Utils.getStableEntry("fields.csv"));
-                csv.write(new OutputStreamWriter(out), fields);
+                csv.write(new OutputStreamWriter(out, StandardCharsets.UTF_8), fields);
                 out.closeEntry();
 
                 out.putNextEntry(Utils.getStableEntry("methods.csv"));
-                csv.write(new OutputStreamWriter(out), methods);
+                csv.write(new OutputStreamWriter(out, StandardCharsets.UTF_8), methods);
                 out.closeEntry();
             }
 

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractDownloadMCFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/AbstractDownloadMCFunction.java
@@ -20,6 +20,7 @@
 
 package net.minecraftforge.gradle.mcp.function;
 
+import net.minecraftforge.gradle.common.util.Utils;
 import net.minecraftforge.gradle.mcp.util.MCPEnvironment;
 import org.gradle.internal.hash.HashValue;
 import com.google.gson.Gson;
@@ -37,10 +38,7 @@ public abstract class AbstractDownloadMCFunction extends AbstractFileDownloadFun
 
     private static DownloadInfo getDownloadInfo(MCPEnvironment environment, String artifact) {
         try {
-            Gson gson = new Gson();
-            Reader reader = new FileReader(environment.getStepOutput(DownloadVersionJSONFunction.class));
-            JsonObject json = gson.fromJson(reader, JsonObject.class);
-            reader.close();
+            JsonObject json = Utils.loadJson(environment.getStepOutput(DownloadVersionJSONFunction.class));
 
             JsonObject artifactInfo = json.getAsJsonObject("downloads").getAsJsonObject(artifact);
             String url = artifactInfo.get("url").getAsString();

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/AccessTransformerFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/AccessTransformerFunction.java
@@ -29,6 +29,7 @@ import org.gradle.api.Project;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -70,7 +71,7 @@ public class AccessTransformerFunction extends ExecuteFunction {
         if (transformers != null) {
             File tmp = File.createTempFile("FG_ats_", ".cfg");
             tmp.deleteOnExit();
-            Files.write(tmp.toPath(), transformers.getBytes());
+            Files.write(tmp.toPath(), transformers.getBytes(StandardCharsets.UTF_8));
             List<String> args = new ArrayList<>(Arrays.asList(runArgs));
             args.add("--atFile");
             args.add(tmp.getAbsolutePath());

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/DownloadVersionJSONFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/DownloadVersionJSONFunction.java
@@ -20,6 +20,8 @@
 
 package net.minecraftforge.gradle.mcp.function;
 
+import com.google.common.io.Files;
+import net.minecraftforge.gradle.common.util.Utils;
 import net.minecraftforge.gradle.mcp.util.MCPEnvironment;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -28,6 +30,7 @@ import com.google.gson.JsonObject;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
 public class DownloadVersionJSONFunction extends AbstractFileDownloadFunction {
 
@@ -39,10 +42,7 @@ public class DownloadVersionJSONFunction extends AbstractFileDownloadFunction {
 
     private static DownloadInfo getDownloadInfo(MCPEnvironment environment) {
         try {
-            Gson gson = new Gson();
-            Reader reader = new FileReader(environment.getStepOutput(DownloadManifestFunction.class));
-            JsonObject json = gson.fromJson(reader, JsonObject.class);
-            reader.close();
+            JsonObject json = Utils.loadJson(environment.getStepOutput(DownloadManifestFunction.class));
 
             // Look for the version we want and return its URL
             for (JsonElement e : json.getAsJsonArray("versions")) {

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/ExecuteFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/ExecuteFunction.java
@@ -25,11 +25,8 @@ import net.minecraftforge.gradle.common.util.Utils;
 import net.minecraftforge.gradle.mcp.util.MCPEnvironment;
 import org.gradle.api.tasks.JavaExec;
 
-import java.io.BufferedOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -121,7 +118,7 @@ public class ExecuteFunction implements MCPFunction {
         // Execute command
         JavaExec java = environment.project.getTasks().create("_", JavaExec.class);
         try (BufferedOutputStream log_out = new BufferedOutputStream(new FileOutputStream(environment.getFile("console.log")))) {
-            PrintWriter writer = new PrintWriter(log_out);
+            PrintWriter writer = new PrintWriter(new OutputStreamWriter(log_out, StandardCharsets.UTF_8.name()));
             Function<String,String> quote = s -> '"' + s + '"';
             writer.println("JVM Args:    " + jvmArgList.stream().map(quote).collect(Collectors.joining(", ")));
             writer.println("Run Args:    " + runArgList.stream().map(quote).collect(Collectors.joining(", ")));

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/ListLibrariesFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/ListLibrariesFunction.java
@@ -20,6 +20,9 @@
 
 package net.minecraftforge.gradle.mcp.function;
 
+import com.google.common.io.CharStreams;
+import com.google.common.io.Files;
+import net.minecraftforge.gradle.common.util.Utils;
 import net.minecraftforge.gradle.mcp.util.MCPEnvironment;
 import net.minecraftforge.gradle.common.util.MavenArtifactDownloader;
 import com.google.gson.Gson;
@@ -46,10 +49,7 @@ public class ListLibrariesFunction implements MCPFunction {
         File output = (File)environment.getArguments().computeIfAbsent("output", (key) -> environment.getFile("libraries.txt"));
 
         try {
-            Gson gson = new Gson();
-            Reader reader = new FileReader(environment.getStepOutput(DownloadVersionJSONFunction.class));
-            JsonObject json = gson.fromJson(reader, JsonObject.class);
-            reader.close();
+            JsonObject json = Utils.loadJson(environment.getStepOutput(DownloadVersionJSONFunction.class));
 
             // Gather all the libraries
             Set<File> files = new HashSet<>();

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/PatchFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/PatchFunction.java
@@ -32,6 +32,8 @@ import org.apache.commons.io.IOUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -52,8 +54,8 @@ public class PatchFunction implements MCPFunction {
     public  void initialize(MCPEnvironment environment, ZipFile zip) throws IOException {
         patches = zip.stream().filter(e -> !e.isDirectory() && e.getName().startsWith(path) && e.getName().endsWith(".patch"))
         .collect(Collectors.toMap(e -> e.getName().substring(path.length()), e -> {
-            try {
-                return IOUtils.toString(zip.getInputStream(e));
+            try (InputStream stream = zip.getInputStream(e)) {
+                return IOUtils.toString(stream, StandardCharsets.UTF_8);
             } catch (IOException ex) {
                 throw new RuntimeException(ex);
             }

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/SideAnnotationStripperFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/SideAnnotationStripperFunction.java
@@ -29,6 +29,7 @@ import org.gradle.api.Project;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -69,7 +70,7 @@ public class SideAnnotationStripperFunction extends ExecuteFunction {
             File tmp = env.getFile("string_data.sas").getAbsoluteFile();
             if (!tmp.getParentFile().exists())
                 tmp.getParentFile().mkdirs();
-            Files.write(tmp.toPath(), data.getBytes());
+            Files.write(tmp.toPath(), data.getBytes(StandardCharsets.UTF_8));
             List<String> args = new ArrayList<>(Arrays.asList(runArgs));
             args.add("--data");
             args.add(tmp.getAbsolutePath());

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/StripJarFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/StripJarFunction.java
@@ -31,6 +31,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarEntry;
@@ -52,7 +53,8 @@ public class StripJarFunction implements MCPFunction {
     @Override
     public void initialize(MCPEnvironment environment, ZipFile zip) throws IOException {
         // Read valid file names from mapping
-        BufferedReader br = new BufferedReader(new InputStreamReader(zip.getInputStream(zip.getEntry(mappings))));
+        BufferedReader br = new BufferedReader(new InputStreamReader(zip.getInputStream(zip.getEntry(mappings)),
+                StandardCharsets.UTF_8));
         filter = br.lines().filter(l -> !l.startsWith("\t")).map(s -> s.split(" ")[0] + ".class").collect(Collectors.toSet());
         br.close();
     }

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/task/CreateFakeSASPatches.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/task/CreateFakeSASPatches.java
@@ -22,6 +22,7 @@ package net.minecraftforge.gradle.patcher.task;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Supplier;
@@ -66,7 +67,7 @@ public class CreateFakeSASPatches extends DefaultTask {
             getOutput().mkdirs();
         for (File file : getFiles()) {
             getProject().getLogger().lifecycle("File: " + file);
-            for (String line : FileUtils.readLines(file)) {
+            for (String line : FileUtils.readLines(file, StandardCharsets.UTF_8)) {
                 int idx = line.indexOf('#');
                 if (idx == 0 || line.isEmpty()) continue;
                 if (idx != -1) line = line.substring(0, idx - 1);

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/task/TaskCreateExc.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/task/TaskCreateExc.java
@@ -171,7 +171,7 @@ public class TaskCreateExc extends DefaultTask {
                 CsvReader reader = new CsvReader();
                 reader.setContainsHeader(true);
                 try {
-                    CsvContainer csv  = reader.read(new InputStreamReader(zip.getInputStream(e)));
+                    CsvContainer csv  = reader.read(new InputStreamReader(zip.getInputStream(e), StandardCharsets.UTF_8));
                     for (CsvRow row : csv.getRows()) {
                         names.put(row.getField("searge"), row.getField("name"));
                     }

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/task/TaskGenerateUserdevConfig.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/task/TaskGenerateUserdevConfig.java
@@ -23,15 +23,7 @@ package net.minecraftforge.gradle.patcher.task;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
+import java.util.*;
 
 import groovy.lang.MissingPropertyException;
 import org.gradle.api.DefaultTask;
@@ -127,7 +119,7 @@ public class TaskGenerateUserdevConfig extends DefaultTask {
         if (patcher != null) {
             if (project != getProject() && patcher.patches != null) { //patches == null means they dont add anything, used by us as a 'clean' workspace.
                 if (json.parent == null) {
-                    json.parent = String.format("%s:%s:%s:userdev", project.getGroup(), project.getName(), project.getVersion());
+                    json.parent = String.format(Locale.ROOT, "%s:%s:%s:userdev", project.getGroup(), project.getName(), project.getVersion());
                     return;
                 }
             }

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -85,15 +85,8 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -503,7 +496,7 @@ public class MinecraftUserRepo extends BaseRepo {
             if (ret == null) {
                 return null;
             }
-            FileUtils.writeByteArrayToFile(pom, ret.getBytes());
+            FileUtils.writeStringToFile(pom, ret, StandardCharsets.UTF_8);
             cache.save();
             Utils.updateHash(pom, HashFunction.SHA1);
         }
@@ -667,7 +660,7 @@ public class MinecraftUserRepo extends BaseRepo {
                     File parentAT = project.file("build/" + at.getName() + "/parent_at.cfg");
                     if (!parentAT.getParentFile().exists())
                         parentAT.getParentFile().mkdirs();
-                    Files.write(parentAT.toPath(), baseAT.toString().getBytes());
+                    Files.write(parentAT.toPath(), baseAT.toString().getBytes(StandardCharsets.UTF_8));
                     at.setAts(parentAT);
                 }
 
@@ -831,8 +824,8 @@ public class MinecraftUserRepo extends BaseRepo {
                         if (name.startsWith("META-INF/services/") && !entry.isDirectory()) {
                             List<String> existing = servicesLists.computeIfAbsent(name, k -> new ArrayList<>());
                             if (existing.size() > 0) existing.add("");
-                            existing.add(String.format("# %s - %s", patcher.artifact, patcher.getUniversal().getCanonicalFile().getName()));
-                            existing.addAll(IOUtils.readLines(zin));
+                            existing.add(String.format(Locale.ROOT, "# %s - %s", patcher.artifact, patcher.getUniversal().getCanonicalFile().getName()));
+                            existing.addAll(IOUtils.readLines(zin, StandardCharsets.UTF_8));
                         } else {
                             ZipEntry _new = new ZipEntry(name);
                             _new.setTime(0); //SHOULD be the same time as the main entry, but NOOOO _new.setTime(entry.getTime()) throws DateTimeException, so you get 0, screw you!
@@ -858,8 +851,8 @@ public class MinecraftUserRepo extends BaseRepo {
                         if (name.startsWith("META-INF/services/") && !entry.isDirectory()) {
                             List<String> existing = servicesLists.computeIfAbsent(name, k -> new ArrayList<>());
                             if (existing.size() > 0) existing.add("");
-                            existing.add(String.format("# %s - %s", patcher.artifact, patcher.getZip().getCanonicalFile().getName()));
-                            existing.addAll(IOUtils.readLines(zin));
+                            existing.add(String.format(Locale.ROOT, "# %s - %s", patcher.artifact, patcher.getZip().getCanonicalFile().getName()));
+                            existing.addAll(IOUtils.readLines(zin, StandardCharsets.UTF_8));
                         } else {
                             ZipEntry _new = new ZipEntry(name);
                             _new.setTime(0);
@@ -878,7 +871,7 @@ public class MinecraftUserRepo extends BaseRepo {
             ZipEntry _new = new ZipEntry(name);
             _new.setTime(0);
             zip.putNextEntry(_new);
-            IOUtils.writeLines(kv.getValue(), "\n", zip);
+            IOUtils.writeLines(kv.getValue(), "\n", zip, StandardCharsets.UTF_8);
             added.add(name);
         }
     }
@@ -894,7 +887,7 @@ public class MinecraftUserRepo extends BaseRepo {
     }
 
     private File findObfToSrg(MappingFile.Format format) throws IOException {
-        String ext = format.name().toLowerCase();
+        String ext = format.name().toLowerCase(Locale.ROOT);
         File root = cache(mcp.getArtifact().getGroup().replace('.', '/'), mcp.getArtifact().getName(), mcp.getArtifact().getVersion());
         File file = new File(root, "obf_to_srg." + ext);
 
@@ -1152,7 +1145,7 @@ public class MinecraftUserRepo extends BaseRepo {
 
                     if (name.endsWith(".java")) {
                         String mapped = map.rename(zin, addJavadocs && vanilla.contains(name.substring(0, name.length() - 5)));
-                        IOUtils.write(mapped, zout);
+                        IOUtils.write(mapped, zout, StandardCharsets.UTF_8);
                     } else {
                         IOUtils.copy(zin, zout);
                     }

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
@@ -47,6 +47,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -165,7 +166,7 @@ public class Deobfuscator {
 
                     if (_old.getName().endsWith(".java")) {
                         String mapped = map.rename(zin, false);
-                        IOUtils.write(mapped, zout);
+                        IOUtils.write(mapped, zout, StandardCharsets.UTF_8);
                     } else {
                         IOUtils.copy(zin, zout);
                     }


### PR DESCRIPTION
I had an issue where a corrupted copy of ClientHooks.java was found inside a jar file:

...\build\tmp\expandedArchives\forge-1.16.3-34.1.0_mapped_snapshot_20201028-1.16.3-sources.jar_d036fe06dff3dbdda94c44ac227acd65\net\minecraftforge\fml\client\ClientHooks.java:183: error: unmappable character (0x81) for encoding UTF-8
        return description.endsWith(":NOFML?��?��r") ? description.substring(0, description.length() - 8)+"?��?��r" : description;

Best practices for file I/O streams is always to specify the character set. I think it's reasonable to just enforce UTF-8 in all situations, so I fixed that.

To find other cases, I added forbidden-apis to the project, and fixed all the other things it found.