### PR TITLE
Introduced sourceFileEncoding setting to config.json

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/config/UserdevConfigV2.java
+++ b/src/common/java/net/minecraftforge/gradle/common/config/UserdevConfigV2.java
@@ -22,6 +22,8 @@ package net.minecraftforge.gradle.common.config;
 
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -44,6 +46,7 @@ public class UserdevConfigV2 extends UserdevConfigV1 {
     public String patchesModifiedPrefix;
     private Boolean notchObf; //This is a Boolean so we can set to null and it won't be printed in the json.
     private List<String> universalFilters;
+    private String sourceFileCharset = StandardCharsets.UTF_8.name();
 
     public void setNotchObf(boolean value) {
         this.notchObf = value ? true : null;
@@ -51,6 +54,17 @@ public class UserdevConfigV2 extends UserdevConfigV1 {
 
     public boolean getNotchObf() {
         return this.notchObf == null ? false : this.notchObf;
+    }
+
+    public void setSourceFileCharset(String value) {
+        if (!Charset.isSupported(value)) {
+            throw new IllegalArgumentException("Unsupported charset: " + value);
+        }
+        sourceFileCharset = value;
+    }
+
+    public String getSourceFileCharset() {
+        return sourceFileCharset;
     }
 
     public void addUniversalFilter(String value) {

--- a/src/common/java/net/minecraftforge/gradle/common/util/McpNames.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/McpNames.java
@@ -20,14 +20,12 @@
 
 package net.minecraftforge.gradle.common.util;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.OutputStream;
 import java.io.StringReader;
-import java.io.StringWriter;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Deque;
@@ -43,7 +41,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-import java.util.zip.ZipOutputStream;
 
 import de.siegmar.fastcsv.reader.CsvContainer;
 import de.siegmar.fastcsv.reader.CsvReader;
@@ -97,21 +94,18 @@ public class McpNames {
     }
 
     public String rename(InputStream stream, boolean javadocs) throws IOException {
-        return rename(stream, javadocs, true);
+        return rename(stream, javadocs, true, StandardCharsets.UTF_8);
     }
 
     public String rename(InputStream stream, boolean javadocs, boolean lambdas) throws IOException {
-        List<String> input = new ArrayList<>();
-        StringWriter writer = new StringWriter();
-        IOUtils.copy(stream, writer, StandardCharsets.UTF_8);
-        String data = writer.toString();
+        return rename(stream, javadocs, lambdas, StandardCharsets.UTF_8);
+    }
 
-        try (BufferedReader reader = new BufferedReader(new StringReader(data))) {
-            String line = null;
-            while ((line = reader.readLine()) != null) {
-                input.add(line);
-            }
-        }
+    public String rename(InputStream stream, boolean javadocs, boolean lambdas, Charset sourceFileCharset)
+            throws IOException {
+
+        String data = IOUtils.toString(stream, sourceFileCharset);
+        List<String> input = IOUtils.readLines(new StringReader(data));
 
         //Reader doesn't give us the empty line if the file ends with a newline.. so add one.
         if (data.charAt(data.length() - 1) == '\r' || data.charAt(data.length() - 1) == '\n')

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/task/TaskGenerateUserdevConfig.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/task/TaskGenerateUserdevConfig.java
@@ -22,6 +22,7 @@ package net.minecraftforge.gradle.patcher.task;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -79,6 +80,7 @@ public class TaskGenerateUserdevConfig extends DefaultTask {
     private String patchesModifiedPrefix;
     private boolean notchObf = false;
     private List<String> universalFilters;
+    private Charset sourceFileEncoding = StandardCharsets.UTF_8;
 
     @Inject
     public TaskGenerateUserdevConfig(@Nonnull final Project project) {
@@ -113,6 +115,7 @@ public class TaskGenerateUserdevConfig extends DefaultTask {
             json.patchesOriginalPrefix = this.patchesOriginalPrefix;
             json.patchesModifiedPrefix = this.patchesModifiedPrefix;
             json.setNotchObf(this.notchObf);
+            json.setSourceFileCharset(this.sourceFileEncoding.name());
             if (this.universalFilters != null)
                 this.universalFilters.forEach(json::addUniversalFilter);
         }
@@ -337,6 +340,17 @@ public class TaskGenerateUserdevConfig extends DefaultTask {
     }
     public void setNotchObf(boolean value) {
         this.notchObf = value;
+    }
+
+    @Input
+    public Charset getSourceFileEncoding() {
+        return this.sourceFileEncoding;
+    }
+    public void setSourceFileEncoding(Charset value) {
+        this.sourceFileEncoding = value;
+    }
+    public void setSourceFileEncoding(String value) {
+        this.sourceFileEncoding = Charset.forName(value);
     }
 
     @Input

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -1155,7 +1155,9 @@ public class MinecraftUserRepo extends BaseRepo {
                     zout.putNextEntry(Utils.getStableEntry(name));
 
                     if (name.endsWith(".java")) {
-                        String mapped = map.rename(zin, addJavadocs && vanilla.contains(name.substring(0, name.length() - 5)));
+                        String mapped = map.rename(zin,
+                                addJavadocs && vanilla.contains(name.substring(0, name.length() - 5)),
+                                true, sourceFileCharset);
                         IOUtils.write(mapped, zout, sourceFileCharset);
                     } else {
                         IOUtils.copy(zin, zout);

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -79,6 +79,7 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -503,7 +504,7 @@ public class MinecraftUserRepo extends BaseRepo {
             if (ret == null) {
                 return null;
             }
-            FileUtils.writeByteArrayToFile(pom, ret.getBytes());
+            FileUtils.writeByteArrayToFile(pom, ret.getBytes(StandardCharsets.UTF_8));
             cache.save();
             Utils.updateHash(pom, HashFunction.SHA1);
         }
@@ -667,7 +668,7 @@ public class MinecraftUserRepo extends BaseRepo {
                     File parentAT = project.file("build/" + at.getName() + "/parent_at.cfg");
                     if (!parentAT.getParentFile().exists())
                         parentAT.getParentFile().mkdirs();
-                    Files.write(parentAT.toPath(), baseAT.toString().getBytes());
+                    Files.write(parentAT.toPath(), baseAT.toString().getBytes(StandardCharsets.UTF_8));
                     at.setAts(parentAT);
                 }
 
@@ -878,7 +879,8 @@ public class MinecraftUserRepo extends BaseRepo {
             ZipEntry _new = new ZipEntry(name);
             _new.setTime(0);
             zip.putNextEntry(_new);
-            IOUtils.writeLines(kv.getValue(), "\n", zip);
+            // JAR File Specification requires UTF-8 encoding here
+            IOUtils.writeLines(kv.getValue(), "\n", zip, StandardCharsets.UTF_8);
             added.add(name);
         }
     }
@@ -1142,6 +1144,8 @@ public class MinecraftUserRepo extends BaseRepo {
                 sources.getParentFile().mkdirs();
 
             boolean addJavadocs = parent == null || parent.getConfigV2() == null || parent.getConfigV2().processor == null;
+            Charset sourceFileCharset = parent == null || parent.getConfigV2() == null ? StandardCharsets.UTF_8 :
+                    Charset.forName(parent.getConfigV2().getSourceFileCharset());
             debug("    Renaming Sources, Javadocs: " + addJavadocs);
             try(ZipInputStream zin = new ZipInputStream(new FileInputStream(patched));
                 ZipOutputStream zout = new ZipOutputStream(new FileOutputStream(sources))) {
@@ -1152,7 +1156,7 @@ public class MinecraftUserRepo extends BaseRepo {
 
                     if (name.endsWith(".java")) {
                         String mapped = map.rename(zin, addJavadocs && vanilla.contains(name.substring(0, name.length() - 5)));
-                        IOUtils.write(mapped, zout);
+                        IOUtils.write(mapped, zout, sourceFileCharset);
                     } else {
                         IOUtils.copy(zin, zout);
                     }

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/util/Deobfuscator.java
@@ -47,6 +47,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Random;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
@@ -165,7 +166,7 @@ public class Deobfuscator {
 
                     if (_old.getName().endsWith(".java")) {
                         String mapped = map.rename(zin, false);
-                        IOUtils.write(mapped, zout);
+                        IOUtils.write(mapped, zout, StandardCharsets.UTF_8);
                     } else {
                         IOUtils.copy(zin, zout);
                     }


### PR DESCRIPTION
- `sourceFileEncoding` setting added to `UserdevConfigV2`.
  Kept as `String` to make serialisation easier. Could be Charset
  but would then require custom serialisation logic.
- `sourceFileEncoding` added to `TaskGenerateUserdevConfig`.
  This one is a `Charset` because type safety in build scripts
  is a good idea, but I added an overload taking `String` for
  convenience of people who don't care.
- `MinecraftUserRepo` now uses the config to get the encoding
  when writing .java files. Some other cases of writing to other
  files in the same class were fixed to use UTF-8 instead.
- `Deobfuscator` now uses UTF-8 - it looks like the string it's
  writing was originally read as UTF-8 in the method called on 
  the line above.
