### PR TITLE
Fix MavenArtifactDownloader deadlock.

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/MavenArtifactDownloader.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MavenArtifactDownloader.java
@@ -112,8 +112,8 @@ public class MavenArtifactDownloader {
                 try {
                     project.getLogger().info("Waiting for download of {} on other thread", artifact);
                     while (!activeDownload.isDone()) {
-                        // Release the monitor of ACTIVE_DOWNLOADS while waiting on the download
-                        // When a new download finishes, we'll get notified and check again, whether the download is complete.
+                        // Release the monitor of ACTIVE_DOWNLOADS while waiting on the download;
+                        // when a new download finishes, we'll get notified and we can check whether the download is complete again. 
                         ACTIVE_DOWNLOADS.wait();
                     }
                     return activeDownload.get();

--- a/src/common/java/net/minecraftforge/gradle/common/util/MavenArtifactDownloader.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MavenArtifactDownloader.java
@@ -111,6 +111,11 @@ public class MavenArtifactDownloader {
                 // Some other thread is already working downloading this exact artifact, wait for it to finish
                 try {
                     project.getLogger().info("Waiting for download of {} on other thread", artifact);
+                    while (!activeDownload.isDone()) {
+                        // Release the monitor of ACTIVE_DOWNLOADS while waiting on the download
+                        // When a new download finishes, we'll get notified and check again, whether the download is complete.
+                        ACTIVE_DOWNLOADS.wait();
+                    }
                     return activeDownload.get();
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
@@ -174,6 +179,7 @@ public class MavenArtifactDownloader {
         } finally {
             synchronized (ACTIVE_DOWNLOADS) {
                 ACTIVE_DOWNLOADS.remove(downloadKey);
+                ACTIVE_DOWNLOADS.notifyAll();
             }
         }
         return ret;


### PR DESCRIPTION
This fixes #886 by releasing the monitor of `ACTIVE_DOWNLOADS` (through `Object#wait`) when waiting on a concurrent download. Whenever a download finishes, all waiting threads will be notified and check whether the download they are currently waiting on has completed. If that is the case, the result is returned. If not, the thread invokes `Object#wait` again and waits for the next download to complete.