### PR TITLE
Fix typo in step output name

### DIFF
--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/DownloadCoreFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/DownloadCoreFunction.java
@@ -36,7 +36,7 @@ class DownloadCoreFunction extends DownloadFileFunction {
     private static DownloadInfo getDownloadInfo(MCPEnvironment environment, String artifact, String extension) {
         try {
             Gson gson = new Gson();
-            Reader reader = new FileReader(environment.getStepOutput("downloadManifest"));
+            Reader reader = new FileReader(environment.getStepOutput("downloadJson"));
             JsonObject json = gson.fromJson(reader, JsonObject.class);
             reader.close();
 


### PR DESCRIPTION
I’m assuming that’s a typo. Otherwise the function fails with NPE.

__Change__ https://github.com/MinecraftForge/ForgeGradle/commit/ce0ff72c9265ebbf38e999213d1d554b39826346

__Before__
https://github.com/MinecraftForge/ForgeGradle/blob/f61d2a42b1c601b1ab92079ff5559ab16842b47c/src/mcp/java/net/minecraftforge/gradle/mcp/function/DownloadCoreFunction.java#L39

__After__
https://github.com/MinecraftForge/ForgeGradle/blob/ce0ff72c9265ebbf38e999213d1d554b39826346/src/mcp/java/net/minecraftforge/gradle/mcp/function/DownloadCoreFunction.java#L39

__Should be__
https://github.com/MinecraftForge/ForgeGradle/blob/93d84e7932c39e743c284b67b7351de29b642f92/src/mcp/java/net/minecraftforge/gradle/mcp/function/MCPFunctionFactory.java#L44-L45