### PR TITLE
fix: DynamicJarExec using unsupported type for @InputFiles

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/tasks/DynamicJarExec.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/DynamicJarExec.java
@@ -22,14 +22,17 @@ package net.minecraftforge.gradle.common.tasks;
 
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
+import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
+import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.util.List;
+import java.util.Map;
 
 public abstract class DynamicJarExec extends JarExec {
     public DynamicJarExec() {
@@ -48,6 +51,11 @@ public abstract class DynamicJarExec extends JarExec {
 
     @InputFiles
     @Optional
+    public Provider<Iterable<File>> getDataIterable() {
+        return getData().map(Map::values);
+    }
+
+    @Internal
     public abstract MapProperty<String, File> getData();
 
     @InputFile


### PR DESCRIPTION
Declaring a processor for Post Processing using the ForgeGradle Patcher Plugin will result in hard failing the build in `:postProcess`.
```
Caused by: org.gradle.internal.typeconversion.UnsupportedNotationException: Cannot convert the provided notation to a File or URI: {}.
The following types/formats are supported:
  - A String or CharSequence path, for example 'src/main/java' or '/usr/include'.
  - A String or CharSequence URI, for example 'file:/usr/include'.
  - A File instance.
  - A Path instance.
  - A Directory instance.
  - A RegularFile instance.
  - A URI or URL instance.
  - A TextResource instance.
```

This is due to `DynamicJarExec#getData` returning an unsupported type for the @InputFiles which Gradle then tries to convert.
See https://docs.gradle.org/current/userguide/more_about_tasks.html#table:incremental_build_annotations for reference.

Currently fixed in a non breaking way, this may want a second look in 5.2.