### PR TITLE
1.18 fixes

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/config/MCPConfigV2.java
+++ b/src/common/java/net/minecraftforge/gradle/common/config/MCPConfigV2.java
@@ -49,7 +49,7 @@ public class MCPConfigV2 extends MCPConfigV1 {
 
             byte[] data = IOUtils.toByteArray(zip.getInputStream(entry));
             int spec = Config.getSpec(data);
-            if (spec == 2)
+            if (spec == 2 || spec == 3)
                 return MCPConfigV2.get(data);
             if (spec == 1)
                 return new MCPConfigV2(MCPConfigV1.get(data));

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -95,9 +95,9 @@ public class Utils {
     public static final String FORGE_MAVEN = "https://maven.minecraftforge.net/";
     public static final String MOJANG_MAVEN = "https://libraries.minecraft.net/";
     public static final String BINPATCHER =  "net.minecraftforge:binarypatcher:1.+:fatjar";
-    public static final String ACCESSTRANSFORMER = "net.minecraftforge:accesstransformers:3.0.+:fatjar";
+    public static final String ACCESSTRANSFORMER = "net.minecraftforge:accesstransformers:8.0.+:fatjar";
     public static final String SPECIALSOURCE = "net.md-5:SpecialSource:1.10.0:shaded";
-    public static final String FART = "net.minecraftforge:ForgeAutoRenamingTool:0.1.5:all";
+    public static final String FART = "net.minecraftforge:ForgeAutoRenamingTool:0.1.8:all";
     public static final String SRG2SOURCE =  "net.minecraftforge:Srg2Source:8.+:fatjar";
     public static final String SIDESTRIPPER = "net.minecraftforge:mergetool:1.1.3:fatjar";
     public static final String INSTALLERTOOLS = "net.minecraftforge:installertools:1.2.8:fatjar";

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -97,7 +97,7 @@ public class Utils {
     public static final String BINPATCHER =  "net.minecraftforge:binarypatcher:1.+:fatjar";
     public static final String ACCESSTRANSFORMER = "net.minecraftforge:accesstransformers:8.0.+:fatjar";
     public static final String SPECIALSOURCE = "net.md-5:SpecialSource:1.10.0:shaded";
-    public static final String FART = "net.minecraftforge:ForgeAutoRenamingTool:0.1.8:all";
+    public static final String FART = "net.minecraftforge:ForgeAutoRenamingTool:0.1.+:all";
     public static final String SRG2SOURCE =  "net.minecraftforge:Srg2Source:8.+:fatjar";
     public static final String SIDESTRIPPER = "net.minecraftforge:mergetool:1.1.3:fatjar";
     public static final String INSTALLERTOOLS = "net.minecraftforge:installertools:1.2.8:fatjar";

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/ListLibrariesFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/ListLibrariesFunction.java
@@ -30,50 +30,45 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.Reader;
 import java.io.OutputStreamWriter;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.nio.charset.StandardCharsets;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 
 class ListLibrariesFunction implements MCPFunction {
+    private static final Attributes.Name FORMAT = new Attributes.Name("Bundler-Format");
 
     @Override
     public File execute(MCPEnvironment environment) {
         File output = (File)environment.getArguments().computeIfAbsent("output", (key) -> environment.getFile("libraries.txt"));
+        File bundle = (File) environment.getArguments().get("bundle");
 
-        try {
-            Gson gson = new Gson();
-            Reader reader = new FileReader(environment.getStepOutput("downloadJson"));
-            JsonObject json = gson.fromJson(reader, JsonObject.class);
-            reader.close();
+        try (FileSystem bundleFs = bundle == null ? null : FileSystems.newFileSystem(bundle.toPath(), null)) {
+            Set<String> artifacts;
+            if (bundleFs == null) {
+                artifacts = listDownloadJsonLibraries(environment, output);
+            } else {
+                artifacts = listBundleLibraries(environment, bundleFs, output);
+            }
 
-            // Gather all the libraries
-            Set<File> files = new HashSet<>();
-            for (JsonElement libElement : json.getAsJsonArray("libraries")) {
-                JsonObject library = libElement.getAsJsonObject();
-                String name = library.get("name").getAsString();
-                List<String> lst = new ArrayList<>();
+            Set<File> libraries = new HashSet<>();
+            for (String artifact : artifacts) {
+                File lib = MavenArtifactDownloader.gradle(environment.project, artifact, false);
+                if (lib == null)
+                    throw new RuntimeException("Could not resolve download: " + artifact);
 
-                if (library.has("downloads")) {
-                    JsonObject downloads = library.get("downloads").getAsJsonObject();
-                    if (downloads.has("artifact"))
-                        lst.add(name);
-                    if (downloads.has("classifiers"))
-                        downloads.get("classifiers").getAsJsonObject().keySet().forEach(cls -> lst.add(name + ':' + cls));
-                }
-
-
-                for (String artifact : lst) {
-                    File lib = MavenArtifactDownloader.gradle(environment.project, artifact, false);
-                    if (lib == null)
-                        throw new RuntimeException("Could not resolve download: " + artifact);
-
-                    files.add(lib);
-                }
+                libraries.add(lib);
             }
 
             // Write the list
@@ -81,7 +76,7 @@ class ListLibrariesFunction implements MCPFunction {
             output.getParentFile().mkdirs();
             output.createNewFile();
             PrintWriter writer = new PrintWriter(new OutputStreamWriter(new FileOutputStream(output), StandardCharsets.UTF_8));
-            for (File file : files) {
+            for (File file : libraries) {
                 writer.println("-e=" + file.getAbsolutePath());
             }
             writer.flush();
@@ -93,4 +88,83 @@ class ListLibrariesFunction implements MCPFunction {
         return output;
     }
 
+    private Set<String> listBundleLibraries(MCPEnvironment environment, FileSystem bundleFs, File output) throws IOException {
+        Path mfp = bundleFs.getPath("META-INF", "MANIFEST.MF");
+        if (!Files.exists(mfp))
+            throw new RuntimeException("Input archive does not contain META-INF/MANIFEST.MF");
+
+        Manifest mf;
+        try (InputStream is = Files.newInputStream(mfp)) {
+            mf = new Manifest(is);
+        }
+        String format = mf.getMainAttributes().getValue(FORMAT);
+        if (format == null)
+            throw new RuntimeException("Invalid bundler archive; missing format entry from manifest");
+
+        if (!"1.0".equals(format))
+            throw new RuntimeException("Unsupported bundler format " + format + "; only 1.0 is supported");
+
+        FileList libraries = FileList.read(bundleFs.getPath("META-INF", "libraries.list"));
+        Set<String> artifacts = new HashSet<>();
+        for (FileList.Entry entry : libraries.entries) {
+            artifacts.add(entry.id);
+        }
+
+        return artifacts;
+    }
+
+    private Set<String> listDownloadJsonLibraries(MCPEnvironment environment, File output) throws IOException {
+        Gson gson = new Gson();
+        Reader reader = new FileReader(environment.getStepOutput("downloadJson"));
+        JsonObject json = gson.fromJson(reader, JsonObject.class);
+        reader.close();
+
+        // Gather all the libraries
+        Set<String> artifacts = new HashSet<>();
+        for (JsonElement libElement : json.getAsJsonArray("libraries")) {
+            JsonObject library = libElement.getAsJsonObject();
+            String name = library.get("name").getAsString();
+
+            if (library.has("downloads")) {
+                JsonObject downloads = library.get("downloads").getAsJsonObject();
+                if (downloads.has("artifact"))
+                    artifacts.add(name);
+                if (downloads.has("classifiers"))
+                    downloads.get("classifiers").getAsJsonObject().keySet().forEach(cls -> artifacts.add(name + ':' + cls));
+            }
+        }
+
+        return artifacts;
+    }
+
+    private static class FileList {
+        static FileList read(Path path) throws IOException {
+            List<Entry> ret = new ArrayList<>();
+            for (String line : Files.readAllLines(path)) {
+                String[] pts = line.split("\t");
+                if (pts.length != 3)
+                    throw new IllegalStateException("Invalid file list line: " + line);
+                ret.add(new Entry(pts[0], pts[1], pts[2]));
+            }
+            return new FileList(ret);
+
+        }
+        private final List<Entry> entries;
+
+        private FileList(List<Entry> entries) {
+            this.entries = entries;
+        }
+
+        private static class Entry {
+            private final String hash;
+            @SuppressWarnings("unused")
+            private final String id;
+            private final String path;
+            Entry(String hash, String id, String path) {
+                this.hash = hash;
+                this.id = id;
+                this.path = path;
+            }
+        }
+    }
 }


### PR DESCRIPTION
This PR includes fixes to support 1.18. Changes included:
* Support MCPConfig config.json spec 3
* Support listing server libraries with bundler's `libraries.list`
* Fix `MinecraftRepo#getMCVersion` and clarify its purpose
* Update AccessTransformers to 8.0.x for newer ASM version to support java 17
  * Logging got broken in 8.0.x, this is probably something that should be looked into
* Update FART to use `0.1.+`
* Allow downloading MCPConfig from custom mavens instead of only forge maven (useful for local testing and other projects like RetroGradle)