### PR TITLE
Display official license in the warning & add a task to 'hide' it

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/MojangLicenseHelper.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MojangLicenseHelper.java
@@ -20,19 +20,129 @@
 
 package net.minecraftforge.gradle.common.util;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+
 import org.gradle.api.Project;
 
 public class MojangLicenseHelper {
-    //TODO: Add a task that people can run to quiet this warning.
-    //Also output the specific text from the targeted MC version.
+
+    public static final String ACCEPT_LICENSE = "acceptTheCurrentOfficialLicense";
+    public static final String REVOKE_LICENSE = "revokeAcceptanceOfTheCurrentOfficialLicense";
+
+    /**
+     * @see #displayWarning(Project, String, String) 
+     */
+    @Deprecated
     public static void displayWarning(Project project, String channel) {
+        displayWarning(project, channel, null);
+    }
+
+    public static void displayWarning(Project project, String channel, @Nullable String version) {
         if ("official".equals(channel)) {
-            String warning = "WARNING: "
-                + "This project is configured to use the official obfuscation mappings provided by Mojang. "
-                + "These mapping fall under their associated license, you should be fully aware of this license. "
-                + "For the latest license text, refer to the mapping file itself, or the reference copy here: "
-                + "https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md";
+            Optional<String> license = version != null ? getOfficialLicense(project, version) : Optional.empty();
+            Optional<String> licenseHash = license.map(HashFunction.SHA1::hash);
+
+            if (license.isPresent() && isAccepted(project, licenseHash.get())) return;
+
+            String warning = getWarning(license.orElse(null));
+
             project.getLogger().warn(warning);
+            license.map(s -> "WARNING: " + s).ifPresent(project.getLogger()::warn);
         }
+    }
+
+    public static void accept(Project project, String channel, String version) {
+        if (!"official".equals(channel)) return;
+
+        String hash = getOfficialLicense(project, version)
+            .map(HashFunction.SHA1::hash)
+            .orElseThrow(() -> new IllegalStateException("Could not get Mojang license text for " + version));
+
+        Path accepted = getLicensePath(project, hash);
+
+        if (Files.exists(accepted)) return;
+
+        try {
+            Utils.createEmpty(accepted.toFile());
+
+            project.getLogger().warn("WARNING: These warnings will not be shown again until the license changes");
+        } catch (IOException exception) {
+            project.getLogger().error("Could not accept Mojang license", exception);
+        }
+    }
+
+    public static void revoke(Project project, String channel, String version) {
+        if (!"official".equals(channel)) return;
+
+        String hash = getOfficialLicense(project, version)
+            .map(HashFunction.SHA1::hash)
+            .orElseThrow(() -> new IllegalStateException("Could not get Mojang license text for " + version));
+
+        Path accepted = getLicensePath(project, hash);
+
+        Utils.delete(accepted.toFile());
+    }
+
+    private static String getWarning(String license) {
+        String warning = "WARNING: "
+            + "This project is configured to use the official obfuscation mappings provided by Mojang. "
+            + "These mapping fall under their associated license, you should be fully aware of this license. "
+            + "For the latest license text, refer {REFER}, or the reference copy here: "
+            + "https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md"
+            + ", You can hide this warning by running the `{TASK}` task";
+
+        return warning
+            .replace("{REFER}", license != null ? "below" : "to the mapping file itself")
+            .replace("{TASK}", ACCEPT_LICENSE);
+    }
+
+    private static boolean isAccepted(Project project, String hash) {
+        return Files.exists(getLicensePath(project, hash));
+    }
+
+    private static Optional<String> getOfficialLicense(Project project, String version) {
+        String minecraftVersion = getMinecraftVersion(version);
+        String artifact = "net.minecraft:client:" + minecraftVersion + ":mappings@txt";
+
+        File client = MavenArtifactDownloader.generate(project, artifact, true);
+
+        if (client == null) return Optional.empty();
+
+        try {
+            return Optional.of(
+                Files.lines(client.toPath())
+                    .filter(line -> line.startsWith("#"))        // Only Comments
+                    .map(l -> l.substring(1).trim())             // Remove initial #
+                    .collect(Collectors.joining("\n"))   // Join via \n
+            );
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return Optional.empty();
+    }
+
+    private static Path getLicensePath(Project project, String hash) {
+        return new File(Utils.getCache(project, "licenses"), hash + ".accepted").toPath();
+    }
+
+    private static final Predicate<String> MCP_CONFIG_TIMESTAMP = Pattern.compile("\\d{8}\\.\\d{6}").asPredicate();
+
+    private static String getMinecraftVersion(String version) {
+        int idx = version.lastIndexOf('-');
+
+        if (idx != -1 && MCP_CONFIG_TIMESTAMP.test(version.substring(idx + 1))) {
+            version = version.substring(0, idx);
+        }
+
+        return version;
     }
 }

--- a/src/common/java/net/minecraftforge/gradle/common/util/MojangLicenseHelper.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MojangLicenseHelper.java
@@ -45,6 +45,12 @@ public class MojangLicenseHelper {
         displayWarning(project, channel, null);
     }
 
+    public static void displayWarningUpdate(Project project, String originalChannel, String channel, @Nullable String version) {
+        if ("official".equals(originalChannel)) return;
+
+        displayWarning(project, channel, version);
+    }
+
     public static void displayWarning(Project project, String channel, @Nullable String version) {
         if ("official".equals(channel)) {
             Optional<String> license = version != null ? getOfficialLicense(project, version) : Optional.empty();
@@ -114,9 +120,14 @@ public class MojangLicenseHelper {
 
         File client = MavenArtifactDownloader.generate(project, artifact, true);
 
-        if (client == null) return Optional.empty();
-
         try {
+            if (client == null && project.hasProperty("UPDATE_MAPPINGS")) {
+                MinecraftRepo repo = (MinecraftRepo) MinecraftRepo.create(project);
+                client = repo.findFile(Artifact.from(artifact));
+            }
+
+            if (client == null) return Optional.empty();
+
             return Optional.of(
                 Files.lines(client.toPath())
                     .filter(line -> line.startsWith("#"))        // Only Comments

--- a/src/common/java/net/minecraftforge/gradle/common/util/MojangLicenseHelper.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MojangLicenseHelper.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
@@ -45,10 +46,12 @@ public class MojangLicenseHelper {
         displayWarning(project, channel, null);
     }
 
-    public static void displayWarningUpdate(Project project, String originalChannel, String channel, @Nullable String version) {
-        if ("official".equals(originalChannel)) return;
-
+    public static void displayWarning(Project project, String channel, @Nullable String version, @Nullable String updateChannel, @Nullable String updateVersion) {
         displayWarning(project, channel, version);
+
+        if (updateChannel == null || Objects.equals(channel, updateChannel)) return;
+
+        displayWarning(project, updateChannel, updateVersion);
     }
 
     public static void displayWarning(Project project, String channel, @Nullable String version) {
@@ -120,14 +123,9 @@ public class MojangLicenseHelper {
 
         File client = MavenArtifactDownloader.generate(project, artifact, true);
 
+        if (client == null) return Optional.empty();
+
         try {
-            if (client == null && project.hasProperty("UPDATE_MAPPINGS")) {
-                MinecraftRepo repo = (MinecraftRepo) MinecraftRepo.create(project);
-                client = repo.findFile(Artifact.from(artifact));
-            }
-
-            if (client == null) return Optional.empty();
-
             return Optional.of(
                 Files.lines(client.toPath())
                     .filter(line -> line.startsWith("#"))        // Only Comments

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
@@ -318,7 +318,7 @@ public class PatcherPlugin implements Plugin<Project> {
         if (doingUpdate) {
             String version = (String) project.property("UPDATE_MAPPINGS");
             String channel = project.hasProperty("UPDATE_MAPPINGS_CHANNEL") ? (String) project.property("UPDATE_MAPPINGS_CHANNEL") : "snapshot";
-            MojangLicenseHelper.displayWarning(project, channel, version);
+            project.afterEvaluate(p -> MojangLicenseHelper.displayWarningUpdate(p, extension.getMappingChannel(), channel, version));
 
             TaskProvider<DownloadMCPMappingsTask> dlMappingsNew = project.getTasks().register("downloadMappingsNew", DownloadMCPMappingsTask.class);
             dlMappingsNew.get().setMappings(channel + '_' + version);

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
@@ -127,8 +127,8 @@ public class PatcherPlugin implements Plugin<Project> {
         TaskProvider<Jar> userdevJar = project.getTasks().register("userdevJar", Jar.class);
         TaskProvider<TaskGenerateUserdevConfig> userdevConfig = project.getTasks().register("userdevConfig", TaskGenerateUserdevConfig.class, project);
         TaskProvider<DefaultTask> release = project.getTasks().register("release", DefaultTask.class);
-        TaskProvider<DefaultTask> acceptLicense = project.getTasks().register(MojangLicenseHelper.ACCEPT_LICENSE, DefaultTask.class);
-        TaskProvider<DefaultTask> revokeLicense = project.getTasks().register(MojangLicenseHelper.REVOKE_LICENSE, DefaultTask.class);
+        TaskProvider<DefaultTask> hideLicense = project.getTasks().register(MojangLicenseHelper.HIDE_LICENSE, DefaultTask.class);
+        TaskProvider<DefaultTask> showLicense = project.getTasks().register(MojangLicenseHelper.SHOW_LICENSE, DefaultTask.class);
 
         //Add Known repos
         project.getRepositories().maven(e -> {
@@ -148,15 +148,15 @@ public class PatcherPlugin implements Plugin<Project> {
             e.metadataSources(MetadataSources::artifact);
         });
 
-        acceptLicense.configure(task -> {
+        hideLicense.configure(task -> {
             task.doLast(_task -> {
-                MojangLicenseHelper.accept(project, extension.getMappingChannel(), extension.getMappingVersion());
+                MojangLicenseHelper.hide(project, extension.getMappingChannel(), extension.getMappingVersion());
             });
         });
 
-        revokeLicense.configure(task -> {
+        showLicense.configure(task -> {
             task.doLast(_task -> {
-                MojangLicenseHelper.revoke(project, extension.getMappingChannel(), extension.getMappingVersion());
+                MojangLicenseHelper.show(project, extension.getMappingChannel(), extension.getMappingVersion());
             });
         });
 

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
@@ -315,13 +315,13 @@ public class PatcherPlugin implements Plugin<Project> {
         });
 
         final boolean doingUpdate = project.hasProperty("UPDATE_MAPPINGS");
+        final String updateVersion = doingUpdate ? (String)project.property("UPDATE_MAPPINGS") : null;
+        final String updateChannel = doingUpdate
+            ? (project.hasProperty("UPDATE_MAPPINGS_CHANNEL") ? (String)project.property("UPDATE_MAPPINGS_CHANNEL") : "snapshot")
+            : null;
         if (doingUpdate) {
-            String version = (String) project.property("UPDATE_MAPPINGS");
-            String channel = project.hasProperty("UPDATE_MAPPINGS_CHANNEL") ? (String) project.property("UPDATE_MAPPINGS_CHANNEL") : "snapshot";
-            project.afterEvaluate(p -> MojangLicenseHelper.displayWarningUpdate(p, extension.getMappingChannel(), channel, version));
-
             TaskProvider<DownloadMCPMappingsTask> dlMappingsNew = project.getTasks().register("downloadMappingsNew", DownloadMCPMappingsTask.class);
-            dlMappingsNew.get().setMappings(channel + '_' + version);
+            dlMappingsNew.get().setMappings(updateChannel + '_' + updateVersion);
 
             TaskProvider<TaskApplyMappings> toMCPNew = project.getTasks().register("srg2mcpNew", TaskApplyMappings.class);
             toMCPNew.configure(task -> {
@@ -384,7 +384,7 @@ public class PatcherPlugin implements Plugin<Project> {
                 PatcherPlugin patcher = extension.parent.getPlugins().findPlugin(PatcherPlugin.class);
 
                 if (mcp != null) {
-                    MojangLicenseHelper.displayWarning(p, extension.getMappingChannel(), extension.getMappingVersion());
+                    MojangLicenseHelper.displayWarning(p, extension.getMappingChannel(), extension.getMappingVersion(), updateChannel, updateVersion);
                     SetupMCPTask setupMCP = (SetupMCPTask) tasks.getByName("setupMCP");
 
                     if (procConfig != null) {

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -177,7 +177,7 @@ public class UserDevPlugin implements Plugin<Project> {
             String channel = project.hasProperty("UPDATE_MAPPINGS_CHANNEL") ? (String)project.property("UPDATE_MAPPINGS_CHANNEL") : "snapshot";
 
             logger.lifecycle("This process uses Srg2Source for java source file renaming. Please forward relevant bug reports to https://github.com/MinecraftForge/Srg2Source/issues.");
-            MojangLicenseHelper.displayWarning(project, channel, version);
+            project.afterEvaluate(p -> MojangLicenseHelper.displayWarningUpdate(p, extension.getMappingChannel(), channel, version));
 
             JavaCompile javaCompile = (JavaCompile) project.getTasks().getByName("compileJava");
             JavaPluginConvention javaConv = (JavaPluginConvention) project.getConvention().getPlugins().get("java");

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -172,12 +172,13 @@ public class UserDevPlugin implements Plugin<Project> {
             task.setMeta(downloadMCMeta.get().getOutput());
         });
 
-        if (project.hasProperty("UPDATE_MAPPINGS")) {
-            String version = (String)project.property("UPDATE_MAPPINGS");
-            String channel = project.hasProperty("UPDATE_MAPPINGS_CHANNEL") ? (String)project.property("UPDATE_MAPPINGS_CHANNEL") : "snapshot";
-
+        final boolean doingUpdate = project.hasProperty("UPDATE_MAPPINGS");
+        final String updateVersion = doingUpdate ? (String)project.property("UPDATE_MAPPINGS") : null;
+        final String updateChannel = doingUpdate
+            ? (project.hasProperty("UPDATE_MAPPINGS_CHANNEL") ? (String)project.property("UPDATE_MAPPINGS_CHANNEL") : "snapshot")
+            : null;
+        if (doingUpdate) {
             logger.lifecycle("This process uses Srg2Source for java source file renaming. Please forward relevant bug reports to https://github.com/MinecraftForge/Srg2Source/issues.");
-            project.afterEvaluate(p -> MojangLicenseHelper.displayWarningUpdate(p, extension.getMappingChannel(), channel, version));
 
             JavaCompile javaCompile = (JavaCompile) project.getTasks().getByName("compileJava");
             JavaPluginConvention javaConv = (JavaPluginConvention) project.getConvention().getPlugins().get("java");
@@ -202,7 +203,7 @@ public class UserDevPlugin implements Plugin<Project> {
             });
 
             dlMappingsNew.configure(task -> {
-                task.setMappings(channel + "_" + version);
+                task.setMappings(updateChannel + "_" + updateVersion);
                 task.setOutput(project.file("build/mappings_new.zip"));
             });
 
@@ -273,7 +274,7 @@ public class UserDevPlugin implements Plugin<Project> {
                     .add(MinecraftRepo.create(project)) //Provides vanilla extra/slim/data jars. These don't care about OBF names.
                     .attach(project);
 
-            MojangLicenseHelper.displayWarning(p, extension.getMappingChannel(), extension.getMappingVersion());
+            MojangLicenseHelper.displayWarning(p, extension.getMappingChannel(), extension.getMappingVersion(), updateChannel, updateVersion);
 
             project.getRepositories().maven(e -> {
                 e.setUrl(Utils.MOJANG_MAVEN);

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -126,18 +126,18 @@ public class UserDevPlugin implements Plugin<Project> {
         TaskProvider<DownloadMCMeta> downloadMCMeta = project.getTasks().register("downloadMCMeta", DownloadMCMeta.class);
         TaskProvider<ExtractNatives> extractNatives = project.getTasks().register("extractNatives", ExtractNatives.class);
         TaskProvider<DownloadAssets> downloadAssets = project.getTasks().register("downloadAssets", DownloadAssets.class);
-        TaskProvider<DefaultTask> acceptLicense = project.getTasks().register(MojangLicenseHelper.ACCEPT_LICENSE, DefaultTask.class);
-        TaskProvider<DefaultTask> revokeLicense = project.getTasks().register(MojangLicenseHelper.REVOKE_LICENSE, DefaultTask.class);
+        TaskProvider<DefaultTask> hideLicense = project.getTasks().register(MojangLicenseHelper.HIDE_LICENSE, DefaultTask.class);
+        TaskProvider<DefaultTask> showLicense = project.getTasks().register(MojangLicenseHelper.SHOW_LICENSE, DefaultTask.class);
 
-        acceptLicense.configure(task -> {
+        hideLicense.configure(task -> {
             task.doLast(_task -> {
-                MojangLicenseHelper.accept(project, extension.getMappingChannel(), extension.getMappingVersion());
+                MojangLicenseHelper.hide(project, extension.getMappingChannel(), extension.getMappingVersion());
             });
         });
 
-        revokeLicense.configure(task -> {
+        showLicense.configure(task -> {
             task.doLast(_task -> {
-                MojangLicenseHelper.revoke(project, extension.getMappingChannel(), extension.getMappingVersion());
+                MojangLicenseHelper.show(project, extension.getMappingChannel(), extension.getMappingVersion());
             });
         });
 


### PR DESCRIPTION
New Tasks:
- hideOfficialWarningUntilChanged
- reshowOfficialWarning

Moved the `MojangLicenseHelper#displayWarning` to fix an edge case where the MinecraftRepo (Which is used to grab the PG)  wasn't available during an initial task (It would of skipped showing the license (not the warning)).

The new warning:
```
> Configure project :
Java: 1.8.0_231 JVM: 25.231-b11(Oracle Corporation) Arch: amd64
WARNING: This project is configured to use the official obfuscation mappings provided by Mojang. These mapping fall under their associated license, you should be fully aware of this license. For the latest license text, refer below, or the reference copy here: https://github.com/MinecraftForge/MCPConfig/blob/master/Mojang.md, You can hide this warning by running the `agreeToTheCurrentOfficialLicense` task
WARNING: (c) 2020 Microsoft Corporation. These mappings are provided "as-is" and you bear the risk of using them. You may copy and use the mappings for development purposes, but you may not redistribute the mappings complete and unmodified. Microsoft makes no warranties, express or implied, with respect to the mappings provided here.  Use and modification of this document or the source code (in any form) of Minecraft: Java Edition is governed by the Minecraft End User License Agreement available at https://account.mojang.com/documents/minecraft_eula.

> Task :downloadMcpConfig
> Task :extractSrg UP-TO-DATE
> Task :createMcpToSrg UP-TO-DATE
> Task :compileJava UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :compileTestJava NO-SOURCE
> Task :processTestResources NO-SOURCE
> Task :testClasses UP-TO-DATE

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 2s
5 actionable tasks: 1 executed, 4 up-to-date
16:56:46: Tasks execution finished ':classes :testClasses'.
```

After running `hideOfficialWarningUntilChanged`:
```
> Configure project :
Java: 1.8.0_231 JVM: 25.231-b11(Oracle Corporation) Arch: amd64

> Task :downloadMcpConfig
> Task :extractSrg UP-TO-DATE
> Task :createMcpToSrg UP-TO-DATE
> Task :compileJava UP-TO-DATE
> Task :processResources UP-TO-DATE
> Task :classes UP-TO-DATE
> Task :compileTestJava NO-SOURCE
> Task :processTestResources NO-SOURCE
> Task :testClasses UP-TO-DATE

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.8.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 3s
5 actionable tasks: 1 executed, 4 up-to-date
16:57:51: Tasks execution finished ':classes :testClasses'.
```