### PR TITLE
Implement a fix for a crash that can occur when JiJ is enabled.

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/DependencyManagementExtension.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/DependencyManagementExtension.java
@@ -81,6 +81,10 @@ public class DependencyManagementExtension extends GroovyObjectSupport {
                                 && MavenPomUtils.hasChildWithText(el, MavenPomUtils.MAVEN_POM_NAMESPACE + "groupId", "net.minecraftforge"))
                         .forEach(el -> el.parent().remove(el));
 
+                dependenciesNodeList.stream()
+                        .filter(el -> MavenPomUtils.hasChildWithText(el, MavenPomUtils.MAVEN_POM_NAMESPACE + "artifactId", "client", "server", "joined")
+                                && MavenPomUtils.hasChildWithText(el, MavenPomUtils.MAVEN_POM_NAMESPACE + "groupId", "net.minecraft"))
+                        .forEach(el -> el.parent().remove(el));
 
                 dependenciesNodeList.stream()
                         .filter(el -> MavenPomUtils.hasChildWithContainedText(el, MavenPomUtils.MAVEN_POM_NAMESPACE + "version", "_mapped_"))

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -77,6 +77,8 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
 public class UserDevPlugin implements Plugin<Project> {
+    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(UserDevPlugin.class);
+
     public static final String JAR_JAR_TASK_NAME = "jarJar";
     public static final String JAR_JAR_GROUP = "jarjar";
 
@@ -329,11 +331,12 @@ public class UserDevPlugin implements Plugin<Project> {
             Utils.createRunConfigTasks(extension, extractNatives, downloadAssets, createSrgToMcp);
         });
 
-        project.afterEvaluate(projectAfter -> projectAfter.getTasks().withType(JarJar.class).configureEach(jarJar -> {
+        project.getTasks().withType(JarJar.class).configureEach(jarJar -> {
             if (jarJar.isEnabled()) {
+                LOGGER.info("Creating reobfuscation task for JarJar task: " + jarJar.getName());
                 reobfExtension.create(jarJar.getName());
             }
-        }));
+        });
     }
 
     private NamedDomainObjectContainer<RenameJarInPlace> createReobfExtension(Project project) {

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -48,7 +48,10 @@ import net.minecraftforge.gradle.userdev.util.DependencyRemapper;
 import net.minecraftforge.srgutils.IMappingFile;
 
 import org.apache.commons.lang3.StringUtils;
-import org.gradle.api.*;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.DependencySet;
@@ -77,8 +80,6 @@ import java.util.stream.Stream;
 import javax.annotation.Nonnull;
 
 public class UserDevPlugin implements Plugin<Project> {
-    private static final org.slf4j.Logger LOGGER = org.slf4j.LoggerFactory.getLogger(UserDevPlugin.class);
-
     public static final String JAR_JAR_TASK_NAME = "jarJar";
     public static final String JAR_JAR_GROUP = "jarjar";
 
@@ -333,7 +334,7 @@ public class UserDevPlugin implements Plugin<Project> {
 
         project.getTasks().withType(JarJar.class).configureEach(jarJar -> {
             if (jarJar.isEnabled()) {
-                LOGGER.info("Creating reobfuscation task for JarJar task: " + jarJar.getName());
+                logger.info("Creating reobfuscation task for JarJar task: {}", jarJar.getName());
                 reobfExtension.create(jarJar.getName());
             }
         });


### PR DESCRIPTION
When #879 was merged a corner case opened up with the way FG registers the reobfuscation tasks for JiJ.
This has been fixed with this PR by using a immediate lazy resolve when the JiJ tasks get added.

Additionally cleans up the maven publication from any vanilla artifacts.
Adds a logging line to keep track of the automatically added Reobf tasks for JiJ to make future testing and diagnosing easier.