### PR TITLE
[7.0] Use JSpecify annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ gradleutils.pluginDevDefaults(configurations, libs.versions.gradle)
 
 dependencies {
     // Static Analysis
-    compileOnly libs.nulls
+    api libs.annotations.jspecify
 
     // Gradle API
     compileOnly libs.gradle
@@ -59,6 +59,10 @@ tasks.named('shadowJar', ShadowJar) {
     enableAutoRelocation = true
     archiveClassifier = null
     relocationPrefix = 'net.minecraftforge.gradle.shadow'
+
+    dependencies {
+        exclude dependency(libs.annotations.jspecify)
+    }
 }
 
 tasks.withType(Javadoc).configureEach {

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,7 +30,7 @@ dependencyResolutionManagement.versionCatalogs.register('libs') {
     plugin 'shadow',         'com.gradleup.shadow'            version '9.3.0' // https://plugins.gradle.org/plugin/com.gradleup.shadow
 
     // Static Analysis
-    library 'nulls', 'org.jetbrains', 'annotations' version '26.0.2-1'
+    library 'annotations-jspecify', 'org.jspecify', 'jspecify' version '1.0.0'
 
     // Gradle API
     // Original: https://github.com/remal-gradle-api/packages/packages/760197?version=9.0.0

--- a/src/main/java/net/minecraftforge/gradle/internal/ClosureOwnerInternal.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/ClosureOwnerInternal.java
@@ -26,7 +26,7 @@ import org.gradle.api.capabilities.Capability;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/net/minecraftforge/gradle/internal/ForgeGradleFlowAction.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/ForgeGradleFlowAction.java
@@ -9,7 +9,7 @@ import org.gradle.api.Project;
 import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.SetProperty;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
 import java.io.File;

--- a/src/main/java/net/minecraftforge/gradle/internal/ForgeGradlePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/ForgeGradlePlugin.java
@@ -11,7 +11,7 @@ import org.gradle.api.flow.FlowScope;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.ExtensionAware;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
 import java.util.function.Consumer;

--- a/src/main/java/net/minecraftforge/gradle/internal/MinecraftDependencyImpl.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/MinecraftDependencyImpl.java
@@ -37,7 +37,7 @@ import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
 import java.io.File;
@@ -45,8 +45,9 @@ import java.util.Objects;
 import java.util.Set;
 
 abstract class MinecraftDependencyImpl implements MinecraftDependencyInternal {
-    private transient @Nullable("configuration cache") ExternalModuleDependency delegate;
-    private transient @Nullable("configuration cache") TaskProvider<SyncMavenizer> mavenizer;
+    // These can be nullable due to configuration caching.
+    private transient @Nullable ExternalModuleDependency delegate;
+    private transient @Nullable TaskProvider<SyncMavenizer> mavenizer;
 
     final Property<String> asString = getObjects().property(String.class);
     final Property<String> asPath = getObjects().property(String.class);
@@ -79,13 +80,15 @@ abstract class MinecraftDependencyImpl implements MinecraftDependencyInternal {
         );
     }
 
+    // Can be nullable due to configuration caching.
     @Override
-    public @Nullable("configuration cache") ExternalModuleDependency asDependency() {
+    public @Nullable ExternalModuleDependency asDependency() {
         return this.delegate;
     }
 
+    // Can be nullable due to configuration caching.
     @Override
-    public @Nullable("configuration cache") TaskProvider<SyncMavenizer> asTask() {
+    public @Nullable TaskProvider<SyncMavenizer> asTask() {
         return this.mavenizer;
     }
 
@@ -258,12 +261,12 @@ abstract class MinecraftDependencyImpl implements MinecraftDependencyInternal {
 
                 spec.getFrom()
                     .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.JAR_TYPE)
-                    .attribute(Category.CATEGORY_ATTRIBUTE, this.getObjects().named(Category.class, Category.LIBRARY))
+                    .attribute(Category.CATEGORY_ATTRIBUTE, spec.getFrom().named(Category.class, Category.LIBRARY))
                     .attribute(attribute, false);
 
                 spec.getTo()
                     .attribute(ArtifactTypeDefinition.ARTIFACT_TYPE_ATTRIBUTE, ArtifactTypeDefinition.JAR_TYPE)
-                    .attribute(Category.CATEGORY_ATTRIBUTE, this.getObjects().named(Category.class, Category.LIBRARY))
+                    .attribute(Category.CATEGORY_ATTRIBUTE, spec.getTo().named(Category.class, Category.LIBRARY))
                     .attribute(attribute, true);
             });
 

--- a/src/main/java/net/minecraftforge/gradle/internal/MinecraftDependencyInternal.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/MinecraftDependencyInternal.java
@@ -17,7 +17,7 @@ import org.gradle.api.reflect.HasPublicType;
 import org.gradle.api.reflect.TypeOf;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 interface MinecraftDependencyInternal extends MinecraftDependency, HasPublicType, MinecraftMappingsContainerInternal {
     String MC_EXT_NAME = "__fg_minecraft_dependency";
@@ -46,9 +46,11 @@ interface MinecraftDependencyInternal extends MinecraftDependency, HasPublicType
 
     ExternalModuleDependency init(Object dependencyNotation, Closure<?> closure);
 
-    @Nullable("configuration cache") ExternalModuleDependency asDependency();
+    // Can be nullable due to configuration caching.
+    @Nullable ExternalModuleDependency asDependency();
 
-    @Nullable("configuration cache") TaskProvider<SyncMavenizer> asTask();
+    // Can be nullable due to configuration caching.
+    @Nullable TaskProvider<SyncMavenizer> asTask();
 
     Action<? super AttributeContainer> addAttributes();
 

--- a/src/main/java/net/minecraftforge/gradle/internal/MinecraftMappingsContainerInternal.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/MinecraftMappingsContainerInternal.java
@@ -7,14 +7,15 @@ package net.minecraftforge.gradle.internal;
 import groovy.transform.NamedParam;
 import groovy.transform.NamedParams;
 import net.minecraftforge.gradle.MinecraftMappingsContainer;
-import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.NullUnmarked;
 
 import java.util.Map;
 
 interface MinecraftMappingsContainerInternal extends MinecraftMappingsContainer {
     // NOTE: Overridden with @UnknownNullability, null is checked in MinecraftMappingsImpl
     @Override
-    void mappings(@UnknownNullability String channel, @UnknownNullability String version);
+    @NullUnmarked
+    void mappings(String channel, String version);
 
     @Override
     default void mappings(

--- a/src/main/java/net/minecraftforge/gradle/internal/OperatingSystemName.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/OperatingSystemName.java
@@ -8,7 +8,7 @@ import net.minecraftforge.util.os.OS;
 import org.gradle.api.provider.SetProperty;
 import org.gradle.api.provider.ValueSource;
 import org.gradle.api.provider.ValueSourceParameters;
-import org.jetbrains.annotations.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
 

--- a/src/main/java/net/minecraftforge/gradle/internal/SlimeLauncherExec.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/SlimeLauncherExec.java
@@ -50,13 +50,11 @@ abstract class SlimeLauncherExec extends JavaExec implements ForgeGradleTask, Ha
             try {
                 t = project.getTasks().named(taskName, SlimeLauncherMetadata.class);
             } catch (UnknownDomainObjectException e) {
-                var metadataDep = project.getDependencyFactory().create(module.getGroup(), module.getName(), version, "metadata", "zip");
-                var metadataAttr = project.getObjects().named(Usage.class, "metadata");
                 var metadataConfiguration = project.getConfigurations().detachedConfiguration(
-                    metadataDep
+                    project.getDependencyFactory().create(module.getGroup(), module.getName(), version, "metadata", "zip")
                 );
                 metadataConfiguration.setTransitive(false);
-                metadataConfiguration.attributes(a -> a.attribute(Usage.USAGE_ATTRIBUTE, metadataAttr));
+                metadataConfiguration.attributes(a -> a.attribute(Usage.USAGE_ATTRIBUTE, a.named(Usage.class, "metadata")));
 
                 t = project.getTasks().register(taskName, SlimeLauncherMetadata.class, task -> {
                     task.setDescription("Extracts the Slime Launcher metadata%s.".formatted(single ? "" : " for '%s'".formatted(asString)));

--- a/src/main/java/net/minecraftforge/gradle/internal/Util.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/Util.java
@@ -12,14 +12,13 @@ import org.gradle.api.artifacts.Dependency;
 import org.gradle.api.artifacts.ModuleIdentifier;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.SourceSetContainer;
-import org.jetbrains.annotations.Nullable;
-import org.jetbrains.annotations.UnknownNullability;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 
 final class Util extends SharedUtil {
-    static String checkMappingsParam(ForgeGradleProblems problems, @UnknownNullability Object param, String name) {
+    static String checkMappingsParam(ForgeGradleProblems problems, @Nullable Object param, String name) {
         if (param == null)
             throw problems.nullMappingsParam(name);
 

--- a/src/main/java/net/minecraftforge/gradle/internal/package-info.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/package-info.java
@@ -2,7 +2,7 @@
  * Copyright (c) Forge Development LLC and contributors
  * SPDX-License-Identifier: LGPL-2.1-only
  */
-@NotNullByDefault
+@NullMarked
 package net.minecraftforge.gradle.internal;
 
-import org.jetbrains.annotations.NotNullByDefault;
+import org.jspecify.annotations.NullMarked;

--- a/src/main/java/net/minecraftforge/gradle/package-info.java
+++ b/src/main/java/net/minecraftforge/gradle/package-info.java
@@ -7,8 +7,8 @@
 /// This package houses the entirety of ForgeGradle, a simple plugin designed to bootstrap the process of using
 /// Minecraft as a dependency for your Gradle project.
 @Incubating
-@NotNullByDefault
+@NullMarked
 package net.minecraftforge.gradle;
 
 import org.gradle.api.Incubating;
-import org.jetbrains.annotations.NotNullByDefault;
+import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
- Fulfills #1006.

This PR replaces the usage of JetBrains annotations with [JSpecify](https://jspecify.dev/). JSpecify is one of the newer nullable annotation standards that most people have begun to agree on, including Gradle and Mojang.

This is still a work-in-progress. Part of this PR is getting NullAway and Errorprone working for enhanced static analysis on build of ForgeGradle 7.