### PR TITLE
[3.0] Workaround potential missing repositories within MavenArtifactDownloader

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/MavenArtifactDownloader.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MavenArtifactDownloader.java
@@ -244,8 +244,8 @@ public class MavenArtifactDownloader {
 
         //Remove old repos, and only use the ones we're told to.
         List<ArtifactRepository> old = new ArrayList<>(project.getRepositories());
-        project.getRepositories().clear();
-        project.getRepositories().addAll(repos);
+        //project.getRepositories().clear();
+        project.getRepositories().addAll(0, repos);
 
         Configuration cfg = project.getConfigurations().create(name);
         ExternalModuleDependency dependency = (ExternalModuleDependency)project.getDependencies().create(mine.getDescriptor());


### PR DESCRIPTION
There's a re-occurring and inconsistent bug with ForgeGradle 3 where the MavenArtifactDownloader will use 0 repositories to download a dependency for the MCP toolchain. In my testing, older projects would continuously fail to download `net.minecraftforge:accesstransformers:1.0.+`, despite this artifact existing on the Forge maven just fine.

My workaround for this is simply to add the requested downloading repositories on top of the project's existing repositories before downloading the artifact in `MavenArtifactDownloader#_gradle`.

For full transparency, this PR was done at the request of my friends at @Modding-Legacy to help them preserve older repositories without needing to update the buildscript on each one.