### PR TITLE
Add option to generate Eclipse launch groups

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/MinecraftExtension.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MinecraftExtension.java
@@ -40,6 +40,7 @@ public abstract class MinecraftExtension extends GroovyObjectSupport {
     protected final ConfigurableFileCollection accessTransformers;
 
     private final Provider<String> mapping;
+    protected final Property<Boolean> generateLaunchGroups;
 
     @Inject
     public MinecraftExtension(final Project project) {
@@ -47,6 +48,8 @@ public abstract class MinecraftExtension extends GroovyObjectSupport {
         this.mapping = getMappingChannel().zip(getMappingVersion(), (ch, ver) -> ch + '_' + ver);
         this.runs = project.getObjects().domainObjectContainer(RunConfig.class, name -> new RunConfig(project, name));
         this.accessTransformers = project.getObjects().fileCollection();
+
+        this.generateLaunchGroups = project.getObjects().property(Boolean.class).convention(false);
     }
 
     public Project getProject() {
@@ -127,4 +130,12 @@ public abstract class MinecraftExtension extends GroovyObjectSupport {
     }
 
     public abstract ConfigurableFileCollection getSideAnnotationStrippers();
+
+    public void generateLaunchGroups() {
+        this.generateLaunchGroups.set(true);
+    }
+
+    public boolean generatesLaunchGroups() {
+        return generateLaunchGroups.get();
+    }
 }

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/IntellijRunGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/IntellijRunGenerator.java
@@ -20,6 +20,7 @@
 
 package net.minecraftforge.gradle.common.util.runs;
 
+import net.minecraftforge.gradle.common.util.MinecraftExtension;
 import net.minecraftforge.gradle.common.util.RunConfig;
 import net.minecraftforge.gradle.common.util.Utils;
 
@@ -134,7 +135,7 @@ public class IntellijRunGenerator extends RunConfigGenerator.XMLConfigurationBui
 
     @Override
     @Nonnull
-    protected Map<String, Document> createRunConfiguration(@Nonnull final Project project, @Nonnull final RunConfig runConfig, @Nonnull final DocumentBuilder documentBuilder, List<String> additionalClientArgs) {
+    protected Map<String, Document> createRunConfiguration(@Nonnull final MinecraftExtension mc, @Nonnull final Project project, @Nonnull final RunConfig runConfig, @Nonnull final DocumentBuilder documentBuilder, List<String> additionalClientArgs) {
         final Map<String, Document> documents = new LinkedHashMap<>();
 
         Map<String, Supplier<String>> updatedTokens = configureTokensLazy(project, runConfig,

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
@@ -127,11 +127,11 @@ public abstract class RunConfigGenerator
         parent.appendChild(option);
     }
 
-    protected static void elementAttribute(@Nonnull Document document, @Nonnull final Element parent, @Nonnull final String attributeType, @Nonnull final String key, @Nonnull final String value) {
+    protected static void elementAttribute(@Nonnull Document document, @Nonnull final Element parent, @Nonnull final String attributeType, @Nonnull final String key, @Nonnull final Object value) {
         final Element attribute = document.createElement(attributeType + "Attribute");
         {
             attribute.setAttribute("key", key);
-            attribute.setAttribute("value", value);
+            attribute.setAttribute("value", value.toString());
         }
         parent.appendChild(attribute);
     }
@@ -342,7 +342,7 @@ public abstract class RunConfigGenerator
     static abstract class XMLConfigurationBuilder extends RunConfigGenerator {
 
         @Nonnull
-        protected abstract Map<String, Document> createRunConfiguration(@Nonnull final Project project, @Nonnull final RunConfig runConfig, @Nonnull final DocumentBuilder documentBuilder, List<String> additionalClientArgs);
+        protected abstract Map<String, Document> createRunConfiguration(@Nonnull final MinecraftExtension minecraft, @Nonnull final Project project, @Nonnull final RunConfig runConfig, @Nonnull final DocumentBuilder documentBuilder, List<String> additionalClientArgs);
 
         @Override
         public final void createRunConfiguration(@Nonnull final MinecraftExtension minecraft, @Nonnull final File runConfigurationsDir, @Nonnull final Project project, List<String> additionalClientArgs) {
@@ -356,11 +356,14 @@ public abstract class RunConfigGenerator
                 transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "2");
 
                 minecraft.getRuns().forEach(runConfig -> {
-                    final Map<String, Document> documents = createRunConfiguration(project, runConfig, docBuilder, additionalClientArgs);
+                    final Map<String, Document> documents = createRunConfiguration(minecraft, project, runConfig, docBuilder, additionalClientArgs);
 
                     documents.forEach((fileName, document) -> {
                         final DOMSource source = new DOMSource(document);
-                        final StreamResult result = new StreamResult(new File(runConfigurationsDir, fileName));
+                        final File location = new File(runConfigurationsDir, fileName);
+                        if (!location.getParentFile().exists())
+                            location.getParentFile().mkdirs();
+                        final StreamResult result = new StreamResult(location);
 
                         try {
                             transformer.transform(source, result);


### PR DESCRIPTION
This PR adds an option in the MinecraftExtension (`generateLaunchGroups()`), which will make the `runX.launch` configurations be a launch group, running `prepareX` and the game sequentially, in this order, and as such, having the same behaviour as IntelliJ. 
I'm not sure if the option should be on by default, as it affects launch times (eclipse compiling on file save), needing to run a gradle task.

Draft until I manage to test all contexts in which the configuration can be run.