### PR TITLE
Fix Gradle 8 warnings

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
@@ -250,7 +250,7 @@ public abstract class RunConfigGenerator
         return wrapSpaces ? args.map(RunConfigGenerator::fixupArg) : args;
     }
 
-    protected static Stream<WrappedArgument> getArgsStream(RunConfig runConfig, Supplier<Map<String, String>> updatedTokens, boolean wrapSpaces)
+    private static Stream<WrappedArgument> getArgsStream(RunConfig runConfig, Supplier<Map<String, String>> updatedTokens, boolean wrapSpaces)
     {
         final Stream<WrappedArgument> args = runConfig.getArgs().stream()
                 .map((value) -> new WrappedArgument(() -> runConfig.replace(updatedTokens.get(), value)));


### PR DESCRIPTION
## Lazily evaluate updated tokens map for run tasks

The updated tokens map is created by passing in the contents of the `runtimeClasspath` configuration. However, the run tasks are configured with the updated tokens map, which means the configuration is queried on configuration, which is deprecated and liable to be invalid in Gradle 8 according to [1] and the warnings when running FG.

To avoid resolving the configuration at configuration time, then, the updated tokens map is lazily created and used for configuring the run tasks.

The `WrappedArgument` class provides a way to lazily provide a (optionally post-processed) string, overriding the `toString()` method to return the string instead of the default object behavior. This allows us to pass the object directly into the various configuration methods of JavaExecSpec, which internally store `Object`s which are lazily `toString()`ed when the actual arguments/environment variables/system properties are needed for execution.

As far as I can tell, this is the only place we need to do this: while the configuration is also resolved as part of the individual IDE run configuration generation tasks, it is resolved within the task execution as opposed to the task configuration of the run tasks.

[1]: [Gradle 7.1 User Guide, "Viewing and debugging dependencies", subsection "Resolving unsafe configuration resolution errors"](https://docs.gradle.org/7.1/userguide/viewing_debugging_dependencies.html#sub:resolving-unsafe-configuration-resolution-errors)

##  Add explicit task ordering to prevent Gradle dep. warnings

Gradle 7 now outputs more warnings for different wrong behaviors. One of these behaviors is when a task has an input set indirectly to the output of another task, without any ordering or dependency defined between them (whether via `dependsOn`, `mustRunAfter`, or passing a `Provider` from the output to the input).

To fix this, we define some tasks to `mustRunAfter` other tasks which produce their inputs without being connected via `dependsOn` or `Provider`s. Through this, Gradle will ensure that the producing tasks run _before_ the consuming tasks, but will not force the producers to run (which is what `dependsOn` specifies).
