### PR TITLE
Lazily create JarJar task on jarJar.enable()

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -219,8 +219,6 @@ public class UserDevPlugin implements Plugin<Project> {
             updateMappings.configure(task -> task.dependsOn(extractMappedNew));
         }
 
-        configureJarJarTask(project, jarJarExtension);
-
         if (!project.hasProperty(DISABLE_DEFAULT_CONFIGS_PROP) || !Boolean.parseBoolean((String) project.property(DISABLE_DEFAULT_CONFIGS_PROP))) {
             final Configuration minecraftLibrary = project.getConfigurations().create(MINECRAFT_LIBRARY_CONFIGURATION_NAME);
             final Configuration minecraftEmbed = project.getConfigurations().create(MINECRAFT_EMBED_CONFIGURATION_NAME);
@@ -359,28 +357,5 @@ public class UserDevPlugin implements Plugin<Project> {
         });
         project.getExtensions().add("reobf", reobfExtension);
         return reobfExtension;
-    }
-
-    protected void configureJarJarTask(Project project, JarJarProjectExtension jarJarExtension) {
-        final Configuration configuration = project.getConfigurations().create(JAR_JAR_DEFAULT_CONFIGURATION_NAME);
-
-        JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
-
-        project.getTasks().register(JAR_JAR_TASK_NAME, JarJar.class, jarJar -> {
-            jarJar.setGroup(JAR_JAR_GROUP);
-            jarJar.setDescription("Create a combined JAR of project and selected dependencies");
-            jarJar.getArchiveClassifier().convention("all");
-
-            if (!jarJarExtension.getDefaultSourcesDisabled()) {
-                jarJar.getManifest().inheritFrom(((Jar) project.getTasks().getByName("jar")).getManifest());
-                jarJar.from(javaPluginExtension.getSourceSets().getByName("main").getOutput());
-            }
-
-            jarJar.configuration(configuration);
-
-            jarJar.setEnabled(false);
-        });
-
-        project.getArtifacts().add(JAR_JAR_DEFAULT_CONFIGURATION_NAME, project.getTasks().named(JAR_JAR_TASK_NAME));
     }
 }


### PR DESCRIPTION
Successor to #884, fixes #883.

Hello again chat.

After some discussion in #gradle, we decided that an implementation revolved around lazily creating the `jarJar` task when `jarJar.enable()` is called would be the best solution, so here's my implementation of that. There's currently nothing in place that accounts for the end user in UserDev calling `jarJar.disable()`, but for now this should be fine.