### PR TITLE
Support the new MCPConfig format

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/McpNames.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/McpNames.java
@@ -50,7 +50,7 @@ import org.apache.commons.lang3.tuple.Pair;
 
 public class McpNames {
     private static final String NEWLINE = System.getProperty("line.separator");
-    private static final Pattern SRG_FINDER             = Pattern.compile("(?:[fF]unc_|m_)[0-9]+_[a-zA-Z_]+|(?:[fF]ield_|f_)[0-9]+_[a-zA-Z_]+|p_[\\w]+_\\d+_\\b");
+    private static final Pattern SRG_FINDER             = Pattern.compile("[fF]unc_[0-9]+_[a-zA-Z_]+|m_[0-9]+_|[fF]ield_[0-9]+_[a-zA-Z_]+|f_[0-9]+_|p_[\\w]+_\\d+_\\b");
     private static final Pattern METHOD_JAVADOC_PATTERN = Pattern.compile("^(?<indent>(?: {3})+|\\t+)(?!return)(?:\\w+\\s+)*(?<generic><[\\w\\W]*>\\s+)?(?<return>\\w+[\\w$.]*(?:<[\\w\\W]*>)?[\\[\\]]*)\\s+(?<name>(?:func_|m_)[0-9]+_[a-zA-Z_]+)\\(");
     private static final Pattern FIELD_JAVADOC_PATTERN  = Pattern.compile("^(?<indent>(?: {3})+|\\t+)(?!return)(?:\\w+\\s+)*(?:\\w+[\\w$.]*(?:<[\\w\\W]*>)?[\\[\\]]*)\\s+(?<name>(?:field_|f_)[0-9]+_[a-zA-Z_]+) *(?:=|;)");
     private static final Pattern CLASS_JAVADOC_PATTERN  = Pattern.compile("^(?<indent>(?: )*|\\t*)([\\w|@]*\\s)*(class|interface|@interface|enum) (?<name>[\\w]+)");

--- a/src/common/java/net/minecraftforge/gradle/common/util/McpNames.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/McpNames.java
@@ -50,9 +50,9 @@ import org.apache.commons.lang3.tuple.Pair;
 
 public class McpNames {
     private static final String NEWLINE = System.getProperty("line.separator");
-    private static final Pattern SRG_FINDER             = Pattern.compile("[fF]unc_[0-9]+_[a-zA-Z_]+|[fF]ield_[0-9]+_[a-zA-Z_]+|p_[\\w]+_\\d+_\\b");
-    private static final Pattern METHOD_JAVADOC_PATTERN = Pattern.compile("^(?<indent>(?: {3})+|\\t+)(?!return)(?:\\w+\\s+)*(?<generic><[\\w\\W]*>\\s+)?(?<return>\\w+[\\w$.]*(?:<[\\w\\W]*>)?[\\[\\]]*)\\s+(?<name>func_[0-9]+_[a-zA-Z_]+)\\(");
-    private static final Pattern FIELD_JAVADOC_PATTERN  = Pattern.compile("^(?<indent>(?: {3})+|\\t+)(?!return)(?:\\w+\\s+)*(?:\\w+[\\w$.]*(?:<[\\w\\W]*>)?[\\[\\]]*)\\s+(?<name>field_[0-9]+_[a-zA-Z_]+) *(?:=|;)");
+    private static final Pattern SRG_FINDER             = Pattern.compile("(?:[fF]unc_|m_)[0-9]+_[a-zA-Z_]+|(?:[fF]ield_|f_)[0-9]+_[a-zA-Z_]+|p_[\\w]+_\\d+_\\b");
+    private static final Pattern METHOD_JAVADOC_PATTERN = Pattern.compile("^(?<indent>(?: {3})+|\\t+)(?!return)(?:\\w+\\s+)*(?<generic><[\\w\\W]*>\\s+)?(?<return>\\w+[\\w$.]*(?:<[\\w\\W]*>)?[\\[\\]]*)\\s+(?<name>(?:func_|m_)[0-9]+_[a-zA-Z_]+)\\(");
+    private static final Pattern FIELD_JAVADOC_PATTERN  = Pattern.compile("^(?<indent>(?: {3})+|\\t+)(?!return)(?:\\w+\\s+)*(?:\\w+[\\w$.]*(?:<[\\w\\W]*>)?[\\[\\]]*)\\s+(?<name>(?:field_|f_)[0-9]+_[a-zA-Z_]+) *(?:=|;)");
     private static final Pattern CLASS_JAVADOC_PATTERN  = Pattern.compile("^(?<indent>(?: )*|\\t*)([\\w|@]*\\s)*(class|interface|@interface|enum) (?<name>[\\w]+)");
     private static final Pattern CLOSING_CURLY_BRACE    = Pattern.compile("^(?<indent>(?: )*|\\t*)}");
     private static final Pattern PACKAGE_DECL           = Pattern.compile("^[\\s]*package(\\s)*(?<name>[\\w|.]+);$");

--- a/src/common/java/net/minecraftforge/gradle/common/util/MinecraftRepo.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MinecraftRepo.java
@@ -316,10 +316,11 @@ public class MinecraftRepo extends BaseRepo {
 
             Set<String> whitelist = new HashSet<>();
             List<String> lines = Utils.lines(mappings).map(line -> line.split("#")[0]).filter(l -> !Strings.isNullOrEmpty(l.trim())).collect(Collectors.toList()); //Strip comments and empty lines
+            boolean tsrgv2 = !lines.isEmpty() && lines.get(0).startsWith("tsrg2"); // TSRGv2 has an extra space that we must account for when splitting
             lines.stream()
             .filter(line -> !line.startsWith("\t") || (line.indexOf(':') != -1 && line.startsWith("CL:"))) // Class lines only
             .map(line -> line.indexOf(':') != -1 ? line.substring(4).split(" ") : line.split(" ")) //Convert to: OBF SRG
-            .filter(pts -> pts.length == 2 && !pts[0].endsWith("/")) //Skip packages
+            .filter(pts -> pts.length == (tsrgv2 ? 3 : 2) && !pts[0].endsWith("/")) //Skip packages
             .forEach(pts -> whitelist.add(pts[0]));
 
             for (Enumeration<? extends ZipEntry> entries = zin.entries(); entries.hasMoreElements();) {

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/MCPRepo.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/MCPRepo.java
@@ -497,12 +497,12 @@ public class MCPRepo extends BaseRepo {
                     continue;
                 for (IField fld : cls.getFields()) {
                     String name = obf.remapField(fld.getMapped());
-                    if (name.startsWith("field_"))
+                    if (name.startsWith("field_") || name.startsWith("f_"))
                         cfields.put(name, fld.getOriginal());
                 }
                 for (IMethod mtd : cls.getMethods()) {
                     String name = obf.remapMethod(mtd.getMapped(), mtd.getMappedDescriptor());
-                    if (name.startsWith("func_"))
+                    if (name.startsWith("func_") || name.startsWith("m_"))
                         cmethods.put(name, mtd.getOriginal());
                 }
             }
@@ -512,12 +512,12 @@ public class MCPRepo extends BaseRepo {
                     continue;
                 for (IField fld : cls.getFields()) {
                     String name = obf.remapField(fld.getMapped());
-                    if (name.startsWith("field_"))
+                    if (name.startsWith("field_") || name.startsWith("f_"))
                         sfields.put(name, fld.getOriginal());
                 }
                 for (IMethod mtd : cls.getMethods()) {
                     String name = obf.remapMethod(mtd.getMapped(), mtd.getMappedDescriptor());
-                    if (name.startsWith("func_"))
+                    if (name.startsWith("func_") || name.startsWith("m_"))
                         smethods.put(name, mtd.getOriginal());
                 }
             }


### PR DESCRIPTION
Currently, FG does not support the new MCPConfig format and will filter it out accidentally, causing SRG files to be generated that map srg <-> srg because all the mappings are filtered out. Tested and confirmed to work.