### PR TITLE
Manual specification of JarJar version information

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/AbstractDependencyManagementObject.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/AbstractDependencyManagementObject.java
@@ -1,3 +1,23 @@
+/*
+ * ForgeGradle
+ * Copyright (C) 2018 Forge Development LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
 package net.minecraftforge.gradle.userdev.dependency;
 
 import groovy.lang.Closure;

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/AbstractDependencyManagementObject.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/AbstractDependencyManagementObject.java
@@ -1,0 +1,54 @@
+package net.minecraftforge.gradle.userdev.dependency;
+
+import groovy.lang.Closure;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.artifacts.ResolvedDependency;
+import org.gradle.api.specs.Spec;
+import org.gradle.api.specs.Specs;
+
+import java.util.regex.Pattern;
+
+public class AbstractDependencyManagementObject implements DependencyManagementObject {
+
+    protected final Project project;
+
+    public AbstractDependencyManagementObject(Project project) {
+        this.project = project;
+    }
+
+    protected static ArtifactIdentifier createArtifactIdentifier(final ResolvedDependency dependency) {
+        return new ArtifactIdentifier(dependency.getModuleGroup(), dependency.getModuleName(), dependency.getModuleVersion());
+    }
+
+    protected static ArtifactIdentifier createArtifactIdentifier(final ModuleDependency dependency) {
+        return new ArtifactIdentifier(dependency.getGroup(), dependency.getName(), dependency.getVersion());
+    }
+
+    public Spec<? super DependencyManagementObject.ArtifactIdentifier> dependency(Object notation) {
+        return dependency(project.getDependencies().create(notation));
+    }
+
+    public Spec<? super DependencyManagementObject.ArtifactIdentifier> dependency(Dependency dependency) {
+        return this.dependency(new Closure<Boolean>(null) {
+
+            @SuppressWarnings("ConstantConditions")
+            @Override
+            public Boolean call(final Object it) {
+                if (it instanceof DependencyManagementObject.ArtifactIdentifier) {
+                    final DependencyManagementObject.ArtifactIdentifier identifier = (DependencyManagementObject.ArtifactIdentifier) it;
+                    return (dependency.getGroup() == null || Pattern.matches(dependency.getGroup(), identifier.getGroup())) &&
+                            (dependency.getName() == null || Pattern.matches(dependency.getName(), identifier.getName())) &&
+                            (dependency.getVersion() == null || Pattern.matches(dependency.getVersion(), identifier.getVersion()));
+                }
+
+                return false;
+            }
+        });
+    }
+
+    public Spec<? super DependencyManagementObject.ArtifactIdentifier> dependency(Closure<Boolean> spec) {
+        return Specs.convertClosureToSpec(spec);
+    }
+}

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DefaultDependencyFilter.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DefaultDependencyFilter.java
@@ -20,24 +20,18 @@
 
 package net.minecraftforge.gradle.userdev.dependency;
 
-import com.google.common.collect.ImmutableMap;
-import groovy.lang.Closure;
-import net.minecraftforge.gradle.userdev.tasks.JarJar;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.*;
 import org.gradle.api.specs.Spec;
-import org.gradle.api.specs.Specs;
 
 import java.util.*;
-import java.util.regex.Pattern;
 
-public class DefaultDependencyFilter implements DependencyFilter {
-    private final Project project;
+public class DefaultDependencyFilter extends AbstractDependencyManagementObject implements DependencyFilter {
     protected final List<Spec<? super ArtifactIdentifier>> includeSpecs = new ArrayList<>();
     protected final List<Spec<? super ArtifactIdentifier>> excludeSpecs = new ArrayList<>();
 
     public DefaultDependencyFilter(Project project) {
-        this.project = project;
+        super(project);
     }
 
     @Override
@@ -53,46 +47,13 @@ public class DefaultDependencyFilter implements DependencyFilter {
     }
 
     @Override
-    public Spec<? super ArtifactIdentifier> dependency(Object notation) {
-        return dependency(project.getDependencies().create(notation));
-    }
-
-    @Override
-    public Spec<? super ArtifactIdentifier> dependency(Dependency dependency) {
-        return this.dependency(new Closure<Boolean>(null) {
-
-            @SuppressWarnings("ConstantConditions")
-            @Override
-            public Boolean call(final Object it) {
-                if (it instanceof ArtifactIdentifier) {
-                    final ArtifactIdentifier identifier = (ArtifactIdentifier) it;
-                    return (dependency.getGroup() == null || Pattern.matches(dependency.getGroup(), identifier.getGroup())) &&
-                            (dependency.getName() == null || Pattern.matches(dependency.getName(), identifier.getName())) &&
-                            (dependency.getVersion() == null || Pattern.matches(dependency.getVersion(), identifier.getVersion()));
-                }
-
-                return false;
-            }
-        });
-    }
-
-    @Override
-    public Spec<? super ArtifactIdentifier> dependency(Closure<Boolean> spec) {
-        return Specs.convertClosureToSpec(spec);
-    }
-
-    @Override
     public boolean isIncluded(ResolvedDependency dependency) {
-        return isIncluded(
-                new ArtifactIdentifier(dependency.getModuleGroup(), dependency.getModuleName(), dependency.getModuleVersion())
-        );
+        return isIncluded(createArtifactIdentifier(dependency));
     }
 
     @Override
     public boolean isIncluded(ModuleDependency dependency) {
-        return isIncluded(
-                new ArtifactIdentifier(dependency.getGroup(), dependency.getName(), dependency.getVersion())
-        );
+        return isIncluded(createArtifactIdentifier(dependency));
     }
 
     @Override

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DefaultDependencyVersionInformationHandler.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DefaultDependencyVersionInformationHandler.java
@@ -1,3 +1,23 @@
+/*
+ * ForgeGradle
+ * Copyright (C) 2018 Forge Development LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
 package net.minecraftforge.gradle.userdev.dependency;
 
 import com.google.common.collect.Maps;

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DefaultDependencyVersionInformationHandler.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DefaultDependencyVersionInformationHandler.java
@@ -1,0 +1,65 @@
+package net.minecraftforge.gradle.userdev.dependency;
+
+import com.google.common.collect.Maps;
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.specs.Spec;
+
+import java.util.Map;
+import java.util.Optional;
+
+public class DefaultDependencyVersionInformationHandler extends AbstractDependencyManagementObject implements DependencyVersionInformationHandler {
+
+    private final Map<Spec<? super ArtifactIdentifier>, String> rangedVersions = Maps.newHashMap();
+    private final Map<Spec<? super ArtifactIdentifier>, String> pinnedVersions = Maps.newHashMap();
+
+    public DefaultDependencyVersionInformationHandler(final Project project) {
+        super(project);
+    }
+
+    @Override
+    public void ranged(final Spec<? super ArtifactIdentifier> spec, final String range) {
+        rangedVersions.put(spec, range);
+    }
+
+    @Override
+    public void ranged(final Spec<? super ArtifactIdentifier> spec, final VersionRange range) {
+        ranged(spec, range.toString());
+    }
+
+    @Override
+    public void ranged(final Spec<? super ArtifactIdentifier> spec, final ArtifactVersion version) {
+        ranged(spec, String.format("[%s,%s]", version, version));
+    }
+
+    @Override
+    public void pin(final Spec<? super ArtifactIdentifier> spec, final String version) {
+        pinnedVersions.put(spec, version);
+    }
+
+    @Override
+    public void pin(final Spec<? super ArtifactIdentifier> spec, final ArtifactVersion version) {
+        pin(spec, version.toString());
+    }
+
+    @Override
+    public Optional<String> getVersionRange(final ModuleDependency dependency) {
+        final ArtifactIdentifier identifier = createArtifactIdentifier(dependency);
+        return rangedVersions.entrySet().stream()
+                .filter(entry -> entry.getKey().isSatisfiedBy(identifier))
+                .map(Map.Entry::getValue)
+                .findFirst();
+    }
+
+    @Override
+    public Optional<String> getVersion(final ModuleDependency dependency) {
+        final ArtifactIdentifier identifier = createArtifactIdentifier(dependency);
+        return pinnedVersions.entrySet().stream()
+                .filter(entry -> entry.getKey().isSatisfiedBy(identifier))
+                .map(Map.Entry::getValue)
+                .findFirst();
+    }
+}

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DependencyFilter.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DependencyFilter.java
@@ -20,25 +20,15 @@
 
 package net.minecraftforge.gradle.userdev.dependency;
 
-import groovy.lang.Closure;
-import net.minecraftforge.artifactural.api.artifact.ArtifactIdentifier;
-import org.gradle.api.artifacts.Configuration;
-import org.gradle.api.artifacts.Dependency;
-import org.gradle.api.artifacts.ExternalModuleDependency;
 import org.gradle.api.artifacts.ModuleDependency;
 import org.gradle.api.artifacts.ResolvedDependency;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.specs.Spec;
-
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
 
 /**
  * A dependency filter that can be used to filter out dependencies based on different specifications.
  * Inspired and incrementally derived from the dependency filter in the Shadow plugin.
  */
-public interface DependencyFilter {
+public interface DependencyFilter extends DependencyManagementObject {
     /**
      * Exclude dependencies that match the provided spec.
      * If at least one exclude spec is provided, only the dependencies which fail the check will be excluded.
@@ -56,31 +46,6 @@ public interface DependencyFilter {
      * @return The filter (this object)
      */
     DependencyFilter include(Spec<? super ArtifactIdentifier> spec);
-
-    /**
-     * Create a spec that matches dependencies using the provided notation on group, name, and version
-     * If a regex is supplied for any of the group, name, or version, the spec will match if the dependency matches the regex.
-     *
-     * @param notation The dependency notation to parse.
-     * @return The spec that matches the dependency notation.
-     */
-    Spec<? super ArtifactIdentifier> dependency(Object notation);
-
-    /**
-     * Create a spec that matches the provided dependency on group, name, and version
-     *
-     * @param dependency The dependency to match.
-     * @return The spec that matches the dependency.
-     */
-    Spec<? super ArtifactIdentifier> dependency(Dependency dependency);
-
-    /**
-     * Create a spec that matches the provided closure.
-     *
-     * @param spec The closure to invoke.
-     * @return The spec that matches by invoking the closure.
-     */
-    Spec<? super ArtifactIdentifier> dependency(Closure<Boolean> spec);
 
     /**
      * Indicates if the given resolved dependency passes the filter.
@@ -106,52 +71,4 @@ public interface DependencyFilter {
      */
     boolean isIncluded(ArtifactIdentifier identifier);
 
-    /**
-     * Simple artifact identifier class which only references group, name and version.
-     */
-    final class ArtifactIdentifier {
-        private final String group;
-        private final String name;
-        private final String version;
-
-        /**
-         * Creates a new instance of the given artifact details.
-         *
-         * @param group The group of the artifact to identify.
-         * @param name The name of the artifact to identify.
-         * @param version The version of the artifact to identify.
-         */
-        public ArtifactIdentifier(String group, String name, String version) {
-            this.group = group;
-            this.name = name;
-            this.version = version;
-        }
-
-        /**
-         * Gets the group of the artifact.
-         *
-         * @return The group of the artifact.
-         */
-        public String getGroup() {
-            return group;
-        }
-
-        /**
-         * Gets the name of the artifact.
-         *
-         * @return The name of the artifact.
-         */
-        public String getName() {
-            return name;
-        }
-
-        /**
-         * Gets the version of the artifact.
-         *
-         * @return The version of the artifact.
-         */
-        public String getVersion() {
-            return version;
-        }
-    }
 }

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DependencyManagementObject.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DependencyManagementObject.java
@@ -1,3 +1,23 @@
+/*
+ * ForgeGradle
+ * Copyright (C) 2018 Forge Development LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
 package net.minecraftforge.gradle.userdev.dependency;
 
 import groovy.lang.Closure;

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DependencyManagementObject.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DependencyManagementObject.java
@@ -1,0 +1,81 @@
+package net.minecraftforge.gradle.userdev.dependency;
+
+import groovy.lang.Closure;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.specs.Spec;
+
+public interface DependencyManagementObject {
+    /**
+     * Create a spec that matches dependencies using the provided notation on group, name, and version
+     * If a regex is supplied for any of the group, name, or version, the spec will match if the dependency matches the regex.
+     *
+     * @param notation The dependency notation to parse.
+     * @return The spec that matches the dependency notation.
+     */
+    Spec<? super ArtifactIdentifier> dependency(Object notation);
+
+    /**
+     * Create a spec that matches the provided dependency on group, name, and version
+     *
+     * @param dependency The dependency to match.
+     * @return The spec that matches the dependency.
+     */
+    Spec<? super ArtifactIdentifier> dependency(Dependency dependency);
+
+    /**
+     * Create a spec that matches the provided closure.
+     *
+     * @param spec The closure to invoke.
+     * @return The spec that matches by invoking the closure.
+     */
+    Spec<? super ArtifactIdentifier> dependency(Closure<Boolean> spec);
+
+    /**
+     * Simple artifact identifier class which only references group, name and version.
+     */
+    final class ArtifactIdentifier {
+        private final String group;
+        private final String name;
+        private final String version;
+
+        /**
+         * Creates a new instance of the given artifact details.
+         *
+         * @param group   The group of the artifact to identify.
+         * @param name    The name of the artifact to identify.
+         * @param version The version of the artifact to identify.
+         */
+        public ArtifactIdentifier(String group, String name, String version) {
+            this.group = group;
+            this.name = name;
+            this.version = version;
+        }
+
+        /**
+         * Gets the group of the artifact.
+         *
+         * @return The group of the artifact.
+         */
+        public String getGroup() {
+            return group;
+        }
+
+        /**
+         * Gets the name of the artifact.
+         *
+         * @return The name of the artifact.
+         */
+        public String getName() {
+            return name;
+        }
+
+        /**
+         * Gets the version of the artifact.
+         *
+         * @return The version of the artifact.
+         */
+        public String getVersion() {
+            return version;
+        }
+    }
+}

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DependencyVersionInformationHandler.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DependencyVersionInformationHandler.java
@@ -1,3 +1,23 @@
+/*
+ * ForgeGradle
+ * Copyright (C) 2018 Forge Development LLC
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
 package net.minecraftforge.gradle.userdev.dependency;
 
 import org.apache.maven.artifact.versioning.ArtifactVersion;

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DependencyVersionInformationHandler.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/dependency/DependencyVersionInformationHandler.java
@@ -1,0 +1,73 @@
+package net.minecraftforge.gradle.userdev.dependency;
+
+import org.apache.maven.artifact.versioning.ArtifactVersion;
+import org.apache.maven.artifact.versioning.VersionRange;
+import org.gradle.api.artifacts.Dependency;
+import org.gradle.api.artifacts.ModuleDependency;
+import org.gradle.api.specs.Spec;
+
+import java.util.Optional;
+import java.util.stream.DoubleStream;
+
+/**
+ * A handler which manages version information.
+ * It supports setting a ranged version, and a fixed version for artifacts.
+ */
+public interface DependencyVersionInformationHandler extends DependencyManagementObject {
+
+    /**
+     * Sets the supported version range for dependencies which match the spec.
+     *
+     * @param spec The spec to match dependencies.
+     * @param range The string representation to match the version range.
+     */
+    void ranged(final Spec<? super ArtifactIdentifier> spec, final String range);
+
+    /**
+     * Sets the supported version range for dependencies which match the spec.
+     *
+     * @param spec The spec to match dependencies.
+     * @param range The version range to match.
+     */
+    void ranged(final Spec<? super ArtifactIdentifier> spec, final VersionRange range);
+
+    /**
+     * Sets the supported version range for dependencies which match the spec, but limits it to exactly the given version.
+     *
+     * @param spec The spec to match dependencies.
+     * @param version The version to match.
+     */
+    void ranged(final Spec<? super ArtifactIdentifier> spec, final ArtifactVersion version);
+
+    /**
+     * Sets the fixed version of the dependencies matching the spec.
+     *
+     * @param spec The spec to match.
+     * @param version The string representation of the version.
+     */
+    void pin(final Spec<? super ArtifactIdentifier> spec, final String version);
+
+    /**
+     * Sets the fixed version of the dependencies matching the spec.
+     *
+     * @param spec The spec to match.
+     * @param version The version to set.
+     */
+    void pin(final Spec<? super ArtifactIdentifier> spec, final ArtifactVersion version);
+
+    /**
+     * Gets the version range for the given dependency.
+     *
+     * @param dependency The dependency to get the version range for.
+     * @return The version range, if any.
+     */
+    Optional<String> getVersionRange(ModuleDependency dependency);
+
+    /**
+     * Gets the version for the given dependency.
+     *
+     * @param dependency The dependency to get the version for.
+     * @return The version, if any.
+     */
+    Optional<String> getVersion(ModuleDependency dependency);
+}

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/jarjar/JarJarProjectExtension.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/jarjar/JarJarProjectExtension.java
@@ -25,6 +25,7 @@ import groovy.util.Node;
 import net.minecraftforge.gradle.userdev.DependencyManagementExtension;
 import net.minecraftforge.gradle.userdev.UserDevPlugin;
 import net.minecraftforge.gradle.userdev.dependency.DependencyFilter;
+import net.minecraftforge.gradle.userdev.dependency.DependencyVersionInformationHandler;
 import net.minecraftforge.gradle.userdev.tasks.JarJar;
 import net.minecraftforge.gradle.userdev.util.MavenPomUtils;
 import org.gradle.api.Action;
@@ -127,6 +128,12 @@ public class JarJarProjectExtension extends GroovyObjectSupport {
     public JarJarProjectExtension dependencies(Action<DependencyFilter> c) {
         enable();
         project.getTasks().withType(JarJar.class).configureEach(jarJar -> jarJar.dependencies(c));
+        return this;
+    }
+
+    public JarJarProjectExtension versionInformation(Action<DependencyVersionInformationHandler> c) {
+        enable();
+        project.getTasks().withType(JarJar.class).configureEach(jarJar -> jarJar.versionInformation(c));
         return this;
     }
 

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/util/DeobfuscatingVersionUtils.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/util/DeobfuscatingVersionUtils.java
@@ -69,13 +69,18 @@ public class DeobfuscatingVersionUtils {
         StringBuilder buf = new StringBuilder();
 
         buf.append(restriction.isLowerBoundInclusive() ? '[' : '(');
-        if (restriction.getLowerBound() != null) {
+        if (restriction.getLowerBound() != restriction.getUpperBound()) {
+            if (restriction.getLowerBound() != null) {
+                buf.append(adaptDeobfuscatedVersion(restriction.getLowerBound().toString()));
+            }
+            buf.append(',');
+            if (restriction.getUpperBound() != null) {
+                buf.append(adaptDeobfuscatedVersion(restriction.getUpperBound().toString()));
+            }
+        } else {
             buf.append(adaptDeobfuscatedVersion(restriction.getLowerBound().toString()));
         }
-        buf.append(',');
-        if (restriction.getUpperBound() != null) {
-            buf.append(adaptDeobfuscatedVersion(restriction.getUpperBound().toString()));
-        }
+
         buf.append(restriction.isUpperBoundInclusive() ? ']' : ')');
 
         return buf.toString();

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/util/DeobfuscatingVersionUtils.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/util/DeobfuscatingVersionUtils.java
@@ -20,6 +20,12 @@
 
 package net.minecraftforge.gradle.userdev.util;
 
+import org.apache.maven.artifact.versioning.InvalidVersionSpecificationException;
+import org.apache.maven.artifact.versioning.Restriction;
+import org.apache.maven.artifact.versioning.VersionRange;
+
+import java.util.Iterator;
+
 public class DeobfuscatingVersionUtils {
 
     private DeobfuscatingVersionUtils() {
@@ -32,5 +38,46 @@ public class DeobfuscatingVersionUtils {
         }
 
         return version;
+    }
+
+    public static String adaptDeobfuscatedVersionRange(final String version) {
+        final VersionRange range;
+        try {
+            range = VersionRange.createFromVersionSpec(version);
+        } catch (InvalidVersionSpecificationException e) {
+            throw new IllegalArgumentException("Invalid version range: " + version, e);
+        }
+
+        if (range.getRecommendedVersion() != null) {
+            return adaptDeobfuscatedVersion(range.getRecommendedVersion().toString());
+        }
+
+        StringBuilder buf = new StringBuilder();
+        for (Iterator<Restriction> i = range.getRestrictions().iterator(); i.hasNext(); ) {
+            Restriction r = i.next();
+
+            buf.append(adaptDeobfuscatedVersionRangeRestriction(r));
+
+            if (i.hasNext()) {
+                buf.append(',');
+            }
+        }
+        return buf.toString();
+    }
+
+    public static String adaptDeobfuscatedVersionRangeRestriction(final Restriction restriction) {
+        StringBuilder buf = new StringBuilder();
+
+        buf.append(restriction.isLowerBoundInclusive() ? '[' : '(');
+        if (restriction.getLowerBound() != null) {
+            buf.append(adaptDeobfuscatedVersion(restriction.getLowerBound().toString()));
+        }
+        buf.append(',');
+        if (restriction.getUpperBound() != null) {
+            buf.append(adaptDeobfuscatedVersion(restriction.getUpperBound().toString()));
+        }
+        buf.append(restriction.isUpperBoundInclusive() ? ']' : ')');
+
+        return buf.toString();
     }
 }


### PR DESCRIPTION
This PR enables users of Jar-In-Jar to manually specify the version ranges and pinned versions to use for the dependency they want to include.

This is useful because under normal situations the system will use attributes to marshal this information from the configured dependency into the execution of the tasks. However, due to restrictions on Gradle's end, these attributes can only be used on a dependency that does not target a particular classified dependency (regardless of maven or subproject).

To allow for the use of Jar-In-Jar a dependency information handler will be introduced by this PR which is queried first for dependency version(range) information after which the attributes have used a fallback.

Example:
```groovy
jarJar {
   versionInformation {
      pin(dependency(project(path: ':core', configuration: 'forgeReobfuscated')), project(':core').version)
      ranged(dependency(project(path: ':core', configuration: 'forgeReobfuscated')), "[${project(':core').version}]")
   }
}
```
This example configures a subproject which is consumed from a specific secondary published artifact (the forgeReobfuscated one in particular) to use the exact version of the core project.

