### PR TITLE
Fix Overwritten Arguments within Run Configurations

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
@@ -454,16 +454,18 @@ public class RunConfig extends GroovyObjectSupport implements Serializable {
         RunConfig first = overwrite ? other : this;
         RunConfig second = overwrite ? this : other;
 
-        args = new ArrayList<>();
+        List<String> args = new ArrayList<>();
         if (first.args != null)
             args.addAll(first.args);
         if (second.args != null)
             args.addAll(second.args);
-        jvmArgs = new ArrayList<>();
+        this.args = args;
+        List<String> jvmArgs = new ArrayList<>();
         if (first.jvmArgs != null)
             jvmArgs.addAll(first.jvmArgs);
         if (second.jvmArgs != null)
             jvmArgs.addAll(second.jvmArgs);
+        this.jvmArgs = jvmArgs;
         main = first.main == null ? second.main : first.main;
         mods = first.mods == null ? second.mods : first.mods;
         sources = first.sources == null ? second.sources : first.sources;


### PR DESCRIPTION
As of 5.0.29, a change to the [`RunConfig`](https://github.com/MinecraftForge/ForgeGradle/commit/fe11fabca8c813e09d8c8b70130719a86c0b463b#diff-7abeaa49b901bd9934d7af55c48aa88311ede5bd4d8fc6fcbe3be931c886864eL457-R466) was made that changed how program and jvm arguments were written during a merge.  Originally, they selected the current argument list depending on if it was null or not. However, the change in 5.0.29 made it so both arguments were merged into a single list.

The problem with the implementation was that the current run configuration would have their arguments overridden by a new array list before they were ever added to the new list. To adjust for this, the lists were made into local variables and then overwrites the current instance fields after all arguments have been added.