### PR TITLE
[5.x] Add more configuration to jarJar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     userdevImplementation sourceSets.mcp.output
     userdevImplementation sourceSets.common.output
 
-    userdevImplementation 'net.minecraftforge:JarJar:0.2.21'
+    userdevImplementation 'net.minecraftforge:JarJar:0.3.10'
 }
 
 //Gradle doesn't add it's own source when doing the API. So lets hack it in!

--- a/build.gradle
+++ b/build.gradle
@@ -84,15 +84,9 @@ dependencies {
     commonImplementation('net.minecraftforge:unsafe:0.2.0') {
         transitive = false
     }
-    commonImplementation('org.apache.logging.log4j:log4j-api:2.11.2') {
-        force = true
-    }
-    commonImplementation('org.apache.logging.log4j:log4j-core:2.11.2') {
-        force = true
-    }
     commonImplementation 'org.apache.maven:maven-artifact:3.6.3'
     commonImplementation 'org.apache.httpcomponents:httpclient:4.5.13'
-    commonImplementation 'net.minecraftforge:srgutils:0.4.3'
+    commonImplementation 'net.minecraftforge:srgutils:0.4.13'
     commonImplementation 'net.minecraftforge:DiffPatch:2.0.7:all'
 
     mcpImplementation sourceSets.common.output

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -100,7 +100,7 @@ public class Utils {
     public static final String FART = "net.minecraftforge:ForgeAutoRenamingTool:0.1.+:all";
     public static final String SRG2SOURCE =  "net.minecraftforge:Srg2Source:8.+:fatjar";
     public static final String SIDESTRIPPER = "net.minecraftforge:mergetool:1.1.5:fatjar";
-    public static final String INSTALLERTOOLS = "net.minecraftforge:installertools:1.3.0:fatjar";
+    public static final String INSTALLERTOOLS = "net.minecraftforge:installertools:1.3.2:fatjar";
     public static final String JARCOMPATIBILITYCHECKER = "net.minecraftforge:JarCompatibilityChecker:0.1.+:all";
     public static final long ZIPTIME = 628041600000L;
     public static final TimeZone GMT = TimeZone.getTimeZone("GMT");


### PR DESCRIPTION
Add jarJar.disable()
Add jarJar.disableDefaultSources()
Add configurations minecraftLibrary and minecraftEmbed
minecraftLibrary = Non-MC libs that should be added to legacyClasspath (replaces [https://gist.github.com/SizableShrimp/66b22f1b24c255e1491c8d98d3f11f83](https://gist.github.com/SizableShrimp/66b22f1b24c255e1491c8d98d3f11f83))
minecraftEmbed = Deps that should be JIJed and put into implementation

People who want minecraftLibrary to also enable JIJ should use
```gradle
configurations {
    minecraftEmbed.extendsFrom minecraftLibrary
}
```