### PR TITLE
Change replaceArgs to accept Map<String, Collection<?>>

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/tasks/ApplyRangeMap.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/ApplyRangeMap.java
@@ -53,10 +53,11 @@ public abstract class ApplyRangeMap extends JarExec {
                 "{output}", getOutput().get().getAsFile(),
                 "{annotate}", annotate,
                 "{keepImports}", keepImports
-                ), ImmutableMultimap.<String, Object>builder()
-                        .putAll("{input}", getSources().getFiles())
-                        .putAll("{srg}", getSrgFiles().getFiles())
-                        .putAll("{exc}", getExcFiles().getFiles()).build()
+                ), ImmutableMap.of(
+                "{input}", getSources().getFiles(),
+                "{srg}", getSrgFiles().getFiles(),
+                "{exc}", getExcFiles().getFiles()
+                )
         );
     }
 

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/ExtractRangeMap.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/ExtractRangeMap.java
@@ -31,9 +31,6 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
-import org.gradle.jvm.toolchain.JavaLanguageVersion;
-
 import java.util.List;
 
 public abstract class ExtractRangeMap extends JarExec {
@@ -61,9 +58,10 @@ public abstract class ExtractRangeMap extends JarExec {
                 "{compat}", getSourceCompatibility().get(),
                 "{output}", getOutput().get().getAsFile(),
                 "{batched}", batch
-                ), ImmutableMultimap.<String, Object>builder()
-                        .putAll("{input}", getSources().getFiles())
-                        .putAll("{library}", getDependencies().getFiles()).build()
+                ), ImmutableMap.of(
+                "{input}", getSources().getFiles(),
+                "{library}", getDependencies().getFiles()
+                )
         );
     }
 

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/GenerateBinPatches.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/GenerateBinPatches.java
@@ -33,7 +33,6 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import java.util.List;
 
 public abstract class GenerateBinPatches extends JarExec {
@@ -53,20 +52,10 @@ public abstract class GenerateBinPatches extends JarExec {
                 "{dirty}", getDirtyJar().get().getAsFile(),
                 "{output}", getOutput().get().getAsFile(),
                 "{srg}", getSrg().get().getAsFile()
-                ), ImmutableMultimap.<String, Object>builder()
-                        .putAll("{patches}", getPatchSets().getFiles()).build()
+                ), ImmutableMap.of(
+                "{patches}", getPatchSets().getFiles()
+                )
         );
-        if (getPatchSets().isEmpty()) { // Remove {patches} if there are no patch sets
-            for (int i = 0; i < newArgs.size(); i++) {
-                String newArg = newArgs.get(i);
-                if ("{patches}".equals(newArg)) {
-                    newArgs.remove(i); // {patches}
-                    newArgs.remove(i - 1); // --patches
-                    break;
-                }
-            }
-
-        }
         return newArgs;
     }
 

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/RenameJar.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/RenameJar.java
@@ -41,7 +41,7 @@ public abstract class RenameJar extends JarExec {
     }
 
     protected List<String> filterArgs(List<String> args) {
-        return replaceArgs(args, ImmutableMap.of(
+        return replaceArgsMulti(args, ImmutableMap.of(
                 "{input}", getInput().get().getAsFile(),
                 "{output}", getOutput().get().getAsFile()
                 ), ImmutableMultimap.<String, Object>builder()

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/RenameJarInPlace.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/RenameJarInPlace.java
@@ -52,7 +52,7 @@ public abstract class RenameJarInPlace extends JarExec {
 
     @Override
     protected List<String> filterArgs(List<String> args) {
-        return replaceArgs(args, ImmutableMap.of(
+        return replaceArgsMulti(args, ImmutableMap.of(
                 "{input}", getInput().get().getAsFile(),
                 "{output}", temp.get().getAsFile()
                 ), ImmutableMultimap.<String, Object>builder()


### PR DESCRIPTION
Previously, because of how multimaps worked, a multi-replacement without any values would result in the replacement token (and the prefix) remaining in place. This causes issues if a key was associated with a potentially-empty list, since if the list is empty, the token and prefix remains which certainly causes issues with the program to run.

By changing from a mulitmap to a map of collections, this allows for 'empty inputs', where the key still exists in the map and therefore the replacement token and prefix are removed even if there are no values for that key. 

The original multimap method is renamed and made to forward to the new method, to preserve compatibility and to allow for cleaner calls in situtations where the caller guarantees the multi-replacement key will always have at least one value (such as a file input and additional inputs in the form of a set of files).

/cc @SizableShrimp