### PR TITLE
Make lazy tokens lazier

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/EclipseRunGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/EclipseRunGenerator.java
@@ -13,6 +13,7 @@ import net.minecraftforge.gradle.common.util.RunConfig;
 import net.minecraftforge.gradle.common.util.Utils;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.plugins.ide.eclipse.model.EclipseClasspath;
@@ -31,7 +32,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -39,7 +39,7 @@ import java.util.stream.Stream;
 public class EclipseRunGenerator extends RunConfigGenerator.XMLConfigurationBuilder {
     @Override
     protected Map<String, Document> createRunConfiguration(final MinecraftExtension mc, final Project project, final RunConfig runConfig, final DocumentBuilder documentBuilder,
-            List<String> additionalClientArgs, Set<File> minecraftArtifacts, Set<File> runtimeClasspathArtifacts) {
+            List<String> additionalClientArgs, FileCollection minecraftArtifacts, FileCollection runtimeClasspathArtifacts) {
         final Map<String, Document> documents = new LinkedHashMap<>();
 
         Map<String, Supplier<String>> updatedTokens = configureTokensLazy(project, runConfig, mapModClassesToEclipse(project, runConfig),

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/GenIDERunsTask.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/GenIDERunsTask.java
@@ -21,7 +21,6 @@ import org.gradle.work.DisableCachingByDefault;
 
 import java.io.File;
 import java.util.List;
-import java.util.Set;
 
 @DisableCachingByDefault(because = "IDE runs should always be regenerated")
 abstract class GenIDERunsTask extends DefaultTask {
@@ -41,11 +40,9 @@ abstract class GenIDERunsTask extends DefaultTask {
         MinecraftExtension minecraft = this.getMinecraftExtension().get();
         Project project = this.getProject();
         List<String> additionalClientArgs = this.getAdditionalClientArgs().get();
-        Set<File> minecraftArtifacts = this.getMinecraftArtifacts().getFiles();
-        Set<File> runtimeClasspathArtifacts = this.getRuntimeClasspathArtifacts().getFiles();
 
         runConfigGenerator.createRunConfiguration(minecraft, runConfigurationsDir, project,
-                additionalClientArgs, minecraftArtifacts, runtimeClasspathArtifacts);
+                additionalClientArgs, getMinecraftArtifacts(), getMinecraftArtifacts());
     }
 
     @Internal

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/GenIDERunsTask.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/GenIDERunsTask.java
@@ -42,7 +42,7 @@ abstract class GenIDERunsTask extends DefaultTask {
         List<String> additionalClientArgs = this.getAdditionalClientArgs().get();
 
         runConfigGenerator.createRunConfiguration(minecraft, runConfigurationsDir, project,
-                additionalClientArgs, getMinecraftArtifacts(), getRuntimeClasspathArtifacts());
+                additionalClientArgs, this.getMinecraftArtifacts(), this.getRuntimeClasspathArtifacts());
     }
 
     @Internal

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/GenIDERunsTask.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/GenIDERunsTask.java
@@ -42,7 +42,7 @@ abstract class GenIDERunsTask extends DefaultTask {
         List<String> additionalClientArgs = this.getAdditionalClientArgs().get();
 
         runConfigGenerator.createRunConfiguration(minecraft, runConfigurationsDir, project,
-                additionalClientArgs, getMinecraftArtifacts(), getMinecraftArtifacts());
+                additionalClientArgs, getMinecraftArtifacts(), getRuntimeClasspathArtifacts());
     }
 
     @Internal

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/IntellijRunGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/IntellijRunGenerator.java
@@ -12,6 +12,7 @@ import net.minecraftforge.gradle.common.util.Utils;
 
 import org.gradle.api.Project;
 import org.gradle.api.Task;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.plugins.ide.idea.model.IdeaModel;
@@ -30,7 +31,6 @@ import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -106,7 +106,7 @@ public class IntellijRunGenerator extends RunConfigGenerator.XMLConfigurationBui
 
     @Override
     protected Map<String, Document> createRunConfiguration(final MinecraftExtension mc, @Nonnull final Project project, final RunConfig runConfig, final DocumentBuilder documentBuilder, List<String> additionalClientArgs,
-            Set<File> minecraftArtifacts, Set<File> runtimeClasspathArtifacts) {
+            FileCollection minecraftArtifacts, FileCollection runtimeClasspathArtifacts) {
         final Map<String, Document> documents = new LinkedHashMap<>();
 
         Map<String, Supplier<String>> updatedTokens = configureTokensLazy(project, runConfig,

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/MinecraftRunTask.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/MinecraftRunTask.java
@@ -40,7 +40,7 @@ abstract class MinecraftRunTask extends JavaExec {
 
         Map<String, Supplier<String>> updatedTokens = RunConfigGenerator.configureTokensLazy(project, runConfig,
                 RunConfigGenerator.mapModClassesToGradle(project, runConfig),
-                this.getMinecraftArtifacts().getFiles(), this.getRuntimeClasspathArtifacts().getFiles());
+                this.getMinecraftArtifacts(), this.getRuntimeClasspathArtifacts());
 
         this.setWorkingDir(workDir);
         this.args(RunConfigGenerator.getArgsStream(runConfig, updatedTokens, false).toArray());

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
@@ -179,7 +179,9 @@ public abstract class RunConfigGenerator {
             String resolvedClasspath = getResolvedClasspath(classpath.getFiles());
             if (supplier == null) return resolvedClasspath;
             String oldCp = supplier.get();
-            return oldCp == null || oldCp.isEmpty() ? resolvedClasspath : String.join(File.pathSeparator, oldCp, resolvedClasspath);
+            if (Strings.isNullOrEmpty(oldCp)) return resolvedClasspath;
+            if (Strings.isNullOrEmpty(resolvedClasspath)) return oldCp;
+            return String.join(File.pathSeparator, oldCp, resolvedClasspath);
         });
     }
 

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
@@ -46,6 +46,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -185,6 +186,7 @@ public abstract class RunConfigGenerator {
         });
     }
 
+    @Nonnull
     private static String getResolvedClasspath(Set<File> artifacts) {
         return artifacts.stream()
                 .map(File::getAbsolutePath)

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/RunConfigGenerator.java
@@ -60,7 +60,7 @@ import javax.xml.transform.stream.StreamResult;
 
 public abstract class RunConfigGenerator {
     public abstract void createRunConfiguration(final MinecraftExtension minecraft, final File runConfigurationsDir, final Project project,
-            List<String> additionalClientArgs, Set<File> minecraftArtifacts, Set<File> runtimeClasspathArtifacts);
+            List<String> additionalClientArgs, FileCollection minecraftArtifacts, FileCollection runtimeClasspathArtifacts);
 
     public static void createIDEGenRunsTasks(final MinecraftExtension minecraft, final TaskProvider<Task> prepareRuns, List<String> additionalClientArgs) {
         final Project project = minecraft.getProject();
@@ -139,23 +139,16 @@ public abstract class RunConfigGenerator {
     }
 
     protected static Map<String, Supplier<String>> configureTokensLazy(final Project project, RunConfig runConfig, Stream<String> modClasses,
-            Set<File> minecraftArtifacts, Set<File> runtimeClasspathArtifacts) {
+            FileCollection minecraftArtifacts, FileCollection runtimeClasspathArtifacts) {
         Map<String, Supplier<String>> tokens = new HashMap<>();
         runConfig.getTokens().forEach((k, v) -> tokens.put(k, () -> v));
         runConfig.getLazyTokens().forEach((k, v) -> tokens.put(k, Suppliers.memoize(v::get)));
         tokens.compute("source_roots", (key, sourceRoots) -> Suppliers.memoize(() -> ((sourceRoots != null)
                 ? Stream.concat(Arrays.stream(sourceRoots.get().split(File.pathSeparator)), modClasses)
                 : modClasses).distinct().collect(Collectors.joining(File.pathSeparator))));
-        BiFunction<Supplier<String>, String, String> classpathJoiner = (supplier, evaluated) -> {
-            if (supplier == null)
-                return evaluated;
-            String oldCp = supplier.get();
-            return oldCp == null || oldCp.isEmpty() ? evaluated : String.join(File.pathSeparator, oldCp, evaluated);
-        };
-        String runtimeClasspath = classpathJoiner.apply(tokens.get("runtime_classpath"), getResolvedClasspath(runtimeClasspathArtifacts));
-        tokens.put("runtime_classpath", () -> runtimeClasspath);
-        String minecraftClasspath = classpathJoiner.apply(tokens.get("minecraft_classpath"), getResolvedClasspath(minecraftArtifacts));
-        tokens.put("minecraft_classpath", () -> minecraftClasspath);
+
+        Supplier<String> runtimeClasspath = tokens.compute("runtime_classpath", makeClasspathToken(runtimeClasspathArtifacts));
+        Supplier<String> minecraftClasspath = tokens.compute("minecraft_classpath", makeClasspathToken(minecraftArtifacts));
 
         File classpathFolder = new File(project.getBuildDir(), "classpath");
         BinaryOperator<String> classpathFileWriter = (filename, classpath) -> {
@@ -170,15 +163,24 @@ public abstract class RunConfigGenerator {
             return outputFile.getAbsolutePath();
         };
         tokens.put("runtime_classpath_file",
-                Suppliers.memoize(() -> classpathFileWriter.apply("runtimeClasspath", runtimeClasspath)));
+                Suppliers.memoize(() -> classpathFileWriter.apply("runtimeClasspath", runtimeClasspath.get())));
         tokens.put("minecraft_classpath_file",
-                Suppliers.memoize(() -> classpathFileWriter.apply("minecraftClasspath", minecraftClasspath)));
+                Suppliers.memoize(() -> classpathFileWriter.apply("minecraftClasspath", minecraftClasspath.get())));
 
         // *Grumbles about having to keep a workaround for a "dummy" hack that should have never existed*
         runConfig.getEnvironment().compute("MOD_CLASSES", (key, value) ->
                 Strings.isNullOrEmpty(value) || "dummy".equals(value) ? "{source_roots}" : value);
 
         return tokens;
+    }
+
+    private static BiFunction<String, Supplier<String>, Supplier<String>> makeClasspathToken(FileCollection classpath) {
+        return (key, supplier) -> Suppliers.memoize(() -> {
+            String resolvedClasspath = getResolvedClasspath(classpath.getFiles());
+            if (supplier == null) return resolvedClasspath;
+            String oldCp = supplier.get();
+            return oldCp == null || oldCp.isEmpty() ? resolvedClasspath : String.join(File.pathSeparator, oldCp, resolvedClasspath);
+        });
     }
 
     private static String getResolvedClasspath(Set<File> artifacts) {
@@ -265,11 +267,11 @@ public abstract class RunConfigGenerator {
 
     abstract static class XMLConfigurationBuilder extends RunConfigGenerator {
         protected abstract Map<String, Document> createRunConfiguration(final MinecraftExtension minecraft, final Project project, final RunConfig runConfig, final DocumentBuilder documentBuilder,
-                List<String> additionalClientArgs, Set<File> minecraftArtifacts, Set<File> runtimeClasspathArtifacts);
+                List<String> additionalClientArgs, FileCollection minecraftArtifacts, FileCollection runtimeClasspathArtifacts);
 
         @Override
         public final void createRunConfiguration(final MinecraftExtension minecraft, final File runConfigurationsDir, final Project project, List<String> additionalClientArgs,
-                Set<File> minecraftArtifacts, Set<File> runtimeClasspathArtifacts) {
+                FileCollection minecraftArtifacts, FileCollection runtimeClasspathArtifacts) {
             try {
                 final DocumentBuilderFactory docFactory = DocumentBuilderFactory.newInstance();
                 final DocumentBuilder docBuilder = docFactory.newDocumentBuilder();
@@ -306,11 +308,11 @@ public abstract class RunConfigGenerator {
 
     abstract static class JsonConfigurationBuilder extends RunConfigGenerator {
         protected abstract JsonObject createRunConfiguration(final Project project, final RunConfig runConfig, List<String> additionalClientArgs,
-                Set<File> minecraftArtifacts, Set<File> runtimeClasspathArtifacts);
+                FileCollection minecraftArtifacts, FileCollection runtimeClasspathArtifacts);
 
         @Override
         public final void createRunConfiguration(final MinecraftExtension minecraft, final File runConfigurationsDir, final Project project,
-                List<String> additionalClientArgs, Set<File> minecraftArtifacts, Set<File> runtimeClasspathArtifacts) {
+                List<String> additionalClientArgs, FileCollection minecraftArtifacts, FileCollection runtimeClasspathArtifacts) {
             final JsonObject rootObject = new JsonObject();
             rootObject.addProperty("version", "0.2.0");
             JsonArray runConfigs = new JsonArray();

--- a/src/common/java/net/minecraftforge/gradle/common/util/runs/VSCodeRunGenerator.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/runs/VSCodeRunGenerator.java
@@ -8,18 +8,17 @@ package net.minecraftforge.gradle.common.util.runs;
 import com.google.gson.JsonObject;
 import net.minecraftforge.gradle.common.util.RunConfig;
 import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
 
-import java.io.File;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
 public class VSCodeRunGenerator extends RunConfigGenerator.JsonConfigurationBuilder {
     @Override
     protected JsonObject createRunConfiguration(Project project, RunConfig runConfig, List<String> additionalClientArgs,
-            Set<File> minecraftArtifacts, Set<File> runtimeClasspathArtifacts) {
+            FileCollection minecraftArtifacts, FileCollection runtimeClasspathArtifacts) {
         Map<String, Supplier<String>> updatedTokens = configureTokensLazy(project, runConfig, mapModClassesToVSCode(project, runConfig),
                 minecraftArtifacts, runtimeClasspathArtifacts);
 


### PR DESCRIPTION
 - Defer reading the user-supplied classpath until needed.
 - Pass around `FileCollection`s instead of `Set<File>`s, so we don't need to resolve the contents until actually needed.