### PR TITLE
Add ability to mark client config as authenticated using DevLogin

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -296,6 +296,13 @@ public class UserDevPlugin implements Plugin<Project> {
                 e.metadataSources(MetadataSources::artifact);
             });
             project.getRepositories().mavenCentral(); //Needed for MCP Deps
+            // Attach covers1624 repo for DevLogin
+            project.getRepositories().maven(repo -> {
+                repo.setName("Covers1624");
+                repo.setUrl("https://maven.covers1624.net");
+                repo.mavenContent(content -> content.includeGroup("net.covers1624"));
+            });
+            project.getDependencies().add(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, "net.covers1624:DevLogin:0.1.0.2");
             mcrepo.validate(minecraft, extension.getRuns().getAsMap(), extractNatives.get(), downloadAssets.get(), createSrgToMcp.get()); //This will set the MC_VERSION property.
 
             String mcVer = (String) project.getExtensions().getExtraProperties().get("MC_VERSION");

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/UserDevPlugin.java
@@ -33,6 +33,7 @@ import net.minecraftforge.gradle.common.util.BaseRepo;
 import net.minecraftforge.gradle.common.util.EnvironmentChecks;
 import net.minecraftforge.gradle.common.util.MinecraftRepo;
 import net.minecraftforge.gradle.common.util.MojangLicenseHelper;
+import net.minecraftforge.gradle.common.util.RunConfig;
 import net.minecraftforge.gradle.common.util.Utils;
 import net.minecraftforge.gradle.common.util.VersionJson;
 import net.minecraftforge.gradle.mcp.ChannelProvidersExtension;
@@ -296,13 +297,17 @@ public class UserDevPlugin implements Plugin<Project> {
                 e.metadataSources(MetadataSources::artifact);
             });
             project.getRepositories().mavenCentral(); //Needed for MCP Deps
-            // Attach covers1624 repo for DevLogin
-            project.getRepositories().maven(repo -> {
-                repo.setName("Covers1624");
-                repo.setUrl("https://maven.covers1624.net");
-                repo.mavenContent(content -> content.includeGroup("net.covers1624"));
-            });
-            project.getDependencies().add(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, "net.covers1624:DevLogin:0.1.0.2");
+
+            if(extension.getRuns().stream().anyMatch(RunConfig::isAuthenticated)) {
+                // Attach covers1624 repo for DevLogin
+                project.getRepositories().maven(repo -> {
+                    repo.setName("Covers1624");
+                    repo.setUrl("https://maven.covers1624.net");
+                    repo.mavenContent(content -> content.includeGroup("net.covers1624"));
+                });
+                project.getDependencies().add(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME, "net.covers1624:DevLogin:0.1.0.2");
+            }
+
             mcrepo.validate(minecraft, extension.getRuns().getAsMap(), extractNatives.get(), downloadAssets.get(), createSrgToMcp.get()); //This will set the MC_VERSION property.
 
             String mcVer = (String) project.getExtensions().getExtraProperties().get("MC_VERSION");


### PR DESCRIPTION
This PR brings the ability to mark client run configs as being authenticated. These configs use Covers1624 DevLogin tool to login & authenticate against Mojangs account servers on launch.

See [here](https://github.com/covers1624/DevLogin#devlogin) for more details on DevLogin.

---

I have added Covers maven repo to be able to pull in the DevLogin jar, and have needed to change the main class for the client run config generated to `net.covers1624.devlogin.DevLogin` aswell as append a new program arg `--launch_target <original main>`.
[_Following the [wiki](https://github.com/covers1624/DevLogin/wiki/ForgeGradle-Setup) as a setup guide_]

---

To mark a config as being authenticated the user must specify `authenticated` in their gradle file like so
```groovy
minecraft {
	runs {
		client {
			// ...
			authenticated()
			// ...
		}
	}
}
```