### PR TITLE
Fix configuration resolution method to preserve strategies and exclusions

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
@@ -200,9 +200,8 @@ public abstract class RunConfigGenerator
         return createRunTask(runConfig, project, prepareRuns.get(), additionalClientArgs);
     }
 
-    private static String getResolvedClasspath(ConfigurationContainer configurations, Configuration toResolve) {
-        Dependency[] dependencies = toResolve.getAllDependencies().toArray(new Dependency[0]);
-        return configurations.detachedConfiguration(dependencies).resolve().stream()
+    private static String getResolvedClasspath(Configuration toResolve) {
+        return toResolve.copyRecursive().resolve().stream()
                 .map(File::getAbsolutePath)
                 .collect(Collectors.joining(File.pathSeparator));
     }
@@ -210,7 +209,7 @@ public abstract class RunConfigGenerator
     protected static String createRuntimeClassPathList(final Project project) {
         ConfigurationContainer configurations = project.getConfigurations();
         Configuration runtimeClasspath = configurations.getByName("runtimeClasspath");
-        return getResolvedClasspath(configurations, runtimeClasspath);
+        return getResolvedClasspath(runtimeClasspath);
     }
 
     protected static String createMinecraftClassPath(final Project project) {
@@ -220,7 +219,7 @@ public abstract class RunConfigGenerator
             minecraft = configurations.findByName("minecraftImplementation");
         if (minecraft == null)
             throw new IllegalStateException("Could not find valid minecraft configuration!");
-        return getResolvedClasspath(configurations, minecraft);
+        return getResolvedClasspath(minecraft);
     }
 
     public static TaskProvider<JavaExec> createRunTask(final RunConfig runConfig, final Project project, final Task prepareRuns, final List<String> additionalClientArgs) {


### PR DESCRIPTION
Manually created detached configurations like the one currently being used don't inherit the resolution strategy and other customizations from the original configuration. This does, and otherwise appears to behave exactly the same in testing.

This change lets projects make use of Gradle's custom [dependency resolution rules](https://docs.gradle.org/current/userguide/resolution_rules.html) such as substitutions or version overrides, as well as [exclusions](https://docs.gradle.org/current/userguide/dependency_downgrade_and_exclude.html), allowing for much more streamlined multi-project workspaces and build environments.

As requested, this PR has been tested against the latest version of the MDK, and both upstream Forge and JEI.