### PR TITLE
Add Gradle Version Tests (FG4)

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -514,19 +514,20 @@ public class Utils {
         return toCapitalize.length() > 1 ? toCapitalize.substring(0, 1).toUpperCase() + toCapitalize.substring(1) : toCapitalize;
     }
 
-    public static void checkJavaRange( @Nullable JavaVersionParser.JavaVersion minVersionInclusive, @Nullable JavaVersionParser.JavaVersion maxVersionExclusive) {
-        checkRange("java", JavaVersionParser.getCurrentJavaVersion(), minVersionInclusive, maxVersionExclusive);
+    public static void checkJavaRange(@Nullable JavaVersionParser.JavaVersion minVersionInclusive, @Nullable JavaVersionParser.JavaVersion maxVersionExclusive) {
+        checkRange("java", JavaVersionParser.getCurrentJavaVersion(), minVersionInclusive, maxVersionExclusive, "");
     }
 
-    public static void checkGradleRange( @Nullable GradleVersion minVersionInclusive, @Nullable GradleVersion maxVersionExclusive) {
-        checkRange("Gradle", GradleVersion.current(), minVersionInclusive, maxVersionExclusive);
+    public static void checkGradleRange(@Nullable GradleVersion minVersionInclusive, @Nullable GradleVersion maxVersionExclusive) {
+        checkRange("Gradle", GradleVersion.current(), minVersionInclusive, maxVersionExclusive, "\nNote: Upgrade your gradle version first before trying to switch to FG4.");
     }
 
-    private static <T> void checkRange(String name, Comparable<T> current, @Nullable T minVersionInclusive, @Nullable T maxVersionExclusive) {
+    private static <T> void checkRange(String name, Comparable<T> current, @Nullable T minVersionInclusive, @Nullable T maxVersionExclusive, String additional) {
         if (minVersionInclusive != null && current.compareTo(minVersionInclusive) < 0)
-            throw new RuntimeException(String.format("Found %s version %s. Minimum required is %s.", name, current, minVersionInclusive));
+            throw new RuntimeException(String.format("Found %s version %s. Minimum required is %s.%s", name, current, minVersionInclusive, additional));
+
         if (maxVersionExclusive != null && current.compareTo(maxVersionExclusive) >= 0)
-            throw new RuntimeException(String.format("Found %s version %s. Versions %s and newer are not supported yet.", name, current, maxVersionExclusive));
+            throw new RuntimeException(String.format("Found %s version %s. Versions %s and newer are not supported yet.%s", name, current, maxVersionExclusive, additional));
     }
 
     /**
@@ -540,7 +541,7 @@ public class Utils {
     public static void checkEnvironment() {
         if (ENABLE_TEST_JAVA) {
             checkJavaRange(
-                // Mininum must be update 101 as it's the first one to include Let's Encrypt certificates.
+                // Minimum must be update 101 as it's the first one to include Let's Encrypt certificates.
                 JavaVersionParser.parseJavaVersion("1.8.0_101"),
                 null //TODO: Add JDK range check to MCPConfig?
             );

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -527,7 +527,7 @@ public class Utils {
             throw new RuntimeException(String.format("Found %s version %s. Minimum required is %s.%s", name, current, minVersionInclusive, additional));
 
         if (maxVersionExclusive != null && current.compareTo(maxVersionExclusive) >= 0)
-            throw new RuntimeException(String.format("Found %s version %s. Versions %s and newer are not supported yet.%s", name, current, maxVersionExclusive, additional));
+            throw new RuntimeException(String.format("Found %s version %s. Versions %s and newer are not supported yet.", name, current, maxVersionExclusive));
     }
 
     /**

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
@@ -84,7 +84,7 @@ public class PatcherPlugin implements Plugin<Project> {
 
     @Override
     public void apply(@Nonnull Project project) {
-        Utils.checkJavaVersion();
+        Utils.checkEnvironment();
 
         final PatcherExtension extension = project.getExtensions().create(PatcherExtension.class, PatcherExtension.EXTENSION_NAME, PatcherExtension.class, project);
         if (project.getPluginManager().findPlugin("java") == null) {

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -60,7 +60,7 @@ public class UserDevPlugin implements Plugin<Project> {
 
     @Override
     public void apply(@Nonnull Project project) {
-        Utils.checkJavaVersion();
+        Utils.checkEnvironment();
 
         @SuppressWarnings("unused")
         final Logger logger = project.getLogger();


### PR DESCRIPTION
As requested by Lex in [Discord](https://discord.com/channels/313125603924639766/725850371834118214/818759728879632396)

Extends the already present Java Environment checks

Sample output
```
    Build file 'Example\build.gradle' line: 14

    A problem occurred evaluating root project 'Example'.
    > Failed to apply plugin [id 'net.minecraftforge.gradle']
       > Found Gradle version Gradle 4.10.3. Minimum required is Gradle 6.8.1.

    * Try:
    Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.
```