### PR TITLE
Use the java-gradle-plugin's gradlePlugin block

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,40 @@ license {
     exclude 'net/minecraftforge/gradle/common/util/JavaVersionParser.java'
 }
 
+gradlePlugin {
+    plugins {
+        mcp0 {
+            id = 'net.minecraftforge.gradle.forgedev.mcp'
+            implementationClass = 'net.minecraftforge.gradle.mcp.MCPPlugin'
+        }
+
+        mcp1 {
+            id = 'net.minecraftforge.gradle.mcp'
+            implementationClass = 'net.minecraftforge.gradle.mcp.MCPPlugin'
+        }
+
+        patcher0 {
+            id = 'net.minecraftforge.gradle.forgedev.patcher'
+            implementationClass = 'net.minecraftforge.gradle.patcher.PatcherPlugin'
+        }
+
+        patcher1 {
+            id = 'net.minecraftforge.gradle.forgedev'
+            implementationClass = 'net.minecraftforge.gradle.patcher.PatcherPlugin'
+        }
+
+        patcher2 {
+            id = 'net.minecraftforge.gradle.patcher'
+            implementationClass = 'net.minecraftforge.gradle.patcher.PatcherPlugin'
+        }
+
+        userdev {
+            id = 'net.minecraftforge.gradle'
+            implementationClass = 'net.minecraftforge.gradle.userdev.UserDevPlugin'
+        }
+    }
+}
+
 wrapper {
     gradleVersion = '6.8'
     distributionType = Wrapper.DistributionType.ALL

--- a/src/mcp/resources/META-INF/gradle-plugins/net.minecraftforge.gradle.forgedev.mcp.properties
+++ b/src/mcp/resources/META-INF/gradle-plugins/net.minecraftforge.gradle.forgedev.mcp.properties
@@ -1,1 +1,0 @@
-implementation-class=net.minecraftforge.gradle.mcp.MCPPlugin

--- a/src/mcp/resources/META-INF/gradle-plugins/net.minecraftforge.gradle.mcp.properties
+++ b/src/mcp/resources/META-INF/gradle-plugins/net.minecraftforge.gradle.mcp.properties
@@ -1,1 +1,0 @@
-implementation-class=net.minecraftforge.gradle.mcp.MCPPlugin

--- a/src/patcher/resources/META-INF/gradle-plugins/net.minecraftforge.gradle.forgedev.patcher.properties
+++ b/src/patcher/resources/META-INF/gradle-plugins/net.minecraftforge.gradle.forgedev.patcher.properties
@@ -1,1 +1,0 @@
-implementation-class=net.minecraftforge.gradle.patcher.PatcherPlugin

--- a/src/patcher/resources/META-INF/gradle-plugins/net.minecraftforge.gradle.forgedev.properties
+++ b/src/patcher/resources/META-INF/gradle-plugins/net.minecraftforge.gradle.forgedev.properties
@@ -1,1 +1,0 @@
-implementation-class=net.minecraftforge.gradle.patcher.PatcherPlugin

--- a/src/patcher/resources/META-INF/gradle-plugins/net.minecraftforge.gradle.patcher.properties
+++ b/src/patcher/resources/META-INF/gradle-plugins/net.minecraftforge.gradle.patcher.properties
@@ -1,1 +1,0 @@
-implementation-class=net.minecraftforge.gradle.patcher.PatcherPlugin

--- a/src/userdev/resources/META-INF/gradle-plugins/net.minecraftforge.gradle.properties
+++ b/src/userdev/resources/META-INF/gradle-plugins/net.minecraftforge.gradle.properties
@@ -1,1 +1,0 @@
-implementation-class=net.minecraftforge.gradle.userdev.UserDevPlugin


### PR DESCRIPTION
Has the benefit that there is extended metadata, which allows for modern plugin application
```gradle
plugins {
    id 'net.minecraftforge.gradle' version '4.0.8'
}
```
with some code in the settings.gradle
```gradle
pluginManagement {
    repositories {
        gradlePluginPortal()
        jcenter()

        maven {
            name = "MinecraftForge"
            url = uri("https://files.minecraftforge.net/maven/")
        }
    }
}
```