### PR TITLE
Fix project name in Eclipse and VSCode run generators

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/EclipseRunGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/EclipseRunGenerator.java
@@ -68,7 +68,7 @@ public class EclipseRunGenerator extends RunConfigGenerator.XMLConfigurationBuil
             {
                 rootElement.setAttribute("type", "org.eclipse.jdt.launching.localJavaApplication");
 
-                elementAttribute(javaDocument, rootElement, "string", "org.eclipse.jdt.launching.PROJECT_ATTR", project.getName());
+                elementAttribute(javaDocument, rootElement, "string", "org.eclipse.jdt.launching.PROJECT_ATTR", getEclipseProjectName(project));
                 elementAttribute(javaDocument, rootElement, "string", "org.eclipse.jdt.launching.MAIN_TYPE", runConfig.getMain());
                 elementAttribute(javaDocument, rootElement, "string", "org.eclipse.jdt.launching.VM_ARGUMENTS",
                         getJvmArgs(runConfig, additionalClientArgs, updatedTokens));
@@ -96,6 +96,11 @@ public class EclipseRunGenerator extends RunConfigGenerator.XMLConfigurationBuil
         documents.put(runConfig.getTaskName() + ".launch", javaDocument);
 
         return documents;
+    }
+
+    static String getEclipseProjectName(@Nonnull final Project project) {
+        final EclipseModel eclipse = project.getExtensions().findByType(EclipseModel.class);
+        return eclipse == null ? project.getName() : eclipse.getProject().getName();
     }
 
     static Stream<String> mapModClassesToEclipse(@Nonnull final Project project, @Nonnull final RunConfig runConfig) {

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/VSCodeRunGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/VSCodeRunGenerator.java
@@ -43,7 +43,7 @@ public class VSCodeRunGenerator extends RunConfigGenerator.JsonConfigurationBuil
         config.addProperty("name", runConfig.getTaskName());
         config.addProperty("request", "launch");
         config.addProperty("mainClass", runConfig.getMain());
-        config.addProperty("projectName", project.getName());
+        config.addProperty("projectName", EclipseRunGenerator.getEclipseProjectName(project));
         config.addProperty("cwd", replaceRootDirBy(project, runConfig.getWorkingDirectory(), "${workspaceFolder}"));
         config.addProperty("vmArgs", getJvmArgs(runConfig, additionalClientArgs, updatedTokens));
         config.addProperty("args", getArgs(runConfig, updatedTokens));


### PR DESCRIPTION
This fixes an issue with Eclipse and VSCode run generators where runs are generated with the wrong project name.

Changing the name of the eclipse project in the build.gradle file of a mod, ie adding the following line 
```groovy
eclipse.project.name = "Test" // This name must be different from the gradle project name for the error to appear
```
would previously result in an error in the generated run files.

With this PR, the run generators use the name of the eclipse project as declared in the build.gradle to fill the PROJECT_ATTR attribute of the eclipse run xml and the projectName property of the VSCode run json.
