### PR TITLE
[1.2] Fix forge 1.7.10 build 

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/common/Constants.java
+++ b/src/main/java/net/minecraftforge/gradle/common/Constants.java
@@ -50,11 +50,11 @@ public class Constants
     public static final Closure<Boolean> CALL_FALSE = new Closure<Boolean>(null){ public Boolean call(Object o){ return false; }};
 
     // urls
-    public static final String MC_JSON_URL      = "http://s3.amazonaws.com/Minecraft.Download/versions/{MC_VERSION}/{MC_VERSION}.json";
-    public static final String MC_JAR_URL       = "http://s3.amazonaws.com/Minecraft.Download/versions/{MC_VERSION}/{MC_VERSION}.jar";
-    public static final String MC_SERVER_URL    = "http://s3.amazonaws.com/Minecraft.Download/versions/{MC_VERSION}/minecraft_server.{MC_VERSION}.jar";
+    public static final String MC_JSON_URL      = "https://s3.amazonaws.com/Minecraft.Download/versions/{MC_VERSION}/{MC_VERSION}.json";
+    public static final String MC_JAR_URL       = "https://s3.amazonaws.com/Minecraft.Download/versions/{MC_VERSION}/{MC_VERSION}.jar";
+    public static final String MC_SERVER_URL    = "https://s3.amazonaws.com/Minecraft.Download/versions/{MC_VERSION}/minecraft_server.{MC_VERSION}.jar";
     public static final String MCP_URL          = "https://files.minecraftforge.net/fernflower-fix-1.0.zip";
-    public static final String ASSETS_URL       = "http://resources.download.minecraft.net";
+    public static final String ASSETS_URL       = "https://resources.download.minecraft.net";
     public static final String LIBRARY_URL      = "https://libraries.minecraft.net/";
     public static final String FORGE_MAVEN      = "https://maven.minecraftforge.net";
     public static final String ASSETS_INDEX_URL = "https://s3.amazonaws.com/Minecraft.Download/indexes/{ASSET_INDEX}.json";

--- a/src/main/java/net/minecraftforge/gradle/common/JenkinsExtension.java
+++ b/src/main/java/net/minecraftforge/gradle/common/JenkinsExtension.java
@@ -4,7 +4,7 @@ import org.gradle.api.Project;
 
 public class JenkinsExtension
 {
-    private String server = "http://ci.jenkins.minecraftforge.net/";
+    private String server = "https://jenkins.minecraftforge.net/";
     private String job;
     private String authName = "console_script";
     private String authPassword = "dc6d48ca20a474beeac280a9a16a926e";

--- a/src/main/java/net/minecraftforge/gradle/dev/DevConstants.java
+++ b/src/main/java/net/minecraftforge/gradle/dev/DevConstants.java
@@ -9,8 +9,8 @@ final class DevConstants
 
     }
 
-    static final String INSTALLER_URL       = "http://maven.minecraftforge.net/net/minecraftforge/installer/{INSTALLER_VERSION}/installer-{INSTALLER_VERSION}-shrunk.jar";
-    static final String LAUNCH4J_URL        = "http://files.minecraftforge.net/launch4j/launch4j-3.0.0-"+Constants.OPERATING_SYSTEM+"-"+Constants.SYSTEM_ARCH+".zip";
+    static final String INSTALLER_URL       = "https://maven.minecraftforge.net/net/minecraftforge/installer/{INSTALLER_VERSION}/installer-{INSTALLER_VERSION}-shrunk.jar";
+    static final String LAUNCH4J_URL        = "https://files.minecraftforge.net/launch4j/launch4j-3.0.0-"+Constants.OPERATING_SYSTEM+"-"+Constants.SYSTEM_ARCH+".zip";
 
     static final String DEOBF_DATA          = "{CACHE_DIR}/minecraft/net/minecraft/minecraft_srg/{MC_VERSION}/deobfuscation_data-{MC_VERSION}.lzma";
 

--- a/src/main/java/net/minecraftforge/gradle/user/lib/LiteLoaderPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/lib/LiteLoaderPlugin.java
@@ -114,7 +114,7 @@ public class LiteLoaderPlugin extends UserLibBasePlugin
         project.allprojects(new Action<Project>() {
             public void execute(Project proj)
             {
-                addMavenRepo(proj, "liteloaderRepo", "http://dl.liteloader.com/versions/");
+                addMavenRepo(proj, "liteloaderRepo", "https://dl.liteloader.com/versions/");
             }
         });
         
@@ -123,7 +123,7 @@ public class LiteLoaderPlugin extends UserLibBasePlugin
         {
 
             EtagDownloadTask task = makeTask("getLiteLoaderJson", EtagDownloadTask.class);
-            task.setUrl("http://dl.liteloader.com/versions/versions.json");
+            task.setUrl("https://dl.liteloader.com/versions/versions.json");
             task.setFile(json);
             task.setDieWithError(false);
             


### PR DESCRIPTION
Fixed version of #843
Forge 1.7.10 cannot be built from source due to old URLs in ForgeGradle

- Fixing Outdated URLs

The fix allows building Forge 1.7.10 from source