### PR TITLE
Update maven endpoint + Jenkinsfile + upload task + add warning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,12 +3,12 @@
 pipeline {
     agent {
         docker {
-            image 'gradlewrapper:latest'
+            image 'gradle:jdk8'
             args '-v gradlecache:/gradlecache'
         }
     }
     environment {
-        GRADLE_ARGS = '-Dorg.gradle.daemon.idletimeout=5000 --stacktrace --info'
+        GRADLE_ARGS = '-Dorg.gradle.daemon.idletimeout=5000'
         DISCORD_WEBHOOK = credentials('forge-discord-jenkins-webhook')
         DISCORD_PREFIX = "Job: ForgeGradle Branch: ${BRANCH_NAME} Build: #${BUILD_NUMBER}"
         JENKINS_HEAD = 'https://wiki.jenkins-ci.org/download/attachments/2916393/headshot.png'
@@ -38,19 +38,15 @@ pipeline {
         }
         stage('buildandtest') {
             steps {
-                sh './gradlew ${GRADLE_ARGS} --refresh-dependencies --continue build' // test'
+                withGradle {
+                    sh './gradlew ${GRADLE_ARGS} --refresh-dependencies --continue build test'
+                }
                 script {
+                    env.MYGROUP = sh(returnStdout: true, script: './gradlew properties -q | grep "group:" | awk \'{print $2}\'').trim()
+                    env.MYARTIFACT = sh(returnStdout: true, script: './gradlew properties -q | grep "name:" | awk \'{print $2}\'').trim()
                     env.MYVERSION = sh(returnStdout: true, script: './gradlew properties -q | grep "version:" | awk \'{print $2}\'').trim()
                 }
             }
-            /*
-            post {
-                success {
-                    writeChangelog(currentBuild, 'build/changelog.txt')
-                    archiveArtifacts artifacts: 'build/changelog.txt', fingerprint: false
-                }
-            }
-            */
         }
         stage('publish') {
             when {
@@ -58,19 +54,23 @@ pipeline {
                     changeRequest()
                 }
             }
-            environment {
-                FORGE_MAVEN = credentials('forge-maven-forge-user')
-            }
             steps {
-                sh './gradlew ${GRADLE_ARGS} uploadArchives -PforgeMavenUser=${FORGE_MAVEN_USR} -PforgeMavenPassword=${FORGE_MAVEN_PSW}'
+                withCredentials([usernamePassword(credentialsId: 'maven-forge-user', usernameVariable: 'MAVEN_USER', passwordVariable: 'MAVEN_PASSWORD')]) {
+                    withGradle {
+                        sh './gradlew ${GRADLE_ARGS} uploadArchives'
+                    }
+                }
+            }
+            post {
+                success {
+                    build job: 'filegenerator', parameters: [string(name: 'COMMAND', value: "promote ${env.MYGROUP}:${env.MYARTIFACT} ${env.MYVERSION} latest")], propagate: false, wait: false
+                }
             }
         }
     }
     post {
         always {
             script {
-                archiveArtifacts artifacts: 'build/libs/**/*.jar', fingerprint: true
-
                 if (env.CHANGE_ID == null) { // This is unset for non-PRs
                     discordSend(
                         title: "${DISCORD_PREFIX} Finished ${currentBuild.currentResult}",

--- a/build.gradle
+++ b/build.gradle
@@ -362,10 +362,10 @@ uploadArchives {
 
         dependsOn 'build'
 
-        if (project.hasProperty('forgeMavenPassword'))
+        if (System.getenv('MAVEN_USER'))
         {
-            repository(url: "https://maven.minecraftforge.net/manage/upload") {
-                authentication(userName: project.getProperty('forgeMavenUser'), password: project.getProperty('forgeMavenPassword'))
+            repository(url: "https://maven.minecraftforge.net/") {
+                authentication(userName: System.getenv('MAVEN_USER'), password: System.getenv('MAVEN_PASSWORD'))
             }
         }
         else

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ repositories {
     mavenLocal()
     maven {
         name = "forge"
-        url = "https://files.minecraftforge.net/maven"
+        url = "https://maven.minecraftforge.net"
     }
     maven {
         // because Srg2Source needs an eclipse dependency.
@@ -364,7 +364,7 @@ uploadArchives {
 
         if (project.hasProperty('forgeMavenPassword'))
         {
-            repository(url: "https://files.minecraftforge.net/maven/manage/upload") {
+            repository(url: "https://maven.minecraftforge.net/manage/upload") {
                 authentication(userName: project.getProperty('forgeMavenUser'), password: project.getProperty('forgeMavenPassword'))
             }
         }

--- a/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
@@ -242,7 +242,7 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
 //        ApplyFernFlowerTask ffTask = ((ApplyFernFlowerTask) project.getTasks().getByName("decompileJar"));
 //        ffTask.setClasspath(javaConv.getSourceSets().getByName("main").getCompileClasspath());
 
-        // https://files.minecraftforge.net/maven/de/oceanlabs/mcp/mcp/1.7.10/mcp-1.7.10-srg.zip
+        // https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp/1.7.10/mcp-1.7.10-srg.zip
         project.getDependencies().add(CONFIG_MAPPINGS, ImmutableMap.of(
                 "group", "de.oceanlabs.mcp",
                 "name", delayedString("mcp_" + REPLACE_MCP_CHANNEL).call(),

--- a/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
@@ -267,7 +267,8 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
         }
 
         LOGGER.warn("WARNING: You are using an unsupported version of ForgeGradle.");
-        LOGGER.warn("Please consider upgrading to ForgeGradle 4 and helping in the efforts to get old versions working on the modern toolchain. See #mcpconfig in the Forge discord for more info.");
+        LOGGER.warn("Please consider upgrading to ForgeGradle 4 and helping in the efforts to get old versions working on the modern toolchain.");
+        LOGGER.warn("See https://gist.github.com/TheCurle/fe7ad3ede188cbdd15c235cc75d52d4a for more info on contributing.");
 
         if (!displayBanner)
             return;

--- a/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
@@ -266,6 +266,9 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
             doFGVersionCheck(lines);
         }
 
+        LOGGER.warn("WARNING: You are using an unsupported version of ForgeGradle.");
+        LOGGER.warn("Please consider upgrading to ForgeGradle 4 and helping in the efforts to get old versions working on the modern toolchain. See #mcpconfig in the Forge discord for more info.");
+
         if (!displayBanner)
             return;
 
@@ -281,9 +284,6 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
 
         for (String str : lines)
             LOGGER.lifecycle(str);
-
-        LOGGER.warn("WARNING: You are using an unsupported version of ForgeGradle.");
-        LOGGER.warn("Please consider upgrading to ForgeGradle 4 and helping in the efforts to get old versions working on the modern toolchain. See #mcpconfig in the Forge discord for more info.");
 
         displayBanner = false;
     }

--- a/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
@@ -282,6 +282,9 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
         for (String str : lines)
             LOGGER.lifecycle(str);
 
+        LOGGER.warn("WARNING: You are using an unsupported version of ForgeGradle.");
+        LOGGER.warn("Please consider upgrading to ForgeGradle 4 and helping in the efforts to get old versions working on the modern toolchain. See #gradle in the Forge discord for more info.");
+
         displayBanner = false;
     }
 

--- a/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
@@ -283,7 +283,7 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
             LOGGER.lifecycle(str);
 
         LOGGER.warn("WARNING: You are using an unsupported version of ForgeGradle.");
-        LOGGER.warn("Please consider upgrading to ForgeGradle 4 and helping in the efforts to get old versions working on the modern toolchain. See #gradle in the Forge discord for more info.");
+        LOGGER.warn("Please consider upgrading to ForgeGradle 4 and helping in the efforts to get old versions working on the modern toolchain. See #mcpconfig in the Forge discord for more info.");
 
         displayBanner = false;
     }

--- a/src/main/java/net/minecraftforge/gradle/common/Constants.java
+++ b/src/main/java/net/minecraftforge/gradle/common/Constants.java
@@ -116,11 +116,11 @@ public class Constants
 
     // urls
     public static final String URL_MC_MANIFEST     = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
-    public static final String URL_FF              = "https://files.minecraftforge.net/fernflower-fix-1.0.zip";
+    public static final String URL_FF              = "https://gregtech.overminddl1.com/fernflower-fix-1.0.zip";
     public static final String URL_ASSETS          = "http://resources.download.minecraft.net";
     public static final String URL_LIBRARY         = "https://libraries.minecraft.net/"; // Mojang's Cloudflare front end
     //public static final String URL_LIBRARY         = "https://minecraft-libraries.s3.amazonaws.com/"; // Mojang's AWS server, as Cloudflare is having issues, TODO: Switch back to above when their servers are fixed.
-    public static final String URL_FORGE_MAVEN     = "https://files.minecraftforge.net/maven";
+    public static final String URL_FORGE_MAVEN     = "https://maven.minecraftforge.net";
     public static final List<String> URLS_MCP_JSON = Arrays.asList(
             URL_FORGE_MAVEN + "/de/oceanlabs/mcp/versions.json",
             "http://export.mcpbot.bspk.rs/versions.json"

--- a/src/main/java/net/minecraftforge/gradle/common/Constants.java
+++ b/src/main/java/net/minecraftforge/gradle/common/Constants.java
@@ -116,7 +116,6 @@ public class Constants
 
     // urls
     public static final String URL_MC_MANIFEST     = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
-    public static final String URL_FF              = "https://gregtech.overminddl1.com/fernflower-fix-1.0.zip";
     public static final String URL_ASSETS          = "http://resources.download.minecraft.net";
     public static final String URL_LIBRARY         = "https://libraries.minecraft.net/"; // Mojang's Cloudflare front end
     //public static final String URL_LIBRARY         = "https://minecraft-libraries.s3.amazonaws.com/"; // Mojang's AWS server, as Cloudflare is having issues, TODO: Switch back to above when their servers are fixed.

--- a/src/main/java/net/minecraftforge/gradle/patcher/PatcherConstants.java
+++ b/src/main/java/net/minecraftforge/gradle/patcher/PatcherConstants.java
@@ -29,7 +29,7 @@ final class PatcherConstants
 
     // installer stuff
     static final String REPLACE_INSTALLER        = "{INSTALLER}";
-    static final String INSTALLER_URL            = "https://files.minecraftforge.net/maven/net/minecraftforge/installer/" + REPLACE_INSTALLER + "/installer-" + REPLACE_INSTALLER + "-shrunk.jar";
+    static final String INSTALLER_URL            = "https://maven.minecraftforge.net/net/minecraftforge/installer/" + REPLACE_INSTALLER + "/installer-" + REPLACE_INSTALLER + "-shrunk.jar";
 
     // new project defaults
     static final String DEFAULT_PATCHES_DIR      = "patches";

--- a/src/main/java/net/minecraftforge/gradle/user/patcherUser/forge/ForgeExtension.java
+++ b/src/main/java/net/minecraftforge/gradle/user/patcherUser/forge/ForgeExtension.java
@@ -130,7 +130,7 @@ public class ForgeExtension extends UserBaseExtension
          *     Output: 1.8-11.14.4.1563
          *   Solution:
          *     Again, Abrar downloaded a 2MB MASSIVE json file, when a slim json would do.
-         *     https://files.minecraftforge.net/maven/net/minecraftforge/forge/promotions_slim.json
+         *     https://maven.minecraftforge.net/net/minecraftforge/forge/promotions_slim.json
          *
          *
          * API-Wildcards:


### PR DESCRIPTION
This is mainly for all the whiners out there. This PR is simple in what it does. I updated the maven endpoint to the new one, along with the Jenkinsfile and upload task used by Jenkins. I have no real way to test the Jenkinsfile, but I copied the one from FG4 and modified one line to use the correct gradle task for the older version. I also modified the actual upload task to use the modified variables. A warning is now spit out every time something relating to gradle is executed warning the user that the version is unsupported and they should upgrade or see the Forge discord for more info on helping. The exact message is:
```
WARNING: You are using an unsupported version of ForgeGradle.
Please consider upgrading to ForgeGradle 4 and helping in the efforts to get old versions working on the modern toolchain. See #mcpconfig in the Forge discord for more info.
```