### PR TITLE
[FG5] Fix HackyJavaCompile overriding the global project toolchain

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/HackyJavaCompile.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/HackyJavaCompile.java
@@ -22,7 +22,6 @@ package net.minecraftforge.gradle.userdev.tasks;
 
 import org.gradle.api.internal.tasks.compile.DefaultJavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
-import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.compile.JavaCompile;
@@ -60,9 +59,8 @@ public class HackyJavaCompile extends JavaCompile {
     }
 
     private void setCompiler() {
-        JavaPluginExtension javaPlugin = getProject().getExtensions().getByType(JavaPluginExtension.class);
         JavaToolchainService service = getProject().getExtensions().getByType(JavaToolchainService.class);
-        Provider<JavaCompiler> compiler = service.compilerFor(javaPlugin.toolchain(s -> s.getLanguageVersion().set(JavaLanguageVersion.of(this.getSourceCompatibility()))));
+        Provider<JavaCompiler> compiler = service.compilerFor(s -> s.getLanguageVersion().set(JavaLanguageVersion.of(this.getSourceCompatibility())));
         this.getJavaCompiler().set(compiler);
     }
 


### PR DESCRIPTION
I noticed that my run configs were using JDK8 only if I previously had run the clean task.
Turns out that HackyJavaCompile accidentally changes the entire project's toolchain to lookup the right Java compiler.
Thankfully the toolchain service has a method to lookup compilers without using the toolchain from the project level.

(Note though: this will ignore the distribution that may be set on the project-level toolchain for HackyJavaCompile).