### PR TITLE
Fix issue with HackyJavaCompile and java 8

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -1272,10 +1272,9 @@ public class MinecraftUserRepo extends BaseRepo {
             Set<File> files = Sets.newHashSet(this.extraDataFiles);
             Collections.addAll(files, extraDeps);
             compile.setClasspath(project.files(files));
-            int target = mcp.wrapper.getConfig().getJavaTarget();
-            String targetString = (target <= 8 ? "1." : "") + target;
-            compile.setSourceCompatibility(targetString);
-            compile.setTargetCompatibility(targetString);
+            String target = String.valueOf(mcp.wrapper.getConfig().getJavaTarget());
+            compile.setSourceCompatibility(target);
+            compile.setTargetCompatibility(target);
             compile.setDestinationDir(output);
             compile.setSource(source.isDirectory() ? project.fileTree(source) : project.zipTree(source));
 


### PR DESCRIPTION
Fixes an issue where HackyJavaCompile would throw an exception trying to parse "1.8" as a number.