### PR TITLE
[FG7] Add a way to configure Tools (Mavenizer/Slimelauncher)

### DIFF
--- a/src/main/groovy/net/minecraftforge/gradle/ForgeGradlePlugin.groovy
+++ b/src/main/groovy/net/minecraftforge/gradle/ForgeGradlePlugin.groovy
@@ -82,6 +82,17 @@ class ForgeGradlePlugin implements Plugin<ExtensionAware> {
             this.&getFileSystemOperations,
             this.&getArchiveOperations
         )
+
+        if (target instanceof Project) {
+            Project project = (Project) target;
+
+            for (final def tool in Tools.values()) {
+                project.getConfigurations().register(tool.getConfiguration()) {
+                    it.setTransitive(false) // Cant be transitive, maybe allow it to be later?
+                    it.setVisible(true)
+                }
+            }
+        }
     }
 
     @PackageScope DirectoryProperty getGlobalCaches() {
@@ -96,6 +107,12 @@ class ForgeGradlePlugin implements Plugin<ExtensionAware> {
     @PackageScope Provider<File> getTool(Tools tool) {
         tool.get(this.globalCaches, this.providers)
     }
+
+    @SuppressWarnings('GrDeprecatedAPIUsage') // Intentional deprecation, please use this method
+    @PackageScope Provider<File> getTool(Tools tool, Project project) {
+        tool.get(project, this.globalCaches, this.providers)
+    }
+
 
     @CompileDynamic
     private File getGradleUserHomeDir(ExtensionAware target) {

--- a/src/main/groovy/net/minecraftforge/gradle/ForgeGradlePlugin.groovy
+++ b/src/main/groovy/net/minecraftforge/gradle/ForgeGradlePlugin.groovy
@@ -12,6 +12,7 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.file.ArchiveOperations
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileSystemOperations
 import org.gradle.api.file.ProjectLayout
 import org.gradle.api.flow.FlowProviders
@@ -87,10 +88,7 @@ class ForgeGradlePlugin implements Plugin<ExtensionAware> {
             Project project = (Project) target;
 
             for (final def tool in Tools.values()) {
-                project.getConfigurations().register(tool.getConfiguration()) {
-                    it.setTransitive(false) // Cant be transitive, maybe allow it to be later?
-                    it.setVisible(true)
-                }
+                project.getConfigurations().register(tool.getConfiguration())
             }
         }
     }
@@ -104,12 +102,12 @@ class ForgeGradlePlugin implements Plugin<ExtensionAware> {
     }
 
     @SuppressWarnings('GrDeprecatedAPIUsage') // Intentional deprecation, please use this method
-    @PackageScope Provider<File> getTool(Tools tool) {
-        tool.get(this.globalCaches, this.providers)
+    @PackageScope FileCollection getTool(Tools tool) {
+        objects.fileCollection().from(tool.get(this.globalCaches, this.providers))
     }
 
     @SuppressWarnings('GrDeprecatedAPIUsage') // Intentional deprecation, please use this method
-    @PackageScope Provider<File> getTool(Tools tool, Project project) {
+    @PackageScope FileCollection getTool(Tools tool, Project project) {
         tool.get(project, this.globalCaches, this.providers)
     }
 

--- a/src/main/groovy/net/minecraftforge/gradle/ForgeGradleTask.java
+++ b/src/main/groovy/net/minecraftforge/gradle/ForgeGradleTask.java
@@ -4,6 +4,7 @@
  */
 package net.minecraftforge.gradle;
 
+import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.Provider;
@@ -19,6 +20,11 @@ interface ForgeGradleTask extends Task {
     @Internal
     default Provider<File> getTool(Tools tool) {
         return this.getPlugin().getTool(tool);
+    }
+
+    @Internal
+    default Provider<File> getTool(Tools tool, Project project) {
+        return this.getPlugin().getTool(tool, project);
     }
 
     @Internal

--- a/src/main/groovy/net/minecraftforge/gradle/ForgeGradleTask.java
+++ b/src/main/groovy/net/minecraftforge/gradle/ForgeGradleTask.java
@@ -7,6 +7,7 @@ package net.minecraftforge.gradle;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.tasks.Internal;
 
@@ -18,12 +19,12 @@ interface ForgeGradleTask extends Task {
     }
 
     @Internal
-    default Provider<File> getTool(Tools tool) {
+    default FileCollection getTool(Tools tool) {
         return this.getPlugin().getTool(tool);
     }
 
     @Internal
-    default Provider<File> getTool(Tools tool, Project project) {
+    default FileCollection getTool(Tools tool, Project project) {
         return this.getPlugin().getTool(tool, project);
     }
 

--- a/src/main/groovy/net/minecraftforge/gradle/SlimeLauncherExec.groovy
+++ b/src/main/groovy/net/minecraftforge/gradle/SlimeLauncherExec.groovy
@@ -54,7 +54,7 @@ import java.nio.file.Files
             task.inherit(configs, options.name)
             options.apply(task)
 
-            task.classpath task.getTool(Tools.SLIME_LAUNCHER)
+            task.classpath task.getTool(Tools.SLIME_LAUNCHER, getProject())
 
             if (task.buildAllProjects)
                 task.dependsOn project.allprojects.collect { it.tasks.named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME) }.toArray()

--- a/src/main/groovy/net/minecraftforge/gradle/SlimeLauncherExec.groovy
+++ b/src/main/groovy/net/minecraftforge/gradle/SlimeLauncherExec.groovy
@@ -54,7 +54,7 @@ import java.nio.file.Files
             task.inherit(configs, options.name)
             options.apply(task)
 
-            task.classpath task.getTool(Tools.SLIME_LAUNCHER, getProject())
+            task.classpath task.getTool(Tools.SLIME_LAUNCHER, project)
 
             if (task.buildAllProjects)
                 task.dependsOn project.allprojects.collect { it.tasks.named(LifecycleBasePlugin.ASSEMBLE_TASK_NAME) }.toArray()

--- a/src/main/groovy/net/minecraftforge/gradle/SyncMinecraftMaven.java
+++ b/src/main/groovy/net/minecraftforge/gradle/SyncMinecraftMaven.java
@@ -62,7 +62,7 @@ abstract class SyncMinecraftMaven extends DefaultTask implements ForgeGradleTask
         this.setDescription("Syncs the Minecraft dependencies using Minecraft Mavenizer.");
 
         // JavaExec
-        this.getExecutable().convention(this.getTool(Tools.MINECRAFT_MAVEN));
+        this.getExecutable().convention(this.getTool(Tools.MINECRAFT_MAVEN, getProject()));
         this.getJavaLauncher().convention(Util.launcherForStrictly(this.getProject().getExtensions().getByType(JavaToolchainService.class), Constants.MCMAVEN_JAVA_VERSION).map(j -> j.getExecutablePath().toString()));
         this.getMainClass().convention(Constants.MCMAVEN_MAIN);
 

--- a/src/main/groovy/net/minecraftforge/gradle/Tools.java
+++ b/src/main/groovy/net/minecraftforge/gradle/Tools.java
@@ -72,7 +72,7 @@ enum Tools {
         } catch (UnknownConfigurationException exception) {
             return get(cachesDir, providers);
         } catch (IllegalStateException exception) {
-            throw new IllegalStateException(String.format("Cant have more then one %s define", getConfiguration()));
+            throw new IllegalStateException(String.format("Cant have more then one %s defined", getConfiguration()), exception);
         }
     }
 

--- a/src/main/groovy/net/minecraftforge/gradle/Tools.java
+++ b/src/main/groovy/net/minecraftforge/gradle/Tools.java
@@ -6,6 +6,8 @@ package net.minecraftforge.gradle;
 
 import net.minecraftforge.util.download.DownloadUtils;
 import net.minecraftforge.util.hash.HashStore;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.UnknownConfigurationException;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
@@ -25,15 +27,17 @@ import java.io.IOException;
 import static net.minecraftforge.gradle.ForgeGradlePlugin.LOGGER;
 
 enum Tools {
-    MINECRAFT_MAVEN("minecraft-maven-" + Constants.MCMAVEN_VERSION + ".jar", Constants.MCMAVEN_DL_URL),
-    SLIME_LAUNCHER("slime-launcher-" + Constants.SL_VERSION + ".jar", Constants.SL_DL_URL);
+    MINECRAFT_MAVEN("minecraft-maven-" + Constants.MCMAVEN_VERSION + ".jar", Constants.MCMAVEN_DL_URL, "mavenizer"),
+    SLIME_LAUNCHER("slime-launcher-" + Constants.SL_VERSION + ".jar", Constants.SL_DL_URL, "slimelauncher");
 
     private final String fileName;
     private final String downloadUrl;
+    private final String configuration;
 
-    Tools(String fileName, String downloadUrl) {
+    Tools(String fileName, String downloadUrl, String configuration) {
         this.fileName = fileName;
         this.downloadUrl = downloadUrl;
+        this.configuration = configuration;
     }
 
     /// Gets a provider for this tool using the given caches directory and provider factory.
@@ -49,6 +53,31 @@ enum Tools {
             parameters.getInputFile().set(cachesDir.file("tools/" + this.fileName));
             parameters.getDownloadUrl().set(this.downloadUrl);
         }));
+    }
+
+    /// Gets a provider for this tool using the configuration, otherwise default to {@link Tools#get(Project, DirectoryProperty, ProviderFactory)}
+    ///
+    /// @param project The Project
+    /// @param cachesDir The caches directory to store the tool
+    /// @param providers The provider factory to use
+    /// @return A provider for the tool as a [file][File]
+    /// @deprecated Use [ForgeGradlePlugin#getTool(Tools, Project)] <- [org.gradle.api.plugins.PluginContainer#getPlugin(Class)]
+    ///  <- [org.gradle.api.plugins.PluginAware#getPlugins()]
+    @Deprecated
+    Provider<File> get(Project project, DirectoryProperty cachesDir, ProviderFactory providers) {
+        try {
+            final var cfg = project.getConfigurations().getByName(getConfiguration());
+            final var file = cfg.getSingleFile();
+            return providers.provider(() -> file);
+        } catch (UnknownConfigurationException exception) {
+            return get(cachesDir, providers);
+        } catch (IllegalStateException exception) {
+            throw new IllegalStateException(String.format("Cant have more then one %s define", getConfiguration()));
+        }
+    }
+
+    String getConfiguration() {
+        return configuration;
     }
 
     static abstract class Source implements ValueSource<File, Source.Parameters> {

--- a/src/main/groovy/net/minecraftforge/gradle/Tools.java
+++ b/src/main/groovy/net/minecraftforge/gradle/Tools.java
@@ -9,6 +9,7 @@ import net.minecraftforge.util.hash.HashStore;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.UnknownConfigurationException;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
@@ -64,16 +65,18 @@ enum Tools {
     /// @deprecated Use [ForgeGradlePlugin#getTool(Tools, Project)] <- [org.gradle.api.plugins.PluginContainer#getPlugin(Class)]
     ///  <- [org.gradle.api.plugins.PluginAware#getPlugins()]
     @Deprecated
-    Provider<File> get(Project project, DirectoryProperty cachesDir, ProviderFactory providers) {
+    FileCollection get(Project project, DirectoryProperty cachesDir, ProviderFactory providers) {
         try {
             final var cfg = project.getConfigurations().getByName(getConfiguration());
-            final var file = cfg.getSingleFile();
-            return providers.provider(() -> file);
+            final var files = cfg.getFiles();
+            if (!files.isEmpty()) {
+                return project.getObjects().fileCollection().from(cfg.getFiles());
+            }
         } catch (UnknownConfigurationException exception) {
-            return get(cachesDir, providers);
-        } catch (IllegalStateException exception) {
-            throw new IllegalStateException(String.format("Cant have more then one %s defined", getConfiguration()), exception);
+            System.out.println("[FG7] Unknown Configuration %s, using defaults for tool %s".formatted(getConfiguration(), toString()));
         }
+
+        return project.getObjects().fileCollection().from(get(cachesDir, providers));
     }
 
     String getConfiguration() {


### PR DESCRIPTION
This is mainly a PR to discuss the most ideal way of handling the configurability of these tools that FG7 uses.

The build script would look like this, to override a tool.

```groovy
dependencies {
    mavenizer "net.minecraftforge:minecraft-mavenizer:0.3.3"
    slimelauncher "net.minecraftforge:slime-launcher:0.1.0"

    implementation(minecraft.dep("net.minecraftforge:forge:1.21.5-55.0.23"))
}
```
