### PR TITLE
Support customization of the java launcher for run tasks

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
@@ -279,7 +279,7 @@ public abstract class RunConfigGenerator
             task.setWorkingDir(workDir);
             task.getMainClass().set(runConfig.getMain());
             JavaToolchainService service = project.getExtensions().getByType(JavaToolchainService.class);
-            task.getJavaLauncher().set(service.launcherFor(project.getExtensions().getByType(JavaPluginExtension.class).getToolchain()));
+            task.getJavaLauncher().convention(service.launcherFor(project.getExtensions().getByType(JavaPluginExtension.class).getToolchain()));
 
             task.args(getArgsStream(runConfig, updatedTokens, false).toArray());
             runConfig.getJvmArgs().forEach((arg) -> task.jvmArgs(runConfig.replace(updatedTokens, arg)));


### PR DESCRIPTION
Since the run tasks are created after the project has been evaluated, "setting" the javaLauncher makes it extremely difficult to customize the launcher. This becomes apparent when using a more recent Java version for the build process (which can be useful to evade rare compiler bugs) while still targeting old bytecode. To enable users to configure the launcher more easily, the task is updated to set the *default* value for the launcher. Setting the value via any of the Provider#set methods from user code now will work as expected and the current default behavior is preserved.