### PR TITLE
Allow run configurations to build all projects

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
@@ -68,6 +68,7 @@ public class RunConfig extends GroovyObjectSupport implements Serializable {
     private Boolean client; // so we can have it null
     private Boolean inheritArgs;
     private Boolean inheritJvmArgs;
+    private boolean buildAllProjects;
 
     private Map<String, String> env, props, tokens;
     private Map<String, Supplier<String>> lazyTokens;
@@ -171,6 +172,18 @@ public class RunConfig extends GroovyObjectSupport implements Serializable {
     public boolean getInheritJvmArgs() {
         // Both null and true mean inherit the args
         return inheritJvmArgs != Boolean.FALSE;
+    }
+
+    public void buildAllProjects(boolean value) {
+        setBuildAllProjects(value);
+    }
+
+    public void setBuildAllProjects(boolean value) {
+        this.buildAllProjects = value;
+    }
+
+    public boolean getBuildAllProjects() {
+        return buildAllProjects;
     }
 
     public void args(List<Object> values) {
@@ -504,6 +517,9 @@ public class RunConfig extends GroovyObjectSupport implements Serializable {
         ideaModule = first.ideaModule == null ? second.ideaModule : first.ideaModule;
         singleInstance = first.singleInstance == null ? second.singleInstance : first.singleInstance;
         this.client = first.client == null ? second.client : first.client;
+        if (overwrite) {
+            this.buildAllProjects = other.buildAllProjects;
+        }
 
         if (other.env != null) {
             other.env.forEach(overwrite

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/IntellijRunGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/IntellijRunGenerator.java
@@ -189,7 +189,7 @@ public class IntellijRunGenerator extends RunConfigGenerator.XMLConfigurationBui
 
                         final Element makeTask = javaDocument.createElement("option");
                         {
-                            makeTask.setAttribute("name", "Make");
+                            makeTask.setAttribute("name", runConfig.getBuildAllProjects() ? "MakeProject" : "Make");
                             makeTask.setAttribute("enabled", "true");
                         }
                         methods.appendChild(makeTask);


### PR DESCRIPTION
The current default pre-run behavior in IntelliJ is `Make` (or "Build" inside the IDE), which only builds the source set targetted by the run configuration and none of its dependencies. This is incredibly inconvenient when working with multiple source sets or projects, as changes won't always auto-build when starting a run configuration. It can be changed manually, but the moment run configurations are re-generated it will be overridden again. As far as I can tell, this is not relevant in Eclipse.

This PR adds an extra option to run configurations that allows the pre-run behavior to be set to `MakeProject` (or "Build Project" inside the IDE), which builds all the modules and source sets.