### PR TITLE
Support Gradle 7.0 by updating the licenser plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'java-gradle-plugin'
     id 'eclipse'
     id 'maven-publish'
-    id 'net.minecrell.licenser' version '0.4.1'
+    id 'org.cadixdev.licenser' version '0.5.0'
     id 'org.ajoberstar.grgit' version '4.1.0'
     id 'com.github.ben-manes.versions' version '0.36.0'
   //id 'com.github.johnrengelman.shadow' version '2.0.4'


### PR DESCRIPTION
Turned out to be pretty trivial, only one plugin seemed to be causing deprecation warnings and the author behind the plugin already updated it to fix said warnings in the next release.

The author of the plugin changed the namespace after publishing 0.4.1, hence why 0.4.1 shows up as "latest" when looking up the original namespace.
https://github.com/CadixDev/licenser/commit/f0212fb827413bb193d4b9cdb91eb5f81b606b92