### PR TITLE
[6.0] Version catalog version support (re-try)

### DIFF
--- a/src/common/java/net/minecraftforge/gradle/common/util/MinecraftExtension.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MinecraftExtension.java
@@ -17,8 +17,6 @@ import groovy.lang.Closure;
 import groovy.lang.GroovyObjectSupport;
 import groovy.lang.MissingPropertyException;
 import org.gradle.api.provider.ProviderConvertible;
-import org.jetbrains.annotations.Contract;
-import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
 
@@ -90,12 +88,8 @@ public abstract class MinecraftExtension extends GroovyObjectSupport {
     }
 
     public void mappings(Object channel, Object version) {
-        try {
-            getMappingChannel().set(valueOf(channel, String.class));
-            getMappingVersion().set(valueOf(version, String.class));
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Tried to set mappings using non-Strings", e);
-        }
+        setMappingProperty(getMappingChannel(), channel);
+        setMappingProperty(getMappingVersion(), version);
     }
 
     public void mappings(Map<String, ?> mappings) {
@@ -109,23 +103,14 @@ public abstract class MinecraftExtension extends GroovyObjectSupport {
         mappings(channel, version);
     }
 
-    @Contract("!null, _ -> !null")
-    private static <T> @Nullable T valueOf(@Nullable Object object, Class<T> castTo) {
-        if (object instanceof ProviderConvertible<?>)
-            object = ((ProviderConvertible<?>) object).asProvider().get();
-        else if (object instanceof Provider<?>)
-            object = ((Provider<?>) object).get();
-
-        if (object == null)
-            return null;
-
-        try {
-            return castTo.cast(object);
-        } catch (ClassCastException e) {
-            throw new IllegalArgumentException(String.format(
-                "Expected class %s but got class %s for value: %s", castTo.getName(), object.getClass().getName(), object)
-            );
-        }
+    // Using String#valueOf on the value will account for weird cases of GString and non-String CharSequences
+    private static void setMappingProperty(Property<String> property, Object value) {
+        if (value instanceof ProviderConvertible<?>)
+            property.set(((ProviderConvertible<?>) value).asProvider().map(String::valueOf));
+        else if (value instanceof Provider<?>)
+            property.set(((Provider<?>) value).map(String::valueOf));
+        else
+            property.set(String.valueOf(value));
     }
 
     public ConfigurableFileCollection getAccessTransformers() {

--- a/src/common/java/net/minecraftforge/gradle/common/util/MinecraftExtension.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MinecraftExtension.java
@@ -103,14 +103,17 @@ public abstract class MinecraftExtension extends GroovyObjectSupport {
         mappings(channel, version);
     }
 
-    // Using String#valueOf on the value will account for weird cases of GString and non-String CharSequences
-    private static void setMappingProperty(Property<String> property, Object value) {
+    // Using Object#toString on the value will account for weird cases of GString and non-String CharSequences
+    private void setMappingProperty(Property<String> property, Object value) {
+        Provider<?> provider;
         if (value instanceof ProviderConvertible<?>)
-            property.set(((ProviderConvertible<?>) value).asProvider().map(String::valueOf));
+            provider = ((ProviderConvertible<?>) value).asProvider();
         else if (value instanceof Provider<?>)
-            property.set(((Provider<?>) value).map(String::valueOf));
+            provider = (Provider<?>) value;
         else
-            property.set(String.valueOf(value));
+            provider = project.provider(() -> value);
+
+        property.set(provider.map(Object::toString));
     }
 
     public ConfigurableFileCollection getAccessTransformers() {

--- a/src/common/java/net/minecraftforge/gradle/common/util/MinecraftExtension.java
+++ b/src/common/java/net/minecraftforge/gradle/common/util/MinecraftExtension.java
@@ -16,6 +16,10 @@ import org.gradle.api.provider.Provider;
 import groovy.lang.Closure;
 import groovy.lang.GroovyObjectSupport;
 import groovy.lang.MissingPropertyException;
+import org.gradle.api.provider.ProviderConvertible;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.Nullable;
+
 import java.util.Map;
 
 import javax.inject.Inject;
@@ -85,15 +89,43 @@ public abstract class MinecraftExtension extends GroovyObjectSupport {
         getMappingVersion().set(version);
     }
 
-    public void mappings(Map<String, ? extends CharSequence> mappings) {
-        CharSequence channel = mappings.get("channel");
-        CharSequence version = mappings.get("version");
+    public void mappings(Object channel, Object version) {
+        try {
+            getMappingChannel().set(valueOf(channel, String.class));
+            getMappingVersion().set(valueOf(version, String.class));
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Tried to set mappings using non-Strings", e);
+        }
+    }
+
+    public void mappings(Map<String, ?> mappings) {
+        Object channel = mappings.get("channel");
+        Object version = mappings.get("version");
 
         if (channel == null || version == null) {
             throw new IllegalArgumentException("Must specify both mappings channel and version");
         }
 
-        mappings(channel.toString(), version.toString());
+        mappings(channel, version);
+    }
+
+    @Contract("!null, _ -> !null")
+    private static <T> @Nullable T valueOf(@Nullable Object object, Class<T> castTo) {
+        if (object instanceof ProviderConvertible<?>)
+            object = ((ProviderConvertible<?>) object).asProvider().get();
+        else if (object instanceof Provider<?>)
+            object = ((Provider<?>) object).get();
+
+        if (object == null)
+            return null;
+
+        try {
+            return castTo.cast(object);
+        } catch (ClassCastException e) {
+            throw new IllegalArgumentException(String.format(
+                "Expected class %s but got class %s for value: %s", castTo.getName(), object.getClass().getName(), object)
+            );
+        }
     }
 
     public ConfigurableFileCollection getAccessTransformers() {

--- a/src/userdev/java/net/minecraftforge/gradle/userdev/jarjar/JarJarProjectExtension.java
+++ b/src/userdev/java/net/minecraftforge/gradle/userdev/jarjar/JarJarProjectExtension.java
@@ -18,6 +18,8 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.artifacts.*;
 import org.gradle.api.attributes.Attribute;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.provider.ProviderConvertible;
 import org.gradle.api.publish.maven.MavenPublication;
 
 import java.util.List;
@@ -78,6 +80,14 @@ public class JarJarProjectExtension extends GroovyObjectSupport {
         project.getTasks().withType(JarJar.class).configureEach(JarJar::fromRuntimeConfiguration);
     }
 
+    public void pin(Dependency dependency, ProviderConvertible<String> version) {
+        pin(dependency, version.asProvider());
+    }
+
+    public void pin(Dependency dependency, Provider<String> version) {
+        pin(dependency, version.get());
+    }
+
     public void pin(Dependency dependency, String version) {
         enable();
         if (dependency instanceof ModuleDependency) {
@@ -92,6 +102,14 @@ public class JarJarProjectExtension extends GroovyObjectSupport {
             return Optional.ofNullable(moduleDependency.getAttributes().getAttribute(fixedJarJarVersionAttribute));
         }
         return Optional.empty();
+    }
+
+    public void ranged(Dependency dependency, ProviderConvertible<String> version) {
+        ranged(dependency, version.asProvider());
+    }
+
+    public void ranged(Dependency dependency, Provider<String> version) {
+        ranged(dependency, version.get());
     }
 
     public void ranged(Dependency dependency, String range) {


### PR DESCRIPTION
- Reapplies and fixes #979 (edf7bf3).

My oversight with this PR was that I was enforcing a type requirement of `String`, which `GString` and other subclasses of `CharSequence` are not. Instead of attempting to cast the value to a string, I am using `String#valueOf` before passing it in to the property. This is basically the same as what is already done, the main difference now being that this removes the enforcement on the input being a CharSequence.