### PR TITLE
Bump InstallerTools to 1.2.8

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -98,7 +98,7 @@ public class Utils {
     public static final String SPECIALSOURCE = "net.md-5:SpecialSource:1.10.0:shaded";
     public static final String SRG2SOURCE =  "net.minecraftforge:Srg2Source:8.+:fatjar";
     public static final String SIDESTRIPPER = "net.minecraftforge:mergetool:1.1.3:fatjar";
-    public static final String INSTALLERTOOLS = "net.minecraftforge:installertools:1.2.7:fatjar";
+    public static final String INSTALLERTOOLS = "net.minecraftforge:installertools:1.2.8:fatjar";
     public static final long ZIPTIME = 628041600000L;
     public static final TimeZone GMT = TimeZone.getTimeZone("GMT");
 


### PR DESCRIPTION
Fixes issues introduced by the bump to InstallerTools in https://github.com/MinecraftForge/ForgeGradle/commit/8ead65a2a4c5a2bdcdd05f2c1ce3df492e7345c6 that caused the SrgMcpRenamer to not be able to correct deobfuscate some files (https://github.com/MinecraftForge/InstallerTools/pull/4)