### PR TITLE
[FG5] Use MCPConfig java_target to select JRE for running MCPFunctions

### DIFF
--- a/src/mcp/java/net/minecraftforge/gradle/mcp/MCPPlugin.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/MCPPlugin.java
@@ -28,6 +28,7 @@ import net.minecraftforge.gradle.mcp.tasks.SetupMCP;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.repositories.MavenArtifactRepository.MetadataSources;
+import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.TaskProvider;
 
 import javax.annotation.Nonnull;
@@ -36,6 +37,9 @@ public class MCPPlugin implements Plugin<Project> {
 
     @Override
     public void apply(@Nonnull Project project) {
+        // Needed to gain access to the JavaToolchainService as an extension
+        project.getPluginManager().apply(JavaPlugin.class);
+
         MCPExtension extension = project.getExtensions().create("mcp", MCPExtension.class, project);
 
         TaskProvider<DownloadMCPConfig> downloadConfig = project.getTasks().register("downloadConfig", DownloadMCPConfig.class);

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/util/MCPEnvironment.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/util/MCPEnvironment.java
@@ -23,6 +23,7 @@ package net.minecraftforge.gradle.mcp.util;
 import net.minecraftforge.srgutils.MinecraftVersion;
 import org.gradle.api.Project;
 import org.gradle.api.logging.Logger;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 
 import java.io.File;
 import java.util.Map;
@@ -34,12 +35,14 @@ public class MCPEnvironment {
     public final String side;
     public Logger logger;
     private final MinecraftVersion mcVersion;
+    private final JavaLanguageVersion javaVersion;
 
-    public MCPEnvironment(MCPRuntime runtime, String mcVersion, String side) {
+    public MCPEnvironment(MCPRuntime runtime, String mcVersion, int javaVersion, String side) {
         this.runtime = runtime;
         this.project = runtime.project;
         this.side = side;
         this.mcVersion = MinecraftVersion.from(mcVersion);
+        this.javaVersion = JavaLanguageVersion.of(javaVersion);
     }
 
     public Map<String, Object> getArguments() {
@@ -80,4 +83,10 @@ public class MCPEnvironment {
         return this.mcVersion;
     }
 
+    /**
+     * @return The Java version used to run the MCP steps (decompilation, etc.)
+     */
+    public JavaLanguageVersion getJavaVersion() {
+        return javaVersion;
+    }
 }

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/util/MCPRuntime.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/util/MCPRuntime.java
@@ -58,7 +58,7 @@ public class MCPRuntime {
     public MCPRuntime(Project project, File mcp_config, MCPConfigV2 config, String side,
             File mcpDirectory, Map<String, MCPFunction> extraPres) {
         this.project = project;
-        this.environment = new MCPEnvironment(this, config.getVersion(), side);
+        this.environment = new MCPEnvironment(this, config.getVersion(), config.getJavaTarget(), side);
         this.mcpDirectory = mcpDirectory;
 
         this.zipFile = mcp_config;


### PR DESCRIPTION
Use the Java version that MCPConfig targets to run the MCPConfig functions, instead of the JRE that hosts Gradle.

This should fix J16 being used to decompile 1.16.5 (the decompiler seems to have issues with this), if Gradle itself is running under J16.

Fixes #804 