### PR TITLE
Add support for Gradle 7.0

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
@@ -26,6 +26,7 @@ import net.minecraftforge.gradle.common.util.VersionJson;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
@@ -108,6 +109,7 @@ public class DownloadAssets extends DefaultTask {
         this.meta = value;
     }
 
+    @Internal
     public File getOutput() {
         return Utils.getCache(getProject(), "assets");
     }

--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadAssets.java
@@ -26,7 +26,7 @@ import net.minecraftforge.gradle.common.util.VersionJson;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.Internal;
+import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
@@ -109,7 +109,7 @@ public class DownloadAssets extends DefaultTask {
         this.meta = value;
     }
 
-    @Internal
+    @OutputDirectory
     public File getOutput() {
         return Utils.getCache(getProject(), "assets");
     }

--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadMCMeta.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadMCMeta.java
@@ -23,6 +23,7 @@ package net.minecraftforge.gradle.common.task;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
@@ -62,6 +63,7 @@ public class DownloadMCMeta extends DefaultTask {
         return mcVersion;
     }
 
+    @Internal
     public File getManifest() {
         return manifest;
     }

--- a/src/common/java/net/minecraftforge/gradle/common/task/DownloadMavenArtifact.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/DownloadMavenArtifact.java
@@ -25,6 +25,7 @@ import net.minecraftforge.gradle.common.util.MavenArtifactDownloader;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
@@ -43,6 +44,7 @@ public class DownloadMavenArtifact extends DefaultTask {
         getOutputs().upToDateWhen(task -> false); //We need to always ask, in case the file on maven/our local MinecraftRepo has changed.
     }
 
+    @Internal
     public String getResolvedVersion() {
         return MavenArtifactDownloader.getVersion(getProject(), _artifact.getDescriptor());
     }

--- a/src/common/java/net/minecraftforge/gradle/common/task/JarExec.java
+++ b/src/common/java/net/minecraftforge/gradle/common/task/JarExec.java
@@ -37,6 +37,7 @@ import org.gradle.api.file.FileCollection;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.TaskAction;
 
@@ -112,6 +113,7 @@ public class JarExec extends DefaultTask {
     protected void postProcess(File log) {
     }
 
+    @Internal
     public String getResolvedVersion() {
         return MavenArtifactDownloader.getVersion(getProject(), getTool());
     }

--- a/src/common/java/net/minecraftforge/gradle/common/util/MavenArtifactDownloader.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MavenArtifactDownloader.java
@@ -185,6 +185,7 @@ public class MavenArtifactDownloader {
             if (meta == null)
                 return null; //Don't error, other repos might have it.
             try {
+                // When we drop support for Gradle 6.8, change to reference groovy.xml.XmlParser
                 Node xml = new XmlParser().parse(meta);
                 Node versioning = getPath(xml, "versioning/versions");
                 List<Node> versions = versioning == null ? null : (List<Node>)versioning.get("version");

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/task/DownloadMCPConfigTask.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/task/DownloadMCPConfigTask.java
@@ -24,6 +24,7 @@ import net.minecraftforge.gradle.common.util.MavenArtifactDownloader;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.InputFile;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
@@ -52,6 +53,7 @@ public class DownloadMCPConfigTask extends DefaultTask {
         setDidWork(true);
     }
 
+    @Internal
     public Object getConfig() {
         return this.config;
     }

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/task/DownloadMCPConfigTask.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/task/DownloadMCPConfigTask.java
@@ -23,8 +23,8 @@ package net.minecraftforge.gradle.mcp.task;
 import net.minecraftforge.gradle.common.util.MavenArtifactDownloader;
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
-import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
@@ -53,7 +53,7 @@ public class DownloadMCPConfigTask extends DefaultTask {
         setDidWork(true);
     }
 
-    @Internal
+    @Input
     public Object getConfig() {
         return this.config;
     }

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
@@ -673,7 +673,7 @@ public class PatcherPlugin implements Plugin<Project> {
                 applyPatches.get().setBase(toMCPClean.getOutput());
                 genPatches.get().setDependsOn(Lists.newArrayList(toMCPClean, dirtyZip));
                 genPatches.get().setBase(toMCPClean.getOutput());
-                genPatches.get().setModified(dirtyZip.getArchivePath());
+                genPatches.get().setModified(dirtyZip.getArchiveFile().get().getAsFile());
             }
 
             {

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
@@ -673,7 +673,7 @@ public class PatcherPlugin implements Plugin<Project> {
                 applyPatches.get().setBase(toMCPClean.getOutput());
                 genPatches.get().setDependsOn(Lists.newArrayList(toMCPClean, dirtyZip));
                 genPatches.get().setBase(toMCPClean.getOutput());
-                genPatches.get().setModified(dirtyZip.getArchiveFile().get().getAsFile());
+                genPatches.get().setModified(dirtyZip.getArchivePath());
             }
 
             {


### PR DESCRIPTION
This PR adds support for Gradle 7.0 (while maintaining compatibility with Gradle 6.8.1).

### Summary
- Fix `HackyJavaCompile` to work on Gradle 7.0
- Adds `@Internal` annotations to non-annotated getters
- Remove use of deprecated method

### Testing
A build of ForgeGradle with these changes are available at my maven, `https://sciwhiz12.tk/maven`, the `tk.sciwhiz12.gradle:ForgeGradle:4.1.9` artifact.

This has been tested by gigaherz (as testified in the [`#gradle` channel of The Forge Project Discord server](https://discord.com/channels/313125603924639766/801175194298744902/830431346987892787)) to work with [Gradle 7.0; JDK 8u212] and [Gradle 6.8.3, JDK 15].

Note that this is not compatible by default to run on Java 16, due to the use of reflection by [Artifactural](https://github.com/MinecraftForge/Artifactural/blob/master/src/java9/net/minecraftforge/artifactural/gradle/ModifierAccess.java) (which is done to JDK modules which are strongly encapsulated in JDK 16). 

Using the following in the `gradle.properties` will allow this build of ForgeGradle to work on Java 16 (but building fails due to a bug with ForgeFlower and Java 16):
```properties
org.gradle.jvmargs=-Xmx3G -XX:+IgnoreUnrecognizedVMOptions --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
```

> **Note that ForgeGradle does not officially support building/running with Java 16, as the official Java target is Java 8, the same as Minecraft Forge and Minecraft.**

### In-depth
- **Fix `HackyJavaCompile` to work on Gradle 7.0**
  _(ignore the first commit, the second commit is the one that contains the correct changes)_

Because of the removal of `JavaToolChainInternal` in Gradle 7.0, a bit of refactoring had to be done to accomodate the changes. Instead of manually creating the `CleaningJavaCompiler` (and `DefaultDeleter`) ourselves, we now call `JavaCompile#createCompiler` (a package-private method).

However, `JavaCompile#createCompiler` has different method signatures between 6.8.x and 7.0; notably, 7.0 does not have the `JavaCompileSpec` parameter (as the legacy java toolchain was removed, the `JavaToolChainInternal`, in favor of the new java toolchains system).

As a workaround, it will first check for the `createCompiler` with the parameter (6.8.x), then the one without the parameter (7.0), and fail otherwise (newer version which changes their internals again).
(See `HackyJavaCompile#createCompiler` for the relevant code)

- **Adds `@Internal` annotations to non-annotated getters**

Gradle 7.0 introduced runtime validation of tasks. One validation check is ensuring that all task properties (Gradle defines a task property as something which has a public getter; for example, a `getSources()` method creates a `sources` task property) are marked with the proper annotations.

Some ForgeGradle tasks had getters which were unannotated, which failed this validation check. To fix this, the [`@Internal` annotation](https://docs.gradle.org/7.0/javadoc/org/gradle/api/tasks/Internal.html) is added to those getters, to prevent them from running afoul of the task property annotations runtime validation check.

- **Remove use of deprecated method**

Changes the use of the deprecated `AbstractArchiveTask#getArchivePath()` with the equivalent property `AbstractArchiveTask#getArchiveFile()`. 

Note that a deprecation warning is now present for `groovy.util.XMLParser` when building with the Gradle 7.0 API, but that is due to it having been moved to `groovy.xml` in Groovy 3. A comment has been placed to point towards replacing the reference whenever ForgeGradle drops support for 6.8.x.