### PR TITLE
Fix default JarJar range not using correct formatting

### DIFF
--- a/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/JarJar.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/tasks/JarJar.java
@@ -229,7 +229,7 @@ public abstract class JarJar extends Jar {
         }
         final Optional<String> attributeVersion = getProject().getExtensions().getByType(JarJarProjectExtension.class).getRange(dependency);
 
-        return attributeVersion.map(DeobfuscatingVersionUtils::adaptDeobfuscatedVersionRange).orElseGet(() -> DeobfuscatingVersionUtils.adaptDeobfuscatedVersion(Objects.requireNonNull(dependency.getVersion())));
+        return attributeVersion.map(DeobfuscatingVersionUtils::adaptDeobfuscatedVersionRange).orElseGet(() -> DeobfuscatingVersionUtils.adaptDeobfuscatedVersionRange(Objects.requireNonNull(dependency.getVersion())));
     }
 
     private String getVersionFrom(final ModuleDependency dependency) {


### PR DESCRIPTION
By default when you declare a jar-in-jar dependency, it will try to use the version of the dependency for both the ranged and pinned versions. Unfortunately there is no formatting done for the ranged version, which causes an exception due to a malformed version string. This PR fixes that.

I had this sitting for a while I just literally forgot to make the PR. Whoops. :shrug: