### PR TITLE
[3.0] Do not fail download if content length is unknown

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -426,7 +426,7 @@ public class Utils {
                 read = IOUtils.copy(stream, out);
             }
 
-            if (len >= 0 && read != len) {
+            if (len != -1 && read != len) {
                 output.delete();
                 throw new IOException("Failed to read all of data from " + con.getURL() + " got " + read + " expected " + len);
             }

--- a/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/Utils.java
@@ -426,7 +426,7 @@ public class Utils {
                 read = IOUtils.copy(stream, out);
             }
 
-            if (read != len) {
+            if (len >= 0 && read != len) {
                 output.delete();
                 throw new IOException("Failed to read all of data from " + con.getURL() + " got " + read + " expected " + len);
             }


### PR DESCRIPTION
- Supersedes #974.
- Partial backport of #905 to ForgeGradle 3.

ForgeGradle 3 has its own Maven artifact downloader, which in turn used a combination of Java's (Http)UrlConnection and Apache's Commons IO library. An oversight with the spec of `UrlConnection#getContentLength` has led to an issue where a downloaded file can be erroneously discarded of a source does not declare the content length in its header. This was the case for `https://maven.minecraftforge.net/net/minecraftforge/accesstransformers/maven-metadata.xml`, which caused the downloader to refuse to download AccessTransformers and thus stifle the build process.

This PR fixes this issue by simply skipping the content length check if it is unknown. `-1` is a valid return value if the content length is known, and should not be treated as an error nor overlooked.