### PR TITLE
Fix issues with clean build

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -1017,7 +1017,7 @@ public class MinecraftUserRepo extends BaseRepo {
 
         if (cache.isSame() && patched.exists()) {
             debug("    Cache Hit");
-        } else if (patched.exists() || generate) {
+        } else if (!patched.exists() || generate) {
             debug("    Generating");
             LinkedList<Patcher> parents = new LinkedList<>();
             Patcher patcher = parent;

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -963,7 +963,7 @@ public class MinecraftUserRepo extends BaseRepo {
 
         if (cache.isSame() && decomp.exists()) {
             debug("  Cache Hit");
-        } else if (decomp.exists() || generate) {
+        } else if (!decomp.exists() || generate) {
             debug("  Decompiling");
             File output = mcp.getStepOutput(isPatcher ? "joined" : NAME, null);
             if (parent != null && parent.getConfigV2() != null && parent.getConfigV2().processor != null) {

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -1120,7 +1120,7 @@ public class MinecraftUserRepo extends BaseRepo {
         cache.load(cacheMapped(mapping, "sources", "jar.input"));
         if (cache.isSame() && sources.exists()) {
             debug("    Cache hit");
-        } else if (sources.exists() || generate) {
+        } else if (!sources.exists() || generate) {
             IMappingFile obf_to_srg = IMappingFile.load(obf2srg);
             Set<String> vanilla = obf_to_srg.getClasses().stream().map(IMappingFile.INode::getMapped).collect(Collectors.toSet());
 


### PR DESCRIPTION
I guess all those jars should be rebuilt if doesn't exist, not opposite

Otherwise, for me, it was causing failures in clean build on a clean system 

Probably related to #752, #750