### PR TITLE
Lazily construct values for transient fields in Artifact

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/Artifact.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Artifact.java
@@ -51,14 +51,18 @@ public class Artifact implements ArtifactIdentifier, Comparable<Artifact>, Seria
     @Nullable
     private final String ext;
 
-    // Cached so we don't rebuild every time we're asked.
+    // Cached after building the first time we're asked
     // Transient field so these aren't serialized
-    // TODO: investigate whether this needs to be rebuilt because deserialization
-    private transient final String path;
-    private transient final String file;
-    private transient final String fullDescriptor;
-    private transient final ComparableVersion comparableVersion;
-    private transient final boolean isSnapshot;
+    @Nullable
+    private transient String path;
+    @Nullable
+    private transient String file;
+    @Nullable
+    private transient String fullDescriptor;
+    @Nullable
+    private transient ComparableVersion comparableVersion;
+    @Nullable
+    private transient Boolean isSnapshot;
 
     public static Artifact from(String descriptor) {
         String group, name, version;
@@ -95,39 +99,33 @@ public class Artifact implements ArtifactIdentifier, Comparable<Artifact>, Seria
         this.group = group;
         this.name = name;
         this.version = version;
-        this.comparableVersion = new ComparableVersion(this.version);
-        this.isSnapshot = this.version.toLowerCase(Locale.ROOT).endsWith("-snapshot");
         this.classifier = classifier;
         this.ext = ext != null ? ext : "jar";
-
-        StringBuilder buf = new StringBuilder();
-        buf.append(this.group).append(':').append(this.name).append(':').append(this.version);
-        if (this.classifier != null) {
-            buf.append(':').append(this.classifier);
-        }
-        if (ext != null && !"jar".equals(this.ext)) {
-            buf.append('@').append(this.ext);
-        }
-        this.fullDescriptor = buf.toString();
-
-        String file;
-        file = this.name + '-' + this.version;
-        if (this.classifier != null) file += '-' + this.classifier;
-        file += '.' + this.ext;
-        this.file = file;
-
-        this.path = String.join("/", this.group.replace('.', '/'), this.name, this.version, this.file);
     }
 
     public String getLocalPath() {
-        return path.replace('/', File.separatorChar);
+        return getPath().replace('/', File.separatorChar);
     }
 
     public String getDescriptor() {
+        if (fullDescriptor == null) {
+            StringBuilder buf = new StringBuilder();
+            buf.append(this.group).append(':').append(this.name).append(':').append(this.version);
+            if (this.classifier != null) {
+                buf.append(':').append(this.classifier);
+            }
+            if (ext != null && !"jar".equals(this.ext)) {
+                buf.append('@').append(this.ext);
+            }
+            this.fullDescriptor = buf.toString();
+        }
         return fullDescriptor;
     }
 
     public String getPath() {
+        if (path == null) {
+            this.path = String.join("/", this.group.replace('.', '/'), this.name, this.version, getFilename());
+        }
         return path;
     }
 
@@ -159,10 +157,20 @@ public class Artifact implements ArtifactIdentifier, Comparable<Artifact>, Seria
     }
 
     public String getFilename() {
+        if (file == null) {
+            String file;
+            file = this.name + '-' + this.version;
+            if (this.classifier != null) file += '-' + this.classifier;
+            file += '.' + this.ext;
+            this.file = file;
+        }
         return file;
     }
 
     public boolean isSnapshot() {
+        if (isSnapshot == null) {
+            this.isSnapshot = this.version.toLowerCase(Locale.ROOT).endsWith("-snapshot");
+        }
         return isSnapshot;
     }
 
@@ -177,13 +185,13 @@ public class Artifact implements ArtifactIdentifier, Comparable<Artifact>, Seria
 
     @Override
     public int hashCode() {
-        return fullDescriptor.hashCode();
+        return getDescriptor().hashCode();
     }
 
     @Override
     public boolean equals(Object o) {
         return o instanceof Artifact &&
-                this.fullDescriptor.equals(((Artifact) o).fullDescriptor);
+                this.getDescriptor().equals(((Artifact) o).getDescriptor());
     }
 
     public Spec<Dependency> asDependencySpec() {
@@ -210,12 +218,19 @@ public class Artifact implements ArtifactIdentifier, Comparable<Artifact>, Seria
         };
     }
 
+    ComparableVersion getComparableVersion() {
+        if (comparableVersion == null) {
+            this.comparableVersion = new ComparableVersion(this.version);
+        }
+        return comparableVersion;
+    }
+
     @Override
     public int compareTo(Artifact o) {
         return ComparisonChain.start()
                 .compare(group, o.group)
                 .compare(name, o.name)
-                .compare(comparableVersion, o.comparableVersion)
+                .compare(getComparableVersion(), o.getComparableVersion())
                 // TODO: comparison of timestamps for snapshot versions (isSnapshot)
                 .compare(classifier, o.classifier, Comparator.nullsFirst(Comparator.naturalOrder()))
                 .compare(ext, o.ext, Comparator.nullsFirst(Comparator.naturalOrder()))

--- a/src/common/java/net/minecraftforge/gradle/common/util/Artifact.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Artifact.java
@@ -30,6 +30,7 @@ import org.gradle.api.specs.Spec;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ComparisonChain;
 import com.google.common.collect.Iterables;
+
 import java.io.File;
 import java.io.Serializable;
 import java.util.Comparator;
@@ -122,23 +123,48 @@ public class Artifact implements ArtifactIdentifier, Comparable<Artifact>, Seria
         return path.replace('/', File.separatorChar);
     }
 
-    public String getDescriptor(){ return fullDescriptor; }
-    public String getPath()      { return path;       }
-    @Override
-    public String getGroup()     { return group;      }
-    @Override
-    public String getName()      { return name;       }
-    @Override
-    public String getVersion()   { return version;    }
-    @Override
-    @Nullable
-    public String getClassifier(){ return classifier; }
-    @Override
-    @Nullable
-    public String getExtension() { return ext;        }
-    public String getFilename()  { return file;       }
+    public String getDescriptor() {
+        return fullDescriptor;
+    }
 
-    public boolean isSnapshot()  { return isSnapshot; }
+    public String getPath() {
+        return path;
+    }
+
+    @Override
+    public String getGroup() {
+        return group;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getVersion() {
+        return version;
+    }
+
+    @Override
+    @Nullable
+    public String getClassifier() {
+        return classifier;
+    }
+
+    @Override
+    @Nullable
+    public String getExtension() {
+        return ext;
+    }
+
+    public String getFilename() {
+        return file;
+    }
+
+    public boolean isSnapshot() {
+        return isSnapshot;
+    }
 
     public Artifact withVersion(String version) {
         return Artifact.from(group, name, version, classifier, ext);
@@ -157,7 +183,7 @@ public class Artifact implements ArtifactIdentifier, Comparable<Artifact>, Seria
     @Override
     public boolean equals(Object o) {
         return o instanceof Artifact &&
-            this.fullDescriptor.equals(((Artifact)o).fullDescriptor);
+                this.fullDescriptor.equals(((Artifact) o).fullDescriptor);
     }
 
     public Spec<Dependency> asDependencySpec() {


### PR DESCRIPTION
This PR fixes an issue from https://github.com/MinecraftForge/ForgeGradle/commit/b6ac471841ef54d4f3e668bf71c8f400824a26a2 by moving the construction and assignment of the `transient` fields in `Artifact` from the constructor to getters, fixing any method using these values to work even after deserialization.

As background, `transient` fields are not serialized by Java's serialization mechanisms (which is used by Gradle), which causes an issue as the `equals` and `hashCode` methods of `Artifact` (introduced by the aforementioned commit) relies on one such field. This causes a `NullPointerException` if something attempts to call these two methods on a freshly deserialized `Artifact` instance.

The solution here[^1] is to move creating and assigning the values of these fields to their respective getters (in the case of `comparableVersion`, a new package-private getter), such that their values are created on-demand and cached for future calls.

This PR also cleans up the formatting of the getters in `Artifact` from the single-line getter format.

[^1]: In a [Discord conversation](https://canary.discord.com/channels/313125603924639766/801175194298744902/979467434908057671) on the Forge project discord server, this was the chosen option; the other alternative solution were to remove the `transient` modifier from the fields (which would include data in the serialized form that can already be recreated from the already-serialized fields).