### PR TITLE
[7.0] Begin ForgeGradle 7.0's Release lifecycle

### DIFF
--- a/.github/workflows/publish_fg7.yml
+++ b/.github/workflows/publish_fg7.yml
@@ -18,7 +18,7 @@ jobs:
     uses: MinecraftForge/SharedActions/.github/workflows/gradle.yml@v0
     with:
       java: 21
-      gradle_tasks: 'check publish'
+      gradle_tasks: 'check publish publishPlugins'
       artifact_name: 'forgegradle'
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
@@ -27,4 +27,5 @@ jobs:
       PROMOTE_ARTIFACT_PASSWORD: ${{ secrets.PROMOTE_ARTIFACT_PASSWORD }}
       MAVEN_USER: ${{ secrets.MAVEN_USER }}
       MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
-      GRADLE_CACHE_KEY: ${{ secrets.GRADLE_CACHE_KEY }}
+      GRADLE_PUBLISH_KEY: ${{ secrets.GRADLE_PUBLISH_KEY }}
+      GRADLE_PUBLISH_SECRET: ${{ secrets.GRADLE_PUBLISH_SECRET }}

--- a/src/main/java/net/minecraftforge/gradle/internal/Constants.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/Constants.java
@@ -26,21 +26,26 @@ final class Constants {
     /// Use these with [java.text.MessageFormat#format(String, Object...)].
     static final class Messages {
         static final String WELCOME = """
-            Welcome to ForgeGradle 7.0 Release Candidate!
+            Welcome to ForgeGradle 7.0!
 
             Here are some release highlights:
+            - Now requires Gradle 9.3.0.
+            - A new message board that will display any new messages (only on the next
+              successful build) from ForgeGradle, including release highlights and
+              project-wide warnings.
             - Complete rewrite of the plugin and underlying code.
             - Complete overhaul of DSL objects and registrations.
             - Slimmed down the plugin, which now delegates many actions to separate tools.
-            - Support for declaring defaults in settings.gradle.
-            - Support for all Forge versions from Minecraft 1.20.6 (older versions are a
-              work-in-progress).
+            - Support for declaring defaults in settings.gradle (experimental).
+            - Support for all Forge versions that are supported by ForgeGradle 6.
+              - Minecraft 1.20.6+ are natively supported with no additional setup.
+              - Minecraft 1.13.2 - 1.20.4 (along with certain versions of 1.12.2) are
+                supported alongside the usage of the Renamer plugin (experimental).
 
             A couple of important things to note:
             - Many plugins that worked with ForgeGradle 6, such as Parchment's Librarian,
               do not work with ForgeGradle 7. For most cases (such as parchment), we have
-              implemented native support. If ForgeGradle 7 is lacking in some aspect,
-              please let us know!
+              implemented native support.
             - Many things that ForgeGradle 6 and older used to do are now decentralized
               away from the plugin. This means that your project will need to apply
               'net.minecraftforge.jarjar' if you wish to use Forge's Jar-in-Jar system.
@@ -48,20 +53,30 @@ final class Constants {
               'net.minecraftforge.renamer' plugin. Many of these come with our provided
               MDK, so this should not be an issue for you.
             - If you come across any lingering bugs, please report them to our GitHub
-              issue tracker (https://github.com/MinecraftForge/ForgeGradle/issues).
-              Please do not use Discord as a means to report issues, as they will get
-              lost in the discussion very easily.
+              issue tracker. Please do not use Discord as a means to report issues, as
+              they will get lost in the discussion very easily.
+            - If you would like to see additional examples of ForgeGradle 7 usages,
+              please see our MDKExamples repo (https://github.com/MinecraftForge/MDKExamples).
+              If would like to request a specific usage for ForgeGradle 7, please file an
+              issue on the GitHub issue tracker for it.
 
-            For more details on this release, see https://docs.minecraftforge.net/en/fg-7.0/""";
+            For our GitHub issue tracker, see https://github.com/MinecraftForge/ForgeGradle/issues
+
+            Proper documentation for ForgeGradle 7 is coming soon. For now, feel free to
+            ask any questions you may have on the following platforms:
+            - Forums (https://forums.minecraftforge.net/)
+            - Discord (https://discord.minecraftforge.net/)""";
 
         static final String WELCOME_CONDITION = """
-            This message will not display again until ForgeGradle 7.0 or the below file is
+            This message will not display again until ForgeGradle 7.1 or the below file is
             deleted:
             {}
 
             Documentation will be coming at a later date. Thank you for testing
             ForgeGradle 7!""";
 
+        // TODO [ForgeGradle][Magic] Rewrite this to be more informative as to what is actually happening.
+        //      As of right now, this remains unused.
         static final String MAGIC = """
             This build is using ForgeGradle Magic. ForgeGradle Magic employs automatic
             behavior that is hidden from buildscript authors in order to implement and

--- a/src/main/java/net/minecraftforge/gradle/internal/ForgeGradleMessage.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/ForgeGradleMessage.java
@@ -12,9 +12,12 @@ import org.gradle.api.provider.Provider;
 
 import java.util.Locale;
 
+// TODO [ForgeGradle] Queue Magic message
+//      While FG7 has some magic, none of it is substantial enough for it to warrant it yet
+//      It also needs to be rewritten in a way that makes it much more informative
 enum ForgeGradleMessage {
-    WELCOME("7_0_RC_WELCOME_1", Constants.Messages.WELCOME, Constants.Messages.WELCOME_CONDITION),
-    MAGIC("7_0_RC_MAGIC_1", Constants.Messages.MAGIC);
+    WELCOME("7_0_WELCOME_1", Constants.Messages.WELCOME, Constants.Messages.WELCOME_CONDITION),
+    MAGIC("7_0_MAGIC_1", Constants.Messages.MAGIC);
 
     private static final String MESSAGES_DIR = "messages";
 

--- a/src/main/java/net/minecraftforge/gradle/internal/ForgeGradlePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/ForgeGradlePlugin.java
@@ -25,10 +25,6 @@ abstract class ForgeGradlePlugin extends EnhancedPlugin<ExtensionAware> {
 
     private final ForgeGradleProblems problems = this.getObjects().newInstance(ForgeGradleProblems.class);
 
-    static {
-        LOGGER.lifecycle("ForgeGradle 7 is an incubating plugin.");
-    }
-
     protected abstract @Inject FlowScope getFlowScope();
 
     protected abstract @Inject FlowProviders getFlowProviders();

--- a/src/main/java/net/minecraftforge/gradle/internal/MinecraftExtensionImpl.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/MinecraftExtensionImpl.java
@@ -214,7 +214,7 @@ abstract class MinecraftExtensionImpl implements MinecraftExtensionInternal {
             }
 
             plugin.queueMessage(ForgeGradleMessage.WELCOME);
-            plugin.queueMessage(ForgeGradleMessage.MAGIC);
+            //plugin.queueMessage(ForgeGradleMessage.MAGIC);
 
             getFlowScope().always(ForgeGradleFlowAction.AccessTransformersMissing.class, spec -> spec.parameters(parameters -> {
                 parameters.getFailure().set(getFlowProviders().getBuildWorkResult().map(p -> p.getFailure().orElse(null)));

--- a/src/main/java/net/minecraftforge/gradle/package-info.java
+++ b/src/main/java/net/minecraftforge/gradle/package-info.java
@@ -6,9 +6,7 @@
 ///
 /// This package houses the entirety of ForgeGradle, a simple plugin designed to bootstrap the process of using
 /// Minecraft as a dependency for your Gradle project.
-@Incubating
 @NullMarked
 package net.minecraftforge.gradle;
 
-import org.gradle.api.Incubating;
 import org.jspecify.annotations.NullMarked;


### PR DESCRIPTION
This PR marks the beginning of the ForgeGradle 7.0 release lifecycle (i.e. 7.0.0). This description will have more things added to it soon, but here are the main implications.

- ForgeGradle will have **no buildscript breaking changes** until ForgeGradle 8.0.
  - Binary API breaking changes are still on the table.
- ForgeGradle 6.0 will be dropped from active support
  - Critical bug fixes are still on the table, just like with older versions.