### PR TITLE
Fix IntelliJ downloading sources

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -408,7 +408,7 @@ public class Utils {
     public static void addRepoFilters(Project project) {
         if (!ENABLE_FILTER_REPOS) return;
 
-        if (project.getGradle().getStartParameter().getTaskNames().contains("DownloadSources")) {
+        if (project.getGradle().getStartParameter().getTaskNames().stream().anyMatch(t -> t.endsWith("DownloadSources"))) {
             // Only modify repos already present to fix issues with IntelliJ's download sources
             project.getRepositories().forEach(Utils::addMappedFilter);
         } else {


### PR DESCRIPTION
Newer IntelliJ versions prefix the `DownloadSources` task with a colon, although there may be other cases that make IntelliJ automatically prefix a subproject. The check in `addRepoFilters` has been changed to check all starting task names if they end with `DownloadSources` to future proof this. This fix allows clicking the `Download sources` button on dependency class files with ForgeGradle enabled to run without issues and attempt to download sources.