### PR TITLE
Update Constants.java

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/common/Constants.java
+++ b/src/main/java/net/minecraftforge/gradle/common/Constants.java
@@ -116,7 +116,7 @@ public class Constants
 
     // urls
     public static final String URL_MC_MANIFEST  = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
-    public static final String URL_ASSETS       = "http://resources.download.minecraft.net";
+    public static final String URL_ASSETS       = "https://resources.download.minecraft.net";
     public static final String URL_LIBRARY      = "https://libraries.minecraft.net/";
     public static final String URL_FORGE_MAVEN  = "https://maven.minecraftforge.net";
     public static final String URL_MCP_JSON     = URL_FORGE_MAVEN + "/de/oceanlabs/mcp/versions.json";


### PR DESCRIPTION
Change minecraft assets URL to use https instead of http.
The url http://resources.download.minecraft.net no longer accepts non-https requests and the getAssets tasks fail.