### PR TITLE
Update Artifactural and AccessTransformers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     commonImplementation 'com.google.code.gson:gson:2.8.6'
     commonImplementation 'com.google.guava:guava:30.1-jre'
     commonImplementation 'de.siegmar:fastcsv:2.0.0'
-    commonImplementation 'net.minecraftforge:artifactural:2.0.3'
+    commonImplementation 'net.minecraftforge:artifactural:3.0.8'
     commonImplementation 'org.apache.maven:maven-artifact:3.6.3'
     commonImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
     commonImplementation 'net.minecraftforge:srgutils:0.4.1'

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -106,7 +106,7 @@ public class Utils {
     public static final String FORGE_MAVEN = "https://maven.minecraftforge.net/";
     public static final String MOJANG_MAVEN = "https://libraries.minecraft.net/";
     public static final String BINPATCHER =  "net.minecraftforge:binarypatcher:1.+:fatjar";
-    public static final String ACCESSTRANSFORMER = "net.minecraftforge:accesstransformers:1.0.+:fatjar";
+    public static final String ACCESSTRANSFORMER = "net.minecraftforge:accesstransformers:3.0.+:fatjar";
     public static final String SPECIALSOURCE = "net.md-5:SpecialSource:1.9.0:shaded";
     public static final String SRG2SOURCE =  "net.minecraftforge:Srg2Source:7.+:fatjar";
     public static final String SIDESTRIPPER = "net.minecraftforge:mergetool:1.0.7:fatjar";

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/task/DownloadMCPConfigTask.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/task/DownloadMCPConfigTask.java
@@ -59,7 +59,7 @@ public class DownloadMCPConfigTask extends DefaultTask {
     }
 
     @InputFile
-    private File getConfigFile() {
+    public File getConfigFile() {
         return downloadConfigFile(config);
     }
 

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/task/TaskApplyPatches.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/task/TaskApplyPatches.java
@@ -104,19 +104,19 @@ public class TaskApplyPatches extends DefaultTask {
     }
 
     //@formatter:off
-    @Input                    public File getBase() { return base; }
+    @InputFile                public File getBase() { return base; }
     @InputDirectory @Optional public File getPatches() { return patches ; }
     @OutputFile               public File getOutput() { return output; }
-                    @Optional public File getRejects() { return rejects; }
+    @OutputFile     @Optional public File getRejects() { return rejects; }
     @Input          @Optional public ArchiveFormat getOutputFormat() { return outputFormat; }
     @Input          @Optional public ArchiveFormat getRejectsFormat() { return rejectsFormat; }
-    @Input          @Optional public float getMinFuzzQuality() { return minFuzzQuality; }
-    @Input          @Optional public int getMaxFuzzOffset() { return maxFuzzOffset; }
+    @Input                    public float getMinFuzzQuality() { return minFuzzQuality; }
+    @Input                    public int getMaxFuzzOffset() { return maxFuzzOffset; }
     @Input          @Optional public PatchMode getPatchMode() { return patchMode; }
     @Input          @Optional public String getPatchesPrefix() { return patchesPrefix; }
-                    @Optional public boolean isVerbose() { return verbose; }
-                    @Optional public boolean isPrintSummary() { return printSummary; }
-    @Input          @Optional public boolean isFailOnError() { return failOnError; }
+    @Input                    public boolean isVerbose() { return verbose; }
+    @Input                    public boolean isPrintSummary() { return printSummary; }
+    @Input                    public boolean isFailOnError() { return failOnError; }
     @Input          @Optional public String getOriginalPrefix() { return originalPrefix; }
     @Input          @Optional public String getModifiedPrefix() { return modifiedPrefix; }
                               public void setBase(File base) { this.base = base; }


### PR DESCRIPTION
This PR updates Artifactural and AccessTransformers to function with Gradle 7/prepare for Forge development on 1.17.

Gradle annotations and visiblity in DownloadMCPConfigTask and TaskApplyPatches have been changed to fix errors with forgedev on Gradle 7.