### PR TITLE
Support Gradle caching for some parts of FG

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/tasks/JarExec.java
+++ b/src/common/java/net/minecraftforge/gradle/common/tasks/JarExec.java
@@ -20,6 +20,7 @@ import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.provider.ListProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Classpath;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputFile;
@@ -27,6 +28,8 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Internal;
 import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.internal.jvm.Jvm;
 import org.gradle.jvm.toolchain.JavaLanguageVersion;
@@ -61,6 +64,7 @@ import javax.inject.Inject;
  * <p>The tool JAR is specified using Maven coordinates, and downloaded using the repositories defined through Gradle.</p>
  */
 // TODO: refactor to extend JavaExec?
+@CacheableTask
 public abstract class JarExec extends DefaultTask {
     protected boolean hasLog = true;
 
@@ -224,6 +228,7 @@ public abstract class JarExec extends DefaultTask {
     }
 
     @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
     public Provider<File> getToolJar() {
         return toolFile;
     }

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/AccessTransformJar.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/AccessTransformJar.java
@@ -15,8 +15,15 @@ import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.OutputFile;
 
 import com.google.common.collect.ImmutableMap;
+import org.gradle.api.tasks.PathSensitive;
+import org.gradle.api.tasks.PathSensitivity;
+import org.gradle.api.tasks.SkipWhenEmpty;
+import org.gradle.api.tasks.CacheableTask;
+import org.gradle.work.NormalizeLineEndings;
+
 import java.util.List;
 
+@CacheableTask
 public abstract class AccessTransformJar extends JarExec {
     public AccessTransformJar() {
         getTool().set(Utils.ACCESSTRANSFORMER);
@@ -36,9 +43,13 @@ public abstract class AccessTransformJar extends JarExec {
     }
 
     @InputFiles
+    @SkipWhenEmpty
+    @NormalizeLineEndings
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract ConfigurableFileCollection getAccessTransformers();
 
     @InputFile
+    @PathSensitive(PathSensitivity.RELATIVE)
     public abstract RegularFileProperty getInput();
 
     @OutputFile

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/HackyJavaCompile.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/HackyJavaCompile.java
@@ -8,6 +8,7 @@ package net.minecraftforge.gradle.userdev.tasks;
 import org.gradle.api.internal.tasks.compile.DefaultJavaCompileSpec;
 import org.gradle.api.internal.tasks.compile.JavaCompileSpec;
 import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.WorkResult;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.jvm.toolchain.JavaCompiler;
@@ -23,6 +24,7 @@ import java.lang.reflect.Method;
  *  This is internal API Modders DO NOT reference this.
  *  It can and will be removed if we get a better way to do this.
  */
+@CacheableTask
 public class HackyJavaCompile extends JavaCompile {
 
     public void doHackyCompile() {


### PR DESCRIPTION
This PR adds support for Gradle caching in some parts of FG, mainly focused towards userdev AT applying.

To test this PR:
1. Publish this to local maven and use it in the MDK
2. Enable caching in the MDK's gradle.properties with `org.gradle.caching=true`
3. Add an AT the MDK and build the mod
4. Change the AT and build it again
5. Change the AT back to exactly what it was in step 3 and build again

To compare performance with and without this PR:
- For the PR: use the steps above
- Without the PR: use a fresh copy of the MDK for step 1, skip step 2 and then do steps 3, 4 and 5 above.

Known limitations:
- The AccessTransformerFunction creates a temporary AT file which prevents caching in some cases
- Due to the relative path sensitivity of inputs including an input for the user-supplied AT, it can't fully cache across different mod projects using the same mappings, AT and Forge version, *however* the main recompilation stage should still use the cache
