### PR TITLE
Make mappings a runtime-only dependency

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -522,7 +522,7 @@ public class MinecraftUserRepo extends BaseRepo {
                 int idx = mapping.lastIndexOf('_');
                 String channel = mapping.substring(0, idx);
                 String version = mapping.substring(idx + 1);
-                builder.dependencies().add(MCPRepo.getMappingDep(channel, version), "compile"); //Runtime?
+                builder.dependencies().add(MCPRepo.getMappingDep(channel, version), "runtime");
             }
 
             Patcher patcher = parent;


### PR DESCRIPTION
Removes mappings from the compile classpath.

Mappings are first and foremost a runtime dependency. They contain no code, so adding them to the compile classpath is redundant. Plus with the module system in play, this creates a direct conflict as the module-path can only contain `jar` and `jmod` files.<sup><a href="https://openjdk.org/jeps/261#Module-paths">1</a></sup> 

Here's an example use case for compiling a modular service that depends on `fmlloader`, a legacy jar. By assigning the compile classpath to the module path, we could easily use non-modular jars in our library.
```gradle
compileJava {
    options.compilerArgs << '--module-path' << classpath.asPath
}
```
There's a catch though: currently, the classpath can not be a valid module path because it contains an invalid artifact - mappings. If we try to compile our code in this configuration, the compiler will crash.