### PR TITLE
Rudimentary support for including subprojects with Jar-in-Jar

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DefaultDependencyFilter.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DefaultDependencyFilter.java
@@ -89,7 +89,7 @@ public class DefaultDependencyFilter implements DependencyFilter {
     }
 
     @Override
-    public boolean isIncluded(ExternalModuleDependency dependency) {
+    public boolean isIncluded(Dependency dependency) {
         return isIncluded(
                 new ArtifactIdentifier(dependency.getGroup(), dependency.getName(), dependency.getVersion())
         );

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DependencyFilter.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DependencyFilter.java
@@ -24,7 +24,7 @@ import groovy.lang.Closure;
 import net.minecraftforge.artifactural.api.artifact.ArtifactIdentifier;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.ExternalModuleDependency;
+import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ResolvedDependency;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.specs.Spec;
@@ -95,7 +95,7 @@ public interface DependencyFilter {
      * @param dependency The dependency to check.
      * @return The result of the filter.
      */
-    boolean isIncluded(ExternalModuleDependency dependency);
+    boolean isIncluded(Dependency dependency);
 
     /**
      * Checks if the given artifact identifier matches the dependency.

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/JarJar.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/JarJar.java
@@ -116,8 +116,6 @@ public abstract class JarJar extends Jar {
     @Internal
     public Set<ResolvedDependency> getResolvedDependencies() {
         return this.configurations.stream().flatMap(config -> config.getAllDependencies().stream())
-                .filter(ModuleDependency.class::isInstance)
-                .map(ModuleDependency.class::cast)
                 .map(this::getResolvedDependency)
                 .filter(this.dependencyFilter::isIncluded)
                 .collect(Collectors.toSet());


### PR DESCRIPTION
This adds rudimentary support for including sub projects into a jar-in-jar build by replacing calls referring to `ExternalModuleDependency` with a call to `Dependency` where possible.