### PR TITLE
Fix: changes to ATs break multi-module projects

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -412,18 +412,12 @@ public class MinecraftUserRepo extends BaseRepo {
             group = group.substring(group.indexOf('.', 4) + 1);
         }
         String version = artifact.getVersion();
-        String athash = getATHash(version); //There is no way to reverse the ATs from the hash, so this is just to make Gradle request a new file if they change.
-        if (athash != null)
-            version = version.substring(0, version.length() - (athash.length() + "_at_".length()));
 
         String mappings = getMappings(version);
         if (mappings != null)
             version = version.substring(0, version.length() - (mappings.length() + "_mapped_".length()));
 
         if (!group.equals(GROUP) || !artifact.getName().equals(NAME) || !version.equals(VERSION))
-            return null;
-
-        if ((AT_HASH == null && athash != null) || (AT_HASH != null && !AT_HASH.equals(athash)))
             return null;
 
         if (!isPatcher && mappings == null) //net.minecraft in obf names. We don't do that.

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/MinecraftUserRepo.java
@@ -412,6 +412,9 @@ public class MinecraftUserRepo extends BaseRepo {
             group = group.substring(group.indexOf('.', 4) + 1);
         }
         String version = artifact.getVersion();
+        String athash = getATHash(version);  // Just extract the hash from the version string
+        if (athash != null)
+            version = version.substring(0, version.length() - (athash.length() + "_at_".length()));
 
         String mappings = getMappings(version);
         if (mappings != null)


### PR DESCRIPTION
I'm working on a multi-module Minecraft Forge project.  We were originally using a build script that compiled the dependency-modules into Jars and then had the master module depend on the Jars.  I upgraded the buildscript to work as a true Gradle Multi-module project but, since then, when pulling commits that included changes to AccessTransformers, IDEA would complain about not being able to find the sources.  

I think I have stumbled on the solution and would be very pleased and grateful if you could merge this PR.

-----------------------
Quitting early if  `AT_HASH` does not match `athash` removes the chance for us to generate a new artifact in some scenarios when the ATs have been changed.

Making the comparison here in `MinecraftUserRep::findFile` is problematic and not necessary.  The `HashStore` will look for a cache hit/miss in later `find***` calls.  The `HashStore` compares the current  `AT_HASH` with the cached `AT_HASH` and will return a Cache Miss if the ATs have changed.