### PR TITLE
Support MC Only workflows

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -633,6 +633,11 @@ public class MinecraftUserRepo extends BaseRepo {
             debug("    Creating MCP Inject Sources");
             //Build and inject MCP injected sources
             File inject_src = cacheRaw("inject_src", "jar");
+            if (!inject_src.exists()) {
+                inject_src.getParentFile().mkdirs();
+                inject_src.createNewFile();
+            }
+
             try (ZipInputStream zin = new ZipInputStream(new FileInputStream(mcp.getZip()));
                  ZipOutputStream zos = new ZipOutputStream(new FileOutputStream(inject_src)) ) {
                 String prefix = mcp.wrapper.getConfig().getData("inject");


### PR DESCRIPTION
This fixes a case where FG is run in MC Only mode (Without Forge) while it expects its inject target to exists.

Current the forge variant creates the inject target automatically, but the MC only variant does not.
This causes the MCP injection to fail with a file not found exception since neither the target nor its directories exists.

This fixes this.