### PR TITLE
[6.0] Add support for version catalog versions in `minecraft.mappings`, `jarJar.pin` and `jarJar.ranged`

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/MinecraftExtension.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MinecraftExtension.java
@@ -16,6 +16,10 @@ import org.gradle.api.provider.Provider;
 import groovy.lang.Closure;
 import groovy.lang.GroovyObjectSupport;
 import groovy.lang.MissingPropertyException;
+import org.gradle.api.provider.ProviderConvertible;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -85,15 +89,43 @@ public abstract class MinecraftExtension extends GroovyObjectSupport {
         getMappingVersion().set(version);
     }
 
-    public void mappings(Map<String, ? extends CharSequence> mappings) {
-        CharSequence channel = mappings.get("channel");
-        CharSequence version = mappings.get("version");
+    public void mappings(Object channel, Object version) {
+        try {
+            getMappingChannel().set(valueOf(channel, String.class));
+            getMappingVersion().set(valueOf(version, String.class));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Tried to set mappings using non-Strings", e);
+        }
+    }
+
+    public void mappings(Map<String, ?> mappings) {
+        Object channel = mappings.get("channel");
+        Object version = mappings.get("version");
 
         if (channel == null || version == null) {
             throw new IllegalArgumentException("Must specify both mappings channel and version");
         }
 
-        mappings(channel.toString(), version.toString());
+        mappings(channel, version);
+    }
+
+    @Contract("!null, _ -> !null")
+    private static <T> @Nullable T valueOf(@Nullable Object object, Class<T> castTo) {
+        if (object instanceof ProviderConvertible<?>)
+            object = ((ProviderConvertible<?>) object).asProvider().get();
+        else if (object instanceof Provider<?>)
+            object = ((Provider<?>) object).get();
+
+        if (object == null)
+            return null;
+
+        try {
+            return castTo.cast(object);
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException(String.format(
+                "Expected class %s but got class %s for value: %s", castTo.getName(), object.getClass().getName(), object)
+            );
+        }
     }
 
     public ConfigurableFileCollection getAccessTransformers() {

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/jarjar/JarJarProjectExtension.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/jarjar/JarJarProjectExtension.java
@@ -18,6 +18,8 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.*;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderConvertible;
 import org.gradle.api.publish.maven.MavenPublication;
 
 import java.util.List;
@@ -78,6 +80,14 @@ public class JarJarProjectExtension extends GroovyObjectSupport {
         project.getTasks().withType(JarJar.class).configureEach(JarJar::fromRuntimeConfiguration);
     }
 
+    public void pin(Dependency dependency, ProviderConvertible<String> version) {
+        pin(dependency, version.asProvider());
+    }
+
+    public void pin(Dependency dependency, Provider<String> version) {
+        pin(dependency, version.get());
+    }
+
     public void pin(Dependency dependency, String version) {
         enable();
         if (dependency instanceof ModuleDependency) {
@@ -92,6 +102,14 @@ public class JarJarProjectExtension extends GroovyObjectSupport {
             return Optional.ofNullable(moduleDependency.getAttributes().getAttribute(fixedJarJarVersionAttribute));
         }
         return Optional.empty();
+    }
+
+    public void ranged(Dependency dependency, ProviderConvertible<String> version) {
+        ranged(dependency, version.asProvider());
+    }
+
+    public void ranged(Dependency dependency, Provider<String> version) {
+        ranged(dependency, version.get());
     }
 
     public void ranged(Dependency dependency, String range) {


### PR DESCRIPTION
Similar to #976, allows for using version catalog versions (i.e. `Provider<String>` or `ProviderConvertible<String>`) in mappings declarations and Jar-in-Jar dependency version declarations.

settings.gradle:

```groovy
dependencyResolutionManagement.versionCatalogs.register('libs') {
    version 'mappings-channel', 'official'
    version 'mappings-version', '1.21.8'
}
```

build.gradle:

```groovy
minecraft {
    mappings channel: libs.versions.mappings.channel, version: libs.versions.mappings.version
}
```