### PR TITLE
[FG4] Automatically configure repositories

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -61,6 +61,7 @@ public class UserDevPlugin implements Plugin<Project> {
     @Override
     public void apply(@Nonnull Project project) {
         Utils.checkEnvironment();
+        Utils.addRepoFilters(project);
 
         @SuppressWarnings("unused")
         final Logger logger = project.getLogger();


### PR DESCRIPTION
Automatically configure repositories so they are not considered for the resolution of mapped dependencies.

This can be disabled via setting the System Property `net.minecraftforge.gradle.filter_repos` to `false`

### Example
For example trying to `fg.deobf("curse.maven:jei-238222:3280247")` without adding the cursemaven repository

Before:
```
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not find curse.maven:jei-238222:3280247_mapped_snapshot_20201028-1.16.3.
     Searched in the following locations:
       - https://maven.minecraftforge.net/curse/maven/jei-238222/3280247_mapped_snapshot_20201028-1.16.3/jei-238222-3280247_mapped_snapshot_20201028-1.16.3.module
       - https://maven.minecraftforge.net/curse/maven/jei-238222/3280247_mapped_snapshot_20201028-1.16.3/jei-238222-3280247_mapped_snapshot_20201028-1.16.3.pom
       - https://maven.minecraftforge.net/curse/maven/jei-238222/3280247_mapped_snapshot_20201028-1.16.3/jei-238222-3280247_mapped_snapshot_20201028-1.16.3.jar
       - file:/C:/Users/USER/.gradle/caches/forge_gradle/bundeled_repo/curse/maven/jei-238222/3280247_mapped_snapshot_20201028-1.16.3/jei-238222-3280247_mapped_snapshot_20201028-1.16.3.pom
       - file:/C:/Users/USER/.gradle/caches/forge_gradle/bundeled_repo/curse/maven/jei-238222/3280247_mapped_snapshot_20201028-1.16.3/jei-238222-3280247_mapped_snapshot_20201028-1.16.3.jar
       - https://libraries.minecraft.net/curse/maven/jei-238222/3280247_mapped_snapshot_20201028-1.16.3/jei-238222-3280247_mapped_snapshot_20201028-1.16.3.jar
       - https://repo.maven.apache.org/maven2/curse/maven/jei-238222/3280247_mapped_snapshot_20201028-1.16.3/jei-238222-3280247_mapped_snapshot_20201028-1.16.3.pom
     Required by:
         project :

Possible solution:
 - Declare repository providing the artifact, see the documentation at https://docs.gradle.org/current/userguide/declaring_repositories.html
```

After:
```
Execution failed for task ':compileJava'.
> Could not resolve all files for configuration ':compileClasspath'.
   > Could not find curse.maven:jei-238222:3280247_mapped_snapshot_20201028-1.16.3.
     Searched in the following locations:
       - file:/C:/Users/USER/.gradle/caches/forge_gradle/bundeled_repo/curse/maven/jei-238222/3280247_mapped_snapshot_20201028-1.16.3/jei-238222-3280247_mapped_snapshot_20201028-1.16.3.pom
       - file:/C:/Users/USER/.gradle/caches/forge_gradle/bundeled_repo/curse/maven/jei-238222/3280247_mapped_snapshot_20201028-1.16.3/jei-238222-3280247_mapped_snapshot_20201028-1.16.3.jar
     Required by:
         project :

Possible solution:
 - Declare repository providing the artifact, see the documentation at https://docs.gradle.org/current/userguide/declaring_repositories.html
```