### PR TITLE
Simple Actions workflow for PRs.

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -1,0 +1,25 @@
+name: PR Check
+
+on: [pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java: [ 8, 11, 15 ]
+
+    name: Java ${{ matrix.java }} build test.
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - uses: eskatos/gradle-command-action@v1.3.3
+        with:
+          wrapper-cache-enabled: true
+          dependencies-cache-enabled: true
+          configuration-cache-enabled: false
+          arguments: build --no-daemon


### PR DESCRIPTION
This workflow simply runs `build` on the PR on the specified Java versions, currently 8, 11 and 15. The wrapper and dependencies are cached between runs.

This is meant as a basic implementation until tests or further checks are implemented/needed.

A preview of what these checks look like is available on my fork here: https://github.com/Unnoen/ForgeGradle/actions/runs/498948863