### PR TITLE
Update artifactural and make FG's manual maven respect content filtering

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,7 +78,7 @@ dependencies {
     commonImplementation 'com.google.code.gson:gson:2.8.6'
     commonImplementation 'com.google.guava:guava:30.1-jre'
     commonImplementation 'de.siegmar:fastcsv:2.0.0'
-    commonImplementation('net.minecraftforge:artifactural:3.0.10') {
+    commonImplementation('net.minecraftforge:artifactural:3.0.14') {
         transitive = false
     }
     commonImplementation('net.minecraftforge:unsafe:0.2.0') {


### PR DESCRIPTION
Opening as a draft PR for now as it requires https://github.com/MinecraftForge/Artifactural/pull/7, but this PR in combination with that Artifactural PR will make the manual maven downloading FG does respect declared content filtering of the different repositories.

When doing some initial testing against Mekanism that declares a lot of repositories along with content filters for them, I was seeing rough timing changes on reimporting the project of about 3 minutes without this change to about 20 seconds with this change.