### PR TITLE
Fixes 1.10.2 setupDecomWorkspace

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/common/Constants.java
+++ b/src/main/java/net/minecraftforge/gradle/common/Constants.java
@@ -116,7 +116,7 @@ public class Constants
 
     // urls
     public static final String URL_MC_MANIFEST     = "https://launchermeta.mojang.com/mc/game/version_manifest.json";
-    public static final String URL_ASSETS          = "http://resources.download.minecraft.net";
+    public static final String URL_ASSETS          = "https://resources.download.minecraft.net/";
     public static final String URL_LIBRARY         = "https://libraries.minecraft.net/"; // Mojang's Cloudflare front end
     //public static final String URL_LIBRARY         = "https://minecraft-libraries.s3.amazonaws.com/"; // Mojang's AWS server, as Cloudflare is having issues, TODO: Switch back to above when their servers are fixed.
     public static final String URL_FORGE_MAVEN     = "https://maven.minecraftforge.net";

--- a/src/main/java/net/minecraftforge/gradle/tasks/DownloadAssetsTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/DownloadAssetsTask.java
@@ -187,6 +187,7 @@ public class DownloadAssetsTask extends DefaultTask
                         {
                             // download
                             ReadableByteChannel channel = Channels.newChannel(new URL(Constants.URL_ASSETS + "/" + asset.path).openStream());
+                            LOGGER.debug("Downloading from URL {}", new URL(Constants.URL_ASSETS + "/" + asset.path));
                             FileOutputStream fout = new FileOutputStream(file);
                             FileChannel fileChannel = fout.getChannel();
                             


### PR DESCRIPTION
This fixes the setupDecompWorkspace for MC 1.10, due to http protocol no longer accepted