### PR TITLE
Introduce `ideaFolder` run config property

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/RunConfig.java
@@ -59,7 +59,7 @@ public class RunConfig extends GroovyObjectSupport implements Serializable {
 
     private Boolean singleInstance = null;
 
-    private String taskName, main, ideaModule, workDir;
+    private String taskName, main, ideaModule, ideaFolder, workDir;
 
     private List<SourceSet> sources;
     private List<RunConfig> parents, children;
@@ -284,6 +284,19 @@ public class RunConfig extends GroovyObjectSupport implements Serializable {
         }
 
         return ideaModule;
+    }
+
+    public void ideaFolder(@Nullable String value) {
+        this.setIdeaFolder(value);
+    }
+
+    public void setIdeaFolder(@Nullable String value) {
+        this.ideaFolder = value;
+    }
+
+    @Nullable
+    public final String getIdeaFolder() {
+        return ideaFolder;
     }
 
     public void workingDirectory(String value) {

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/IntellijRunGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/IntellijRunGenerator.java
@@ -155,6 +155,9 @@ public class IntellijRunGenerator extends RunConfigGenerator.XMLConfigurationBui
                     configuration.setAttribute("type", "Application");
                     configuration.setAttribute("factoryName", "Application");
                     configuration.setAttribute("singleton", runConfig.isSingleInstance() ? "true" : "false");
+                    if (runConfig.getIdeaFolder() != null) {
+                        configuration.setAttribute("folderName", runConfig.getIdeaFolder());
+                    }
 
                     elementOption(javaDocument, configuration, "MAIN_CLASS_NAME", runConfig.getMain());
                     elementOption(javaDocument, configuration, "VM_PARAMETERS",


### PR DESCRIPTION
## Introduction

This PR introduces `ideaFolder` run config property, which adds a `folderName` run attribute to IntelliJ-based runs. This allows grouping runs into folders, which helps organizing project-related runs into their own groups.

## Examples

Suppose you have a multi-project build with three subprojects: `mod-a`, `mod-b` and `mod-c`. All of them are mods, which generate their own runs.

Currently, all runs are placed on the same level, which makes runs list bloated. With this PR, adding `ideaFolder(project.name)` inside a run config will place runs under a folder named after subproject's name.

Before             |  After
:-------------------------:|:-------------------------:
<img width="298" alt="image" src="https://user-images.githubusercontent.com/13716167/219214926-cf09b61c-ff01-4b67-bbab-fdea154a08ab.png">  |  <img width="298" alt="image" src="https://user-images.githubusercontent.com/13716167/219214739-ab5564cf-b866-4f82-b720-b6b861451e06.png">

## Implementation notice
1. As IntelliJ permits folders with empty name, `folderName` attribute should be present only when a folder is used.
2. `ideaFolder` follows the same code style as `ideaModule`.