### PR TITLE
Add `java_version` property to MCP Functions and MCPConfig spec v4

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/config/MCPConfigV1.java
+++ b/src/common/java/net/minecraftforge/gradle/common/config/MCPConfigV1.java
@@ -154,6 +154,8 @@ public class MCPConfigV1 extends Config {
         protected List<String> args;
         @Nullable
         protected List<String> jvmargs;
+        @Nullable
+        private Integer java_version;
 
         public String getVersion() {
             return version;
@@ -181,6 +183,14 @@ public class MCPConfigV1 extends Config {
         }
         public void setJvmArgs(List<String> value) {
             this.jvmargs = value;
+        }
+
+        @Nullable
+        public Integer getJavaVersion() {
+            return this.java_version;
+        }
+        public void setJavaVersion(Integer javaVersion) {
+            this.java_version = javaVersion;
         }
     }
 }

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/ExecuteFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/ExecuteFunction.java
@@ -23,8 +23,10 @@ package net.minecraftforge.gradle.mcp.function;
 import net.minecraftforge.gradle.common.util.HashStore;
 import net.minecraftforge.gradle.common.util.Utils;
 import net.minecraftforge.gradle.mcp.util.MCPEnvironment;
+import org.gradle.jvm.toolchain.JavaLanguageVersion;
 import org.gradle.jvm.toolchain.JavaToolchainService;
 
+import javax.annotation.Nullable;
 import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -53,13 +55,20 @@ class ExecuteFunction implements MCPFunction {
     protected String[] runArgs;
     protected final Map<String, String> envVars;
 
+    @Nullable
+    private Integer javaVersion;
     private Map<String, String> data;
 
     public ExecuteFunction(File jar, String[] jvmArgs, String[] runArgs, Map<String, String> envVars) {
+        this(jar, jvmArgs, runArgs, envVars, null);
+    }
+
+    public ExecuteFunction(File jar, String[] jvmArgs, String[] runArgs, Map<String, String> envVars, @Nullable Integer javaVersion) {
         this.jar = jar;
         this.jvmArgs = jvmArgs;
         this.runArgs = runArgs;
         this.envVars = envVars;
+        this.javaVersion = javaVersion;
     }
 
     @Override
@@ -121,7 +130,8 @@ class ExecuteFunction implements MCPFunction {
         // Do not implicitly use the Java version that Gradle itself is using.
         // Instead use a launcher compatible with the version required by MCP.
         JavaToolchainService toolchainService = environment.project.getExtensions().getByType(JavaToolchainService.class);
-        String launcher = toolchainService.launcherFor(spec -> spec.getLanguageVersion().set(environment.getJavaVersion()))
+        JavaLanguageVersion toolchainVersion = this.javaVersion != null ? JavaLanguageVersion.of(this.javaVersion) : environment.getJavaVersion();
+        String launcher = toolchainService.launcherFor(spec -> spec.getLanguageVersion().set(toolchainVersion))
                 .get()
                 .getExecutablePath()
                 .getAsFile()

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/ListLibrariesFunction.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/ListLibrariesFunction.java
@@ -25,6 +25,7 @@ import net.minecraftforge.gradle.common.util.MavenArtifactDownloader;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.tools.ant.types.FileList;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -48,11 +49,19 @@ import java.util.jar.Manifest;
 
 class ListLibrariesFunction implements MCPFunction {
     private static final Attributes.Name FORMAT = new Attributes.Name("Bundler-Format");
+    private final int spec;
+
+    ListLibrariesFunction(int spec) {
+        this.spec = spec;
+    }
 
     @Override
     public File execute(MCPEnvironment environment) {
         File output = (File)environment.getArguments().computeIfAbsent("output", (key) -> environment.getFile("libraries.txt"));
         File bundle = (File) environment.getArguments().get("bundle");
+        if (bundle != null && this.spec < 3) {
+            throw new IllegalArgumentException("Invalid MCP Config: Listing bundle libraries is only supported for MCPConfig spec 3 or higher, found spec: " + this.spec);
+        }
 
         try (FileSystem bundleFs = bundle == null ? null : FileSystems.newFileSystem(bundle.toPath(), null)) {
             Set<String> artifacts;

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/MCPFunctionFactory.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/MCPFunctionFactory.java
@@ -54,7 +54,7 @@ public class MCPFunctionFactory {
             case "strip":
                 return new StripJarFunction();
             case "listLibraries":
-                return new ListLibrariesFunction();
+                return new ListLibrariesFunction(spec);
             case "inject":
                 return new InjectFunction();
             case "patch":

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/function/MCPFunctionFactory.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/function/MCPFunctionFactory.java
@@ -98,10 +98,11 @@ public class MCPFunctionFactory {
      * Non-Public API, Can be changed at any time.
      */
     @Deprecated
-    public static MCPFunction createExecute(File jar, List<String> jvmArgs, List<String> runArgs) {
+    public static MCPFunction createExecute(File jar, List<String> jvmArgs, List<String> runArgs, @Nullable Integer javaVersion) {
         return new ExecuteFunction(jar,
             jvmArgs.toArray(new String[jvmArgs.size()]),
             runArgs.toArray(new String[runArgs.size()]),
-            Collections.emptyMap());
+            Collections.emptyMap(),
+            javaVersion);
     }
 }

--- a/src/mcp/java/net/minecraftforge/gradle/mcp/util/MCPRuntime.java
+++ b/src/mcp/java/net/minecraftforge/gradle/mcp/util/MCPRuntime.java
@@ -102,7 +102,7 @@ public class MCPRuntime {
                     throw new IllegalArgumentException("Could not download MCP Config dependency: " + custom.getVersion());
 
                 @SuppressWarnings("deprecation")
-                MCPFunction tmp = MCPFunctionFactory.createExecute(jar, custom.getJvmArgs(), custom.getArgs());
+                MCPFunction tmp = MCPFunctionFactory.createExecute(jar, custom.getJvmArgs(), custom.getArgs(), custom.getJavaVersion());
                 function = tmp;
             }
 

--- a/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
+++ b/src/patcher/java/net/minecraftforge/gradle/patcher/PatcherPlugin.java
@@ -373,6 +373,9 @@ public class PatcherPlugin implements Plugin<Project> {
                             task.getInput().set(setupMCP.flatMap(SetupMCP::getOutput));
                             task.getTool().set(extension.getProcessor().getVersion());
                             task.getArgs().set(extension.getProcessor().getArgs());
+                            Integer javaVersion = extension.getProcessor().getJavaVersion();
+                            if (javaVersion != null)
+                                task.setRuntimeJavaVersion(javaVersion);
                             task.getData().set(extension.getProcessorData());
                         });
                         setupOutput = procConfig.flatMap(DynamicJarExec::getOutput);


### PR DESCRIPTION
- Validation has been added to error when spec 3 or spec 4 features are used incorrectly