### PR TITLE
Replace SpecialSource RenameJar args instead of appending them to default FART args

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -86,6 +86,7 @@ import java.nio.file.Path;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -834,7 +835,7 @@ public class MinecraftUserRepo extends BaseRepo {
                 // TODO: Switch away from SpecialSource when we properly pass in the libraries from the Minecraft jar/pom
                 // rename.getLibraries().from(minecraftLibs);
                 rename.getTool().set(Utils.SPECIALSOURCE);
-                rename.getArgs().addAll("--in-jar", "{input}", "--out-jar", "{output}", "--srg-in", "{mappings}");
+                rename.getArgs().set(Arrays.asList("--in-jar", "{input}", "--out-jar", "{output}", "--srg-in", "{mappings}"));
                 rename.setHasLog(false);
                 rename.getInput().set(merged);
                 rename.getOutput().set(srged);


### PR DESCRIPTION
This commit https://github.com/MinecraftForge/ForgeGradle/commit/8cde2f12813438d659fe467fa6cadbf03f8d5473 switched to using FART in rename task and exposed a bug in this code that uses SpecialSource - it's appending SpecialSource args instead of replacing them, which meant that in case of old versions (1.12.2 only?) where this code runs it was running with both FART and SpecialSource args.

This also appears to work correctly when using FART here instead of SpecialSource, so I'm not entirely sure if this is the correct way to fix this. The TODO comment seems to indicate that it should be using FART but I don't know exactly what would be required to do this.