### PR TITLE
Make `DownloaderUtils` properly handle compression of response

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/DownloadUtils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/DownloadUtils.java
@@ -168,7 +168,7 @@ public class DownloadUtils {
         final InputStream is = getInputStream(con);
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final int read = IOUtils.copy(is, out);
-        if (len != -1 && read != len) {
+        if (isEncoded(con) && len != -1 && read != len) {
             throw new IOException("Failed to read all data from " + con.getURL() + "; got " + read + " expected " + len);
         }
 
@@ -258,7 +258,8 @@ public class DownloadUtils {
         if (parent != null) parent.mkdirs();
         try (final FileOutputStream fos = new FileOutputStream(output)) {
             final int read = IOUtils.copy(in, fos);
-            if (len != -1 && read != len) {
+            // There will be a discrepancy between the bytes expected and read when we are sent a compressed response
+            if (isEncoded(connection) && len != -1 && read != len) {
                 throw new IOException("Failed to read all data from " + connection.getURL() + "; got " + read + " expected " + len);
             }
         }
@@ -277,6 +278,11 @@ public class DownloadUtils {
             is = strategy.wrap(is);
         }
         return is;
+    }
+
+    private static boolean isEncoded(URLConnection connection) {
+        final String enc = connection.getContentEncoding();
+        return enc == null || enc.equals("identity");
     }
 
     @FunctionalInterface

--- a/src/common/java/net/minecraftforge/gradle/common/util/DownloadUtils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/DownloadUtils.java
@@ -169,7 +169,7 @@ public class DownloadUtils {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
         final int read = IOUtils.copy(is, out);
         if (len != -1 && read != len) {
-            throw new IOException("Failed to read all of data from " + con.getURL() + "; got " + read + " expected " + len);
+            throw new IOException("Failed to read all data from " + con.getURL() + "; got " + read + " expected " + len);
         }
 
         Charset charset = StandardCharsets.UTF_8;
@@ -259,7 +259,7 @@ public class DownloadUtils {
         try (final FileOutputStream fos = new FileOutputStream(output)) {
             final int read = IOUtils.copy(in, fos);
             if (len != -1 && read != len) {
-                throw new IOException("Failed to read all of data from " + connection.getURL() + "; got " + read + " expected " + len);
+                throw new IOException("Failed to read all data from " + connection.getURL() + "; got " + read + " expected " + len);
             }
         }
     }


### PR DESCRIPTION
This PR makes `DownloadUtils` add the `Accept-Encoding` header to requests, as otherwise, it is assumed we accept any compression strategy. The `gzip` and `deflate` strategies are now handled. 
Additionally, when the `content-length` is `-1` or there is a compression strategy in use, an exception will no longer be thrown if the bytes read vs expected don't match, as a discrepancy between the two will usually exist in that scenario.