### PR TITLE
Add an OFFLINE_MODE to Utils class.

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -58,6 +58,7 @@ public class UserDevPlugin implements Plugin<Project> {
 
     @Override
     public void apply(@Nonnull Project project) {
+        Utils.initUtils(project);
         Utils.checkJavaVersion();
 
         @SuppressWarnings("unused")


### PR DESCRIPTION
Added a `Utils.initUtils(Project p)` method which can be used to read 
in a Project's parameters (and other Gradle information) for use in 
configuration.

Additionally, added an OFFLINE_MODE value that is populated by the
`--offline` flag. The OFFLINE_MODE flag is used in several locations 
throughout the Util class to prevent network access when the flag is set.