### PR TITLE
Update MergeTool

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -109,7 +109,7 @@ public class Utils {
     public static final String ACCESSTRANSFORMER = "net.minecraftforge:accesstransformers:3.0.+:fatjar";
     public static final String SPECIALSOURCE = "net.md-5:SpecialSource:1.9.0:shaded";
     public static final String SRG2SOURCE =  "net.minecraftforge:Srg2Source:7.+:fatjar";
-    public static final String SIDESTRIPPER = "net.minecraftforge:mergetool:1.+:fatjar";
+    public static final String SIDESTRIPPER = "net.minecraftforge:mergetool:1.1.3:fatjar";
     public static final String INSTALLERTOOLS = "net.minecraftforge:installertools:1.1.10:fatjar";
     public static final long ZIPTIME = 628041600000L;
     public static final TimeZone GMT = TimeZone.getTimeZone("GMT");

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -109,7 +109,7 @@ public class Utils {
     public static final String ACCESSTRANSFORMER = "net.minecraftforge:accesstransformers:3.0.+:fatjar";
     public static final String SPECIALSOURCE = "net.md-5:SpecialSource:1.9.0:shaded";
     public static final String SRG2SOURCE =  "net.minecraftforge:Srg2Source:7.+:fatjar";
-    public static final String SIDESTRIPPER = "net.minecraftforge:mergetool:1.0.7:fatjar";
+    public static final String SIDESTRIPPER = "net.minecraftforge:mergetool:1.+:fatjar";
     public static final String INSTALLERTOOLS = "net.minecraftforge:installertools:1.1.10:fatjar";
     public static final long ZIPTIME = 628041600000L;
     public static final TimeZone GMT = TimeZone.getTimeZone("GMT");


### PR DESCRIPTION
Currently crashing on 1.17 decomp because it is not using the latest version with updated ASM. Made version range  dynamic with `1.+`.