### PR TITLE
Improve Gradle configuration cache support

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/tasks/ApplyBinPatches.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/ApplyBinPatches.java
@@ -22,11 +22,14 @@ package net.minecraftforge.gradle.common.tasks;
 
 import net.minecraftforge.gradle.common.util.Utils;
 
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
 
 import com.google.common.collect.ImmutableMap;
+
+import javax.inject.Inject;
 import java.util.List;
 
 public abstract class ApplyBinPatches extends JarExec {
@@ -34,7 +37,7 @@ public abstract class ApplyBinPatches extends JarExec {
         getTool().set(Utils.BINPATCHER);
         getArgs().addAll("--clean", "{clean}", "--output", "{output}", "--apply", "{patch}");
 
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.jar")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.jar")));
     }
 
     @Override
@@ -44,6 +47,9 @@ public abstract class ApplyBinPatches extends JarExec {
                 "{output}", getOutput().get().getAsFile(),
                 "{patch}", getPatch().get().getAsFile()), null);
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @InputFile
     public abstract RegularFileProperty getClean();

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/ApplyMappings.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/ApplyMappings.java
@@ -25,12 +25,14 @@ import net.minecraftforge.gradle.common.util.Utils;
 
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
+import javax.inject.Inject;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -42,7 +44,7 @@ public abstract class ApplyMappings extends DefaultTask {
     private boolean lambdas = true;
 
     public ApplyMappings() {
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(s -> s.file("output.zip")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(s -> s.file("output.zip")));
     }
 
     @TaskAction
@@ -68,6 +70,9 @@ public abstract class ApplyMappings extends DefaultTask {
             }
         }
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @InputFile
     public abstract RegularFileProperty getInput();

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/ApplyRangeMap.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/ApplyRangeMap.java
@@ -23,6 +23,7 @@ package net.minecraftforge.gradle.common.tasks;
 import net.minecraftforge.gradle.common.util.Utils;
 
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
@@ -31,6 +32,8 @@ import org.gradle.api.tasks.OutputFile;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+
+import javax.inject.Inject;
 import java.util.List;
 
 public abstract class ApplyRangeMap extends JarExec {
@@ -43,7 +46,7 @@ public abstract class ApplyRangeMap extends JarExec {
                 "--output", "{output}", "--keepImports", "{keepImports}");
         setMinimumRuntimeJavaVersion(11);
 
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.zip")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.zip")));
     }
 
     @Override
@@ -60,6 +63,9 @@ public abstract class ApplyRangeMap extends JarExec {
                 )
         );
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @InputFiles
     public abstract ConfigurableFileCollection getSrgFiles();

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/ArchiveChecksum.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/ArchiveChecksum.java
@@ -21,6 +21,7 @@
 package net.minecraftforge.gradle.common.tasks;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
@@ -29,6 +30,8 @@ import org.gradle.api.tasks.TaskAction;
 import com.google.common.collect.Maps;
 import com.google.common.hash.Hashing;
 import com.google.common.hash.HashingInputStream;
+
+import javax.inject.Inject;
 import java.io.BufferedWriter;
 import java.io.FileInputStream;
 import java.io.FileWriter;
@@ -44,7 +47,7 @@ public abstract class ArchiveChecksum extends DefaultTask {
     //TODO: Filters of some kind?
 
     public ArchiveChecksum() {
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(s -> s.file("output.sha256")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(s -> s.file("output.sha256")));
     }
 
     @TaskAction
@@ -70,6 +73,9 @@ public abstract class ArchiveChecksum extends DefaultTask {
             });
         }
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @InputFile
     public abstract RegularFileProperty getInput();

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/DownloadAssets.java
@@ -73,20 +73,20 @@ public abstract class DownloadAssets extends DefaultTask {
                     try {
                         File localFile = FileUtils.getFile(assetsPath + File.separator + asset.getPath());
                         if (localFile.exists()) {
-                            getProject().getLogger().lifecycle("Copying local object: " + asset.getPath() + " Asset: " + key);
+                            getLogger().lifecycle("Copying local object: " + asset.getPath() + " Asset: " + key);
                             FileUtils.copyFile(localFile, target);
                         } else {
-                            getProject().getLogger().lifecycle("Downloading: " + url + " Asset: " + key);
+                            getLogger().lifecycle("Downloading: " + url + " Asset: " + key);
                             FileUtils.copyURLToFile(url, target, 10_000, 5_000);
                         }
                         if (!HashFunction.SHA1.hash(target).equals(asset.hash)) {
                             failedDownloads.add(key);
                             Utils.delete(target);
-                            getProject().getLogger().error("{} Hash failed.", key);
+                            getLogger().error("{} Hash failed.", key);
                         }
                     } catch (IOException e) {
                         failedDownloads.add(key);
-                        getProject().getLogger().error("{} Failed.", key);
+                        getLogger().error("{} Failed.", key);
                         e.printStackTrace();
                     }
                 };

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/DownloadAssets.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/DownloadAssets.java
@@ -26,6 +26,7 @@ import net.minecraftforge.gradle.common.util.VersionJson;
 
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.InputFile;
@@ -33,6 +34,7 @@ import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
@@ -49,6 +51,7 @@ import java.util.concurrent.TimeUnit;
 
 public abstract class DownloadAssets extends DefaultTask {
     public DownloadAssets() {
+        notCompatibleWithConfigurationCache("MAD");
         getAssetRepository().convention("https://resources.download.minecraft.net/");
         getConcurrentDownloads().convention(8);
     }

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/DownloadMCMeta.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/DownloadMCMeta.java
@@ -24,6 +24,7 @@ import net.minecraftforge.gradle.common.util.ManifestJson;
 
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -33,6 +34,8 @@ import org.gradle.api.tasks.TaskAction;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
+import javax.inject.Inject;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -44,8 +47,8 @@ public abstract class DownloadMCMeta extends DefaultTask {
     private static final Gson GSON = new GsonBuilder().create();
 
     public DownloadMCMeta() {
-        getManifest().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(s -> s.file("manifest.json")));
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(s -> s.file("version.json")));
+        getManifest().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(s -> s.file("manifest.json")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(s -> s.file("version.json")));
     }
 
     @TaskAction
@@ -59,6 +62,9 @@ public abstract class DownloadMCMeta extends DefaultTask {
             }
         }
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @Input
     public abstract Property<String> getMCVersion();

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/DownloadMavenArtifact.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/DownloadMavenArtifact.java
@@ -25,13 +25,16 @@ import net.minecraftforge.gradle.common.util.MavenArtifactDownloader;
 
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 
@@ -40,11 +43,12 @@ public abstract class DownloadMavenArtifact extends DefaultTask {
     private boolean changing = false;
 
     public DownloadMavenArtifact() {
+        notCompatibleWithConfigurationCache("MAD");
         // We need to always ask, in case the file on the remote maven/local fake repo has changed.
         getOutputs().upToDateWhen(task -> false);
 
-        this.artifact = getProject().getObjects().property(Artifact.class);
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName())
+        this.artifact = getProjectObjects().property(Artifact.class);
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName())
                         .zip(getArtifact(), (d, a) -> d.file("output." + a.getExtension())));
     }
 
@@ -85,4 +89,10 @@ public abstract class DownloadMavenArtifact extends DefaultTask {
         if (!output.getParentFile().exists()) output.getParentFile().mkdirs();
         FileUtils.copyFile(out, output);
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
+
+    @Inject
+    protected abstract ObjectFactory getProjectObjects();
 }

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/DynamicJarExec.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/DynamicJarExec.java
@@ -20,6 +20,7 @@
 
 package net.minecraftforge.gradle.common.tasks;
 
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.tasks.InputFile;
@@ -28,12 +29,14 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 
 import com.google.common.collect.ImmutableMap;
+
+import javax.inject.Inject;
 import java.io.File;
 import java.util.List;
 
 public abstract class DynamicJarExec extends JarExec {
     public DynamicJarExec() {
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.jar")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.jar")));
     }
 
     @Override
@@ -45,6 +48,9 @@ public abstract class DynamicJarExec extends JarExec {
 
         return replaceArgs(args, replace.build(), null);
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @InputFiles
     @Optional

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/ExtractInheritance.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/ExtractInheritance.java
@@ -22,6 +22,7 @@ package net.minecraftforge.gradle.common.tasks;
 
 import net.minecraftforge.gradle.common.util.Utils;
 
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.tasks.InputFile;
@@ -30,6 +31,7 @@ import org.gradle.api.tasks.OutputFile;
 
 import com.google.common.collect.ImmutableMap;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.util.List;
 
@@ -38,7 +40,7 @@ public abstract class ExtractInheritance extends JarExec {
         getTool().set(Utils.INSTALLERTOOLS);
         getArgs().addAll("--task", "extract_inheritance", "--input", "{input}", "--output", "{output}");
 
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.json")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.json")));
     }
 
     @Override
@@ -53,6 +55,8 @@ public abstract class ExtractInheritance extends JarExec {
         return newArgs;
     }
 
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @InputFile
     public abstract RegularFileProperty getInput();

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/ExtractMCPData.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/ExtractMCPData.java
@@ -28,6 +28,7 @@ import net.minecraftforge.srgutils.IRenamer;
 
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.Project;
@@ -36,6 +37,7 @@ import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -47,7 +49,7 @@ public abstract class ExtractMCPData extends DefaultTask {
     private boolean allowEmpty = false;
 
     public ExtractMCPData() {
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(s -> s.file("output.srg")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(s -> s.file("output.srg")));
         getKey().convention("mappings");
     }
 
@@ -108,6 +110,9 @@ public abstract class ExtractMCPData extends DefaultTask {
 
         outputFile.createNewFile();
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @Input
     public abstract Property<String> getKey();

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/ExtractNatives.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/ExtractNatives.java
@@ -35,6 +35,11 @@ import java.io.File;
 import java.io.IOException;
 
 public abstract class ExtractNatives extends DefaultTask {
+
+    public ExtractNatives() {
+        notCompatibleWithConfigurationCache("Utils needing getProject()");
+    }
+
     @TaskAction
     public void run() throws IOException {
         VersionJson json = Utils.loadJson(getMeta().get().getAsFile(), VersionJson.class);

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/ExtractRangeMap.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/ExtractRangeMap.java
@@ -23,6 +23,7 @@ package net.minecraftforge.gradle.common.tasks;
 import net.minecraftforge.gradle.common.util.Utils;
 
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.Property;
@@ -31,6 +32,8 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
 
 import com.google.common.collect.ImmutableMap;
+
+import javax.inject.Inject;
 import java.util.List;
 
 public abstract class ExtractRangeMap extends JarExec {
@@ -42,7 +45,7 @@ public abstract class ExtractRangeMap extends JarExec {
                 "{library}", "--input", "{input}", "--batch", "{batched}");
         setMinimumRuntimeJavaVersion(11);
 
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.txt")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.txt")));
         final JavaPluginExtension extension = getProject().getExtensions().findByType(JavaPluginExtension.class);
         if (extension != null && extension.getToolchain().getLanguageVersion().isPresent()) {
             int version = extension.getToolchain().getLanguageVersion().get().asInt();
@@ -64,6 +67,9 @@ public abstract class ExtractRangeMap extends JarExec {
                 )
         );
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @InputFiles
     public abstract ConfigurableFileCollection getSources();

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/JarExec.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/JarExec.java
@@ -85,6 +85,7 @@ public abstract class JarExec extends DefaultTask {
     protected final Provider<RegularFile> logFile = workDir.map(d -> d.file("log.txt"));
 
     public JarExec() {
+        notCompatibleWithConfigurationCache("MAD");
         toolFile = getTool().map(toolStr -> MavenArtifactDownloader.gradle(getProject(), toolStr, false));
         resolvedVersion = getTool().map(toolStr -> MavenArtifactDownloader.getVersion(getProject(), toolStr));
         getDebug().convention(false);

--- a/src/common/java/net/minecraftforge/gradle/common/tasks/JarExec.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/JarExec.java
@@ -27,6 +27,7 @@ import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFile;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.JavaPluginExtension;
@@ -80,7 +81,7 @@ public abstract class JarExec extends DefaultTask {
     private final Provider<File> toolFile;
     private final Provider<String> resolvedVersion;
 
-    protected final Provider<Directory> workDir = getProject().getLayout().getBuildDirectory().dir(getName());
+    protected final Provider<Directory> workDir = getProjectLayout().getBuildDirectory().dir(getName());
     protected final Provider<RegularFile> logFile = workDir.map(d -> d.file("log.txt"));
 
     public JarExec() {
@@ -93,6 +94,9 @@ public abstract class JarExec extends DefaultTask {
             getJavaLauncher().convention(getJavaToolchainService().launcherFor(extension.getToolchain()));
         }
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @Inject
     protected JavaToolchainService getJavaToolchainService() {
@@ -110,7 +114,7 @@ public abstract class JarExec extends DefaultTask {
         jarFile.close();
 
         // Create parent directory for log file
-        Logger logger = getProject().getLogger();
+        Logger logger = getLogger();
         if (logFile.getParentFile() != null && !logFile.getParentFile().exists() && !logFile.getParentFile().mkdirs()) {
             logger.warn("Could not create parent directory '{}' for log file", logFile.getParentFile().getAbsolutePath());
         }

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/tasks/DownloadMCPConfig.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/tasks/DownloadMCPConfig.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 public abstract class DownloadMCPConfig extends DefaultTask {
     @TaskAction
     public void downloadMCPConfig() throws IOException {
+        notCompatibleWithConfigurationCache("MAD");
         File file = getConfigFile();
         File output = getOutput().get().getAsFile();
 

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/tasks/DownloadMCPMappings.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/tasks/DownloadMCPMappings.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 
 public abstract class DownloadMCPMappings extends DefaultTask {
     public DownloadMCPMappings() {
+        notCompatibleWithConfigurationCache("MAD");
         getOutput().convention(getProjectLayout().getBuildDirectory().file("mappings.zip"));
     }
 

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/tasks/DownloadMCPMappings.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/tasks/DownloadMCPMappings.java
@@ -25,18 +25,20 @@ import net.minecraftforge.gradle.mcp.MCPRepo;
 
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 
 public abstract class DownloadMCPMappings extends DefaultTask {
     public DownloadMCPMappings() {
-        getOutput().convention(getProject().getLayout().getBuildDirectory().file("mappings.zip"));
+        getOutput().convention(getProjectLayout().getBuildDirectory().file("mappings.zip"));
     }
 
     @TaskAction
@@ -63,6 +65,9 @@ public abstract class DownloadMCPMappings extends DefaultTask {
             throw new IllegalStateException("Failed to download mappings: " + artifact);
         return ret;
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @Input
     public abstract Property<String> getMappings();

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/tasks/GenerateSRG.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/tasks/GenerateSRG.java
@@ -48,6 +48,7 @@ public abstract class GenerateSRG extends DefaultTask {
     private boolean reverse = false;
 
     public GenerateSRG() {
+        notCompatibleWithConfigurationCache("MAD");
         this.format = getProjectObjects().property(IMappingFile.Format.class)
                 .convention(IMappingFile.Format.TSRG2);
         getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(f -> f.file("output.tsrg")));

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/tasks/GenerateSRG.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/tasks/GenerateSRG.java
@@ -29,13 +29,16 @@ import net.minecraftforge.srgutils.IMappingFile.IMethod;
 import net.minecraftforge.srgutils.IRenamer;
 
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 
@@ -45,9 +48,9 @@ public abstract class GenerateSRG extends DefaultTask {
     private boolean reverse = false;
 
     public GenerateSRG() {
-        this.format = getProject().getObjects().property(IMappingFile.Format.class)
+        this.format = getProjectObjects().property(IMappingFile.Format.class)
                 .convention(IMappingFile.Format.TSRG2);
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(f -> f.file("output.tsrg")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(f -> f.file("output.tsrg")));
     }
 
     @TaskAction
@@ -84,6 +87,12 @@ public abstract class GenerateSRG extends DefaultTask {
         String desc = MCPRepo.getMappingDep(channel, version);
         return MavenArtifactDownloader.generate(getProject(), desc, false);
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
+
+    @Inject
+    protected abstract ObjectFactory getProjectObjects();
 
     @InputFile
     public abstract RegularFileProperty getSrg();

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/tasks/SetupMCP.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/tasks/SetupMCP.java
@@ -28,6 +28,7 @@ import net.minecraftforge.gradle.mcp.util.MCPRuntime;
 
 import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -36,12 +37,13 @@ import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 
 public abstract class SetupMCP extends DefaultTask {
     public SetupMCP() {
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.zip")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.zip")));
 
         this.getOutputs().upToDateWhen(task -> {
             HashStore cache = new HashStore(getProject());
@@ -57,6 +59,9 @@ public abstract class SetupMCP extends DefaultTask {
             }
         });
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @InputFile
     public abstract RegularFileProperty getConfig();

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/tasks/SetupMCP.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/tasks/SetupMCP.java
@@ -43,6 +43,7 @@ import java.io.IOException;
 
 public abstract class SetupMCP extends DefaultTask {
     public SetupMCP() {
+        notCompatibleWithConfigurationCache("MCPRuntime needs getProject()");
         getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.zip")));
 
         this.getOutputs().upToDateWhen(task -> {

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/CreateExc.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/CreateExc.java
@@ -25,6 +25,7 @@ import net.minecraftforge.gradle.common.config.MCPConfigV2;
 import net.minecraftforge.srgutils.IMappingFile;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.DefaultTask;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
@@ -33,6 +34,8 @@ import org.gradle.api.tasks.TaskAction;
 import com.google.common.base.Strings;
 import com.google.common.io.Files;
 import de.siegmar.fastcsv.reader.NamedCsvReader;
+
+import javax.inject.Inject;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -52,7 +55,7 @@ public abstract class CreateExc extends DefaultTask {
     private static final Pattern CLS_ENTRY = Pattern.compile("L([^;]+);");
 
     public CreateExc() {
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.exc")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.exc")));
     }
 
     @TaskAction
@@ -179,6 +182,9 @@ public abstract class CreateExc extends DefaultTask {
         }
         return names;
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @InputFile
     public abstract RegularFileProperty getConfig();

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/CreateFakeSASPatches.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/CreateFakeSASPatches.java
@@ -24,18 +24,23 @@ import org.apache.commons.io.FileUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputDirectory;
 import org.gradle.api.tasks.TaskAction;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 public abstract class CreateFakeSASPatches extends DefaultTask {
     public CreateFakeSASPatches() {
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(d -> d.dir("patches")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(d -> d.dir("patches")));
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @InputFiles
     public abstract ConfigurableFileCollection getFiles();

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/FilterNewJar.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/FilterNewJar.java
@@ -26,12 +26,14 @@ import net.minecraftforge.srgutils.IMappingFile;
 import org.apache.commons.io.IOUtils;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -43,7 +45,7 @@ import java.util.zip.ZipOutputStream;
 
 public abstract class FilterNewJar extends DefaultTask { //TODO: Copy task?
     public FilterNewJar() {
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.jar")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.jar")));
     }
 
     @TaskAction
@@ -82,6 +84,9 @@ public abstract class FilterNewJar extends DefaultTask { //TODO: Copy task?
         }
         return classes.contains(cls);
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @InputFile
     public abstract RegularFileProperty getInput();

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/GenerateBinPatches.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/GenerateBinPatches.java
@@ -24,6 +24,7 @@ import net.minecraftforge.gradle.common.tasks.JarExec;
 import net.minecraftforge.gradle.common.util.Utils;
 
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -33,6 +34,8 @@ import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
 
 import com.google.common.collect.ImmutableMap;
+
+import javax.inject.Inject;
 import java.util.List;
 
 public abstract class GenerateBinPatches extends JarExec {
@@ -41,7 +44,7 @@ public abstract class GenerateBinPatches extends JarExec {
         getArgs().addAll("--clean", "{clean}", "--create", "{dirty}", "--output", "{output}",
                 "--patches", "{patches}", "--srg", "{srg}");
 
-        getOutput().convention(getProject().getLayout().getBuildDirectory()
+        getOutput().convention(getProjectLayout().getBuildDirectory()
                 .dir(getName()).map(d -> d.file(getSide().getOrElse("output") + ".lzma")));
     }
 
@@ -58,6 +61,9 @@ public abstract class GenerateBinPatches extends JarExec {
         );
         return newArgs;
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @InputFile
     public abstract RegularFileProperty getCleanJar();

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/GeneratePatches.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/GeneratePatches.java
@@ -55,8 +55,8 @@ public abstract class GeneratePatches extends DefaultTask {
         Path base = getBase().get().getAsFile().toPath();
         Path modified = getModified().get().getAsFile().toPath();
         Path output = getOutput().get().getAsFile().toPath();
-        getProject().getLogger().info("Base: {}", base);
-        getProject().getLogger().info("Modified: {}", modified);
+        getLogger().info("Base: {}", base);
+        getLogger().info("Modified: {}", modified);
 
         ArchiveFormat outputFormat = getOutputFormat().getOrNull();
         if (outputFormat == null) {

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/GenerateUserdevConfig.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/GenerateUserdevConfig.java
@@ -75,6 +75,7 @@ public abstract class GenerateUserdevConfig extends DefaultTask {
 
     @Inject
     public GenerateUserdevConfig(@Nonnull final Project project) {
+        notCompatibleWithConfigurationCache("");
         this.runs = project.container(RunConfig.class, name -> new RunConfig(project, name));
 
         ObjectFactory objects = project.getObjects();

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/GenerateUserdevConfig.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/tasks/GenerateUserdevConfig.java
@@ -33,6 +33,7 @@ import org.gradle.api.DefaultTask;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Project;
 import org.gradle.api.file.ConfigurableFileCollection;
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.provider.ListProperty;
@@ -86,7 +87,7 @@ public abstract class GenerateUserdevConfig extends DefaultTask {
 
         processorData = objects.mapProperty(String.class, File.class);
 
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.json")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.json")));
     }
 
     @TaskAction
@@ -156,6 +157,9 @@ public abstract class GenerateUserdevConfig extends DefaultTask {
                 !"a/".equals(getPatchesOriginalPrefix().get()) ||
                 !"b/".equals(getPatchesModifiedPrefix().get());
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @Input
     public abstract ListProperty<String> getLibraries();

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/ApplyMCPFunction.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/ApplyMCPFunction.java
@@ -25,6 +25,7 @@ import net.minecraftforge.gradle.common.config.MCPConfigV2;
 import net.minecraftforge.gradle.common.tasks.JarExec;
 import net.minecraftforge.gradle.common.util.Utils;
 
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
@@ -32,6 +33,7 @@ import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
 
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
@@ -44,7 +46,7 @@ public abstract class ApplyMCPFunction extends JarExec {
     private final Map<String, Object> replacements = new HashMap<>();
 
     public ApplyMCPFunction() {
-        getOutput().convention(getProject().getLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.jar")));
+        getOutput().convention(getProjectLayout().getBuildDirectory().dir(getName()).map(d -> d.file("output.jar")));
     }
 
     @TaskAction
@@ -98,6 +100,9 @@ public abstract class ApplyMCPFunction extends JarExec {
 
         super.apply();
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     @Override
     protected List<String> filterArgs(List<String> args) {

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/HackyJavaCompile.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/HackyJavaCompile.java
@@ -20,6 +20,7 @@
 
 package net.minecraftforge.gradle.userdev.tasks;
 
+import org.gradle.api.file.ProjectLayout;
 import org.gradle.api.internal.tasks.compile.DefaultJavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.provider.Provider;
@@ -29,6 +30,8 @@ import org.gradle.jvm.toolchain.JavaCompiler;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 import org.gradle.language.base.internal.compile.Compiler;
+
+import javax.inject.Inject;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -59,8 +62,7 @@ public class HackyJavaCompile extends JavaCompile {
     }
 
     private void setCompiler() {
-        JavaToolchainService service = getProject().getExtensions().getByType(JavaToolchainService.class);
-        Provider<JavaCompiler> compiler = service.compilerFor(s -> s.getLanguageVersion().set(JavaLanguageVersion.of(this.getSourceCompatibility())));
+        Provider<JavaCompiler> compiler = getJavaToolchainService().compilerFor(s -> s.getLanguageVersion().set(JavaLanguageVersion.of(this.getSourceCompatibility())));
         this.getJavaCompiler().set(compiler);
     }
 
@@ -87,6 +89,11 @@ public class HackyJavaCompile extends JavaCompile {
         } catch (IllegalAccessException | InvocationTargetException e) {
             throw new RuntimeException("Exception while invoking JavaCompile#createCompiler", e);
         }
+    }
+
+    @Inject
+    protected JavaToolchainService getJavaToolchainService() {
+        throw new UnsupportedOperationException("Decorated instance, this should never be thrown unless shenanigans");
     }
 
 }

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/HackyJavaCompile.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/HackyJavaCompile.java
@@ -44,6 +44,7 @@ import java.lang.reflect.Method;
 public class HackyJavaCompile extends JavaCompile {
 
     public void doHackyCompile() {
+        notCompatibleWithConfigurationCache("");
 
         // What follows is a horrible hack to allow us to call JavaCompile
         // from our dependency resolver.

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/RenameJarInPlace.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/RenameJarInPlace.java
@@ -24,10 +24,7 @@ import net.minecraftforge.gradle.common.tasks.JarExec;
 import net.minecraftforge.gradle.common.util.Utils;
 
 import org.apache.commons.io.FileUtils;
-import org.gradle.api.file.ConfigurableFileCollection;
-import org.gradle.api.file.Directory;
-import org.gradle.api.file.RegularFile;
-import org.gradle.api.file.RegularFileProperty;
+import org.gradle.api.file.*;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.InputFile;
 import org.gradle.api.tasks.InputFiles;
@@ -36,12 +33,14 @@ import org.gradle.api.tasks.TaskAction;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
+
+import javax.inject.Inject;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
 
 public abstract class RenameJarInPlace extends JarExec {
-    private final Provider<Directory> workDir = getProject().getLayout().getBuildDirectory().dir(getName());
+    private final Provider<Directory> workDir = getProjectLayout().getBuildDirectory().dir(getName());
     private final Provider<RegularFile> temp = workDir.map(s -> s.file("output.jar"));
 
     public RenameJarInPlace() {
@@ -66,13 +65,16 @@ public abstract class RenameJarInPlace extends JarExec {
     public void apply() throws IOException {
         File temp = this.temp.get().getAsFile();
         if (temp.getParentFile() != null && !temp.getParentFile().exists() && !temp.getParentFile().mkdirs()) {
-            getProject().getLogger().warn("Could not create parent directories for temp dir '{}'", temp.getAbsolutePath());
+            getLogger().warn("Could not create parent directories for temp dir '{}'", temp.getAbsolutePath());
         }
 
         super.apply();
 
         FileUtils.copyFile(temp, getInput().get().getAsFile());
     }
+
+    @Inject
+    protected abstract ProjectLayout getProjectLayout();
 
     // TODO: Make this a ConfigurableFileCollection? (then remove getExtraMappings())
     @InputFile


### PR DESCRIPTION
This PR improves support for [Gradle's configuration cache feature](https://docs.gradle.org/7.4.2/userguide/configuration_cache.html) by reducing `getProject()` usages and marking incompatible tasks accordingly so that the configuration cache can be used for compatible tasks.

Note that this is my first time working on a Gradle plugin, so merge with caution - please perform your own tests (I might've overlooked something) and let me know if I've missed anything or done something wrong so that I can improve. :)