### PR TITLE
[7.0] Check minimum Gradle version in middle-man plugin entry point

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,10 @@ java {
     withJavadocJar()
 }
 
+shadow {
+    addTargetJvmVersionAttribute = false
+}
+
 gradleutils.pluginDevDefaults(configurations, libs.versions.gradle)
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,25 @@ java {
 
 gradleutils.pluginDevDefaults(configurations, libs.versions.gradle)
 
+configurations {
+    dependencyScope('runtimeCheckerOnly') {
+        description = 'Contains the dependencies for the runtime environment checker used to check the Gradle version.'
+    }
+
+    resolvable('runtimeCheckerClasspath') {
+        description = 'Contains the classpath for the runtime environment checker used to check the Gradle version.'
+        transitive = false
+        extendsFrom runtimeCheckerOnly
+    }
+
+    named('runtimeClasspath') {
+        extendsFrom runtimeCheckerClasspath
+    }
+}
+
 dependencies {
+    runtimeCheckerOnly projects.runtimeEnvironmentCheck
+
     // Static Analysis
     api libs.annotations.jspecify
 
@@ -51,16 +69,27 @@ license {
     exclude '**/*.properties'
 }
 
+def includeRuntimeChecker = { Jar jar ->
+    jar.dependsOn(configurations.runtimeCheckerClasspath.buildDependencies)
+    jar.from(provider { zipTree(configurations.runtimeCheckerClasspath.singleFile) }) {
+        duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    }
+}
+
 tasks.named('jar', Jar) {
+    includeRuntimeChecker(it)
     archiveClassifier = 'thin'
 }
 
 tasks.named('shadowJar', ShadowJar) {
+    includeRuntimeChecker(it)
+
     enableAutoRelocation = true
     archiveClassifier = null
     relocationPrefix = 'net.minecraftforge.gradle.shadow'
 
     dependencies {
+        exclude dependency(projects.runtimeEnvironmentCheck)
         exclude dependency(libs.annotations.jspecify)
     }
 }
@@ -79,7 +108,7 @@ gradlePlugin {
 
     plugins.register('forgegradle') {
         id = 'net.minecraftforge.gradle'
-        implementationClass = 'net.minecraftforge.gradle.internal.ForgeGradlePlugin'
+        implementationClass = 'net.minecraftforge.gradle.internal.ForgeGradlePluginEntry'
         displayName = gradleutils.displayName.get()
         description = project.description
         tags = ['minecraftforge', 'minecraft']

--- a/runtime-environment-check/build.gradle
+++ b/runtime-environment-check/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+    id 'java'
+    id 'idea'
+    id 'eclipse'
+    alias libs.plugins.gradleutils
+    alias libs.plugins.licenser
+}
+
+gradleutils.displayName = 'Runtime Environment Check'
+description = 'A small Gradle plugin entry point that checks for the required Gradle version.'
+
+java.toolchain.languageVersion = JavaLanguageVersion.of(8)
+
+dependencies {
+    // Static Analysis
+    implementation libs.annotations.jspecify
+
+    // Gradle API
+    compileOnly libs.gradle
+}
+
+license {
+    header = rootProject.file('LICENSE-header.txt')
+    newLine = false
+    exclude '**/*.properties'
+}

--- a/runtime-environment-check/src/main/java/net/minecraftforge/gradle/internal/ForgeGradlePluginEntry.java
+++ b/runtime-environment-check/src/main/java/net/minecraftforge/gradle/internal/ForgeGradlePluginEntry.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.gradle.internal;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.plugins.PluginAware;
+import org.gradle.util.GradleVersion;
+
+import javax.inject.Inject;
+
+// TODO [GradleRuntimeCheck] Move this into its own repository? The idea is that it just checked for a required version.
+//      All of our projects could benefit from this, it could also be something in GradleUtils Shared.
+@SuppressWarnings("unused")
+abstract class ForgeGradlePluginEntry implements Plugin<PluginAware> {
+    private static final GradleVersion CURRENT_GRADLE = GradleVersion.current();
+    private static final GradleVersion MINIMUM_GRADLE = GradleVersion.version("9.3.0-rc-1");
+
+    @Inject
+    public ForgeGradlePluginEntry() { }
+
+    @Override
+    public void apply(PluginAware target) {
+        if (CURRENT_GRADLE.compareTo(MINIMUM_GRADLE) < 0) {
+            String message = String.format(
+                "ForgeGradle requires %s or later to run. You are currently using %s.",
+                MINIMUM_GRADLE,
+                CURRENT_GRADLE
+            );
+            throw new IllegalStateException(message);
+        }
+
+        try {
+            target.getPluginManager().apply(Class.forName("net.minecraftforge.gradle.internal.ForgeGradlePlugin"));
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Failed to find the ForgeGradle entry-point.", e);
+        }
+    }
+}

--- a/runtime-environment-check/src/main/java/net/minecraftforge/gradle/internal/ForgeGradlePluginEntry.java
+++ b/runtime-environment-check/src/main/java/net/minecraftforge/gradle/internal/ForgeGradlePluginEntry.java
@@ -24,7 +24,7 @@ abstract class ForgeGradlePluginEntry implements Plugin<PluginAware> {
     public void apply(PluginAware target) {
         if (CURRENT_GRADLE.compareTo(MINIMUM_GRADLE) < 0) {
             String message = String.format(
-                "ForgeGradle requires %s or later to run. You are currently using %s.",
+                "ForgeGradle 7 requires %s or later to run. You are currently using %s.",
                 MINIMUM_GRADLE,
                 CURRENT_GRADLE
             );

--- a/runtime-environment-check/src/main/java/net/minecraftforge/gradle/internal/ForgeGradlePluginEntry.java
+++ b/runtime-environment-check/src/main/java/net/minecraftforge/gradle/internal/ForgeGradlePluginEntry.java
@@ -5,6 +5,8 @@
 package net.minecraftforge.gradle.internal;
 
 import org.gradle.api.Plugin;
+import org.gradle.api.logging.Logger;
+import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.PluginAware;
 import org.gradle.util.GradleVersion;
 
@@ -14,6 +16,8 @@ import javax.inject.Inject;
 //      All of our projects could benefit from this, it could also be something in GradleUtils Shared.
 @SuppressWarnings("unused")
 abstract class ForgeGradlePluginEntry implements Plugin<PluginAware> {
+    private static final Logger LOGGER = Logging.getLogger(ForgeGradlePluginEntry.class);
+
     private static final GradleVersion CURRENT_GRADLE = GradleVersion.current();
     private static final GradleVersion MINIMUM_GRADLE = GradleVersion.version("9.3.0-rc-1");
 
@@ -28,6 +32,7 @@ abstract class ForgeGradlePluginEntry implements Plugin<PluginAware> {
                 MINIMUM_GRADLE,
                 CURRENT_GRADLE
             );
+            LOGGER.error("ERROR: {}", message);
             throw new IllegalStateException(message);
         }
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -4,6 +4,10 @@ plugins {
 
 rootProject.name = 'forgegradle'
 
+include 'runtime-environment-check'
+
+enableFeaturePreview 'TYPESAFE_PROJECT_ACCESSORS'
+
 // Applying plugins causes them to not have any IDE support when also applied to any build.gradle files
 // The workaround for now is to use this listener here so that it can stay in settings.gradle
 // See: https://youtrack.jetbrains.com/issue/IDEA-332061/Gradle-Missing-Code-Completion-Suggestions-for-Settings-Plugins-in-Groovy-DSL

--- a/src/main/java/net/minecraftforge/gradle/internal/ForgeGradlePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/ForgeGradlePlugin.java
@@ -11,6 +11,7 @@ import org.gradle.api.flow.FlowScope;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.plugins.ExtensionAware;
+import org.gradle.util.GradleVersion;
 import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;


### PR DESCRIPTION
- Closes #1016

This PR adds a Java 8 compatible runtime checker as the plugin entry-point for ForgeGradle 7. All it does is check that the Gradle version is not less than 9.3.0-rc-1. If the version requirement is not met, an exception is immediately thrown.

The setup for this is a little scuffed, but it's good enough for now considering recent events with people needing to use ForgeGradle 7 since other plugins have bumped their minimum Gradle requirements.