### PR TITLE
Support composite builds when generating runs

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
@@ -104,7 +104,8 @@ public class RunConfig extends GroovyObjectSupport implements Serializable {
     }
 
     public final String getUniqueFileName() {
-        return project.getPath().length() > 1 ? String.join("_", String.join("_", project.getPath().substring(1).split(":")), getTaskName()) : getTaskName();
+        String prefix = Utils.getCompositePath(project);
+        return prefix.length() > 1 ? prefix.substring(1).replace(':', '_') + "_" + getTaskName() : getTaskName();
     }
 
     public final String getUniqueName() {

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -31,6 +31,7 @@ import org.apache.commons.io.IOUtils;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.repositories.ArtifactRepository;
+import org.gradle.api.invocation.Gradle;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.TaskProvider;
 
@@ -490,5 +491,53 @@ public class Utils {
         }
 
         return buf.toString();
+    }
+
+    /**
+     * Get the root project of this composite build.
+     *
+     * @param project The current project.
+     * @return The <em>very</em> root project.
+     * @see Project#getRootProject()
+     */
+    public static Project getCompositeRoot(Project project) {
+        Gradle gradle = project.getGradle();
+        while (gradle.getParent() != null) gradle = gradle.getParent();
+        return gradle.getRootProject();
+    }
+
+    /**
+     * Get the path to the current project relative to the composite root.
+     *
+     * @param project The current project.
+     * @return The root
+     * @see Project#getPath()
+     */
+    public static String getCompositePath(Project project) {
+        Gradle gradle = project.getGradle();
+        if (gradle.getParent() == null) return project.getPath();
+
+        // Build up a list of paths. We start off with the current sub-project (we do nothing if we're the root
+        // project).
+        List<String> paths = new ArrayList<>();
+        if (project.getPath().length() > 1) paths.add(project.getPath().substring(1));
+
+        while (gradle.getParent() != null) {
+            // Then for each composite build parent, find the matching IncludedBuild in the parent and add its name to
+            // the path.
+            Project thisProject = gradle.getRootProject();
+            String projectName = gradle
+                .getParent().getIncludedBuilds().stream()
+                .filter(child -> child.getProjectDir().equals(thisProject.getRootDir()))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException("Cannot find valid matching parent"))
+                .getName();
+            paths.add(projectName);
+
+            gradle = gradle.getParent();
+        }
+
+        Collections.reverse(paths);
+        return ":" + String.join(":", paths);
     }
 }

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/IntellijRunGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/IntellijRunGenerator.java
@@ -22,7 +22,6 @@ package net.minecraftforge.gradle.common.util.runs;
 
 import net.minecraftforge.gradle.common.util.RunConfig;
 import net.minecraftforge.gradle.common.util.Utils;
-
 import org.gradle.api.Project;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
@@ -196,9 +195,12 @@ public class IntellijRunGenerator extends RunConfigGenerator.XMLConfigurationBui
 
                         final Element gradleTask = javaDocument.createElement("option");
                         {
+                            String prefix = Utils.getCompositePath(project);
+                            if (prefix.length() == 1) prefix = "";
+
                             gradleTask.setAttribute("name", "Gradle.BeforeRunTask");
                             gradleTask.setAttribute("enabled", "true");
-                            gradleTask.setAttribute("tasks", project.getTasks().getByName("prepare" + Utils.capitalize(runConfig.getTaskName())).getPath());
+                            gradleTask.setAttribute("tasks", prefix + ":prepare" + Utils.capitalize(runConfig.getTaskName()));
                             gradleTask.setAttribute("externalProjectPath", "$PROJECT_DIR$");
                         }
                         methods.appendChild(gradleTask);

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
@@ -88,16 +88,17 @@ public abstract class RunConfigGenerator
 
     public static void createIDEGenRunsTasks(@Nonnull final MinecraftExtension minecraft, @Nonnull final TaskProvider<Task> prepareRuns, @Nonnull final TaskProvider<Task> makeSourceDirs, List<String> additionalClientArgs) {
         final Project project = minecraft.getProject();
+        Project rootProject = Utils.getCompositeRoot(project);
 
         final Map<String, Triple<List<Object>, File, Supplier<RunConfigGenerator>>> ideConfigurationGenerators = ImmutableMap.<String, Triple<List<Object>, File, Supplier<RunConfigGenerator>>>builder()
                 .put("genIntellijRuns", ImmutableTriple.of(Collections.singletonList(prepareRuns),
-                        new File(project.getRootProject().getRootDir(), ".idea/runConfigurations"),
-                        () -> new IntellijRunGenerator(project.getRootProject())))
+                        new File(rootProject.getRootDir(), ".idea/runConfigurations"),
+                        () -> new IntellijRunGenerator(rootProject)))
                 .put("genEclipseRuns", ImmutableTriple.of(ImmutableList.of(prepareRuns, makeSourceDirs),
-                        project.getProjectDir(),
+                        rootProject.getProjectDir(),
                         EclipseRunGenerator::new))
                 .put("genVSCodeRuns", ImmutableTriple.of(ImmutableList.of(prepareRuns, makeSourceDirs),
-                        new File(project.getProjectDir(), ".vscode"),
+                        new File(rootProject.getProjectDir(), ".vscode"),
                         VSCodeRunGenerator::new))
                 .build();
 
@@ -140,7 +141,7 @@ public abstract class RunConfigGenerator
         if (value == null || value.isEmpty()) {
             return value;
         }
-        return value.replace(project.getRootDir().toString(), replacement);
+        return value.replace(Utils.getCompositeRoot(project).getRootDir().toString(), replacement);
     }
 
     protected static Stream<String> mapModClassesToGradle(Project project, RunConfig runConfig)


### PR DESCRIPTION
This adds support for [composite builds (i.e. `includeBuild`)](https://docs.gradle.org/current/userguide/composite_builds.html) to the various run generators.

As each included build is treated as a separate project, generating runs would read/write config from the non-existent `<child project>/.idea` rather than `.idea` (similarly for VSCode).

This change will walk up the entire project hierarchy to find the correct place to read/write IDE configuration. It also remaps the `prepareXXX` tasks to the "full" task path.

I've set up a test repository at https://github.com/SquidDev/fg-composite-demo/ which contains a mixture of projects using `include` and `includeBuild`. https://github.com/SquidDev/fg-composite-demo/commit/c46e017931677f79abfcbc41f74a276e8073dc98 is the commit which switches run generations to this branch, to allow you to see before/after.

I'm marking this as a draft for now, as it will conflict with #868.