### PR TITLE
[7.0] Fix genEclipseRuns not using correct eclipse output directories

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/internal/MinecraftDependencyImpl.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/MinecraftDependencyImpl.java
@@ -198,7 +198,7 @@ abstract class MinecraftDependencyImpl implements MinecraftDependencyInternal {
                 .matching(MinecraftDependencyInternal::is)
                 .size() == 1;
             runs.forEach(options -> {
-                var task = SlimeLauncherExec.register(getProject(), sourceSet, (SlimeLauncherOptionsImpl) options, module.get(), version.get(), asPath.get(), asString, single, minecraft.getEclipseOutputDir());
+                var task = SlimeLauncherExec.register(getProject(), sourceSet, (SlimeLauncherOptionsImpl) options, module.get(), version.get(), asPath.get(), asString, single);
             });
         });
 

--- a/src/main/java/net/minecraftforge/gradle/internal/MinecraftExtensionImpl.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/MinecraftExtensionImpl.java
@@ -329,7 +329,11 @@ abstract class MinecraftExtensionImpl implements MinecraftExtensionInternal {
 
             project.getPluginManager().withPlugin("eclipse", eclipsePlugin -> {
                 if (mergeSourceSets)
-                    project.getExtensions().configure(EclipseModel.class, eclipse -> eclipse.getClasspath().setDefaultOutputDir(sourceSetsDir.getAsFile().get()));
+                    project.getExtensions().configure(EclipseModel.class, eclipse -> eclipse.classpath(classpath -> {
+                        var output = sourceSetsDir.getAsFile().get();
+                        classpath.setDefaultOutputDir(output);
+                        classpath.getBaseSourceOutputDir().set(output);
+                    }));
                 else
                     problems.reportUnmergedSourceSets();
             });

--- a/src/main/java/net/minecraftforge/gradle/internal/MinecraftExtensionImpl.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/MinecraftExtensionImpl.java
@@ -171,7 +171,6 @@ abstract class MinecraftExtensionImpl implements MinecraftExtensionInternal {
 
     static abstract class ForProjectImpl extends MinecraftExtensionImpl implements ForProject {
         private final TaskProvider<Task> genEclipseRuns;
-        final DirectoryProperty eclipseOutputDir = getObjects().directoryProperty().convention(getProjectLayout().getProjectDirectory().dir("bin"));
 
         // Slime Launcher
         private final NamedDomainObjectContainer<SlimeLauncherOptionsImpl> runs = getObjects().domainObjectContainer(SlimeLauncherOptionsImpl.class);
@@ -252,7 +251,6 @@ abstract class MinecraftExtensionImpl implements MinecraftExtensionInternal {
             getProject().getPluginManager().withPlugin("eclipse", appliedPlugin ->
                 getProject().getExtensions().configure(EclipseModel.class, eclipse -> {
                     eclipse.synchronizationTasks(genEclipseRuns);
-                    eclipseOutputDir.fileProvider(getProviders().provider(() -> eclipse.getClasspath().getDefaultOutputDir()));
                 })
             );
 
@@ -293,11 +291,6 @@ abstract class MinecraftExtensionImpl implements MinecraftExtensionInternal {
                 case PREFER_PROJECT ->
                     Collections.unmodifiableList(!settingsRepositories.isEmpty() && projectRepositories.isEmpty() ? settingsRepositories : projectRepositories);
             };
-        }
-
-        @Override
-        public DirectoryProperty getEclipseOutputDir() {
-            return this.eclipseOutputDir;
         }
 
         private void apply(Configuration configuration) {

--- a/src/main/java/net/minecraftforge/gradle/internal/MinecraftExtensionInternal.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/MinecraftExtensionInternal.java
@@ -34,7 +34,5 @@ interface MinecraftExtensionInternal extends MinecraftExtension, HasPublicType, 
         }
 
         @UnmodifiableView List<? extends MavenArtifactRepository> getRepositories();
-
-        DirectoryProperty getEclipseOutputDir();
     }
 }

--- a/src/main/java/net/minecraftforge/gradle/internal/SlimeLauncherExec.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/SlimeLauncherExec.java
@@ -16,6 +16,7 @@ import org.gradle.api.attributes.Usage;
 import org.gradle.api.file.ConfigurableFileCollection;
 import org.gradle.api.file.Directory;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.DirectoryTree;
 import org.gradle.api.file.RegularFileProperty;
 import org.gradle.api.provider.MapProperty;
 import org.gradle.api.provider.Property;
@@ -31,18 +32,26 @@ import org.gradle.api.tasks.Nested;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.SourceSet;
 import org.gradle.api.tasks.TaskProvider;
+import org.gradle.plugins.ide.eclipse.model.EclipseModel;
 import org.gradle.work.DisableCachingByDefault;
+import org.jspecify.annotations.Nullable;
 
 import javax.inject.Inject;
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 
 @DisableCachingByDefault(because = "Running the game cannot be cached")
 abstract class SlimeLauncherExec extends JavaExec implements ForgeGradleTask, HasPublicType {
-    static TaskProvider<SlimeLauncherExec> register(Project project, SourceSet sourceSet, SlimeLauncherOptionsImpl options, ModuleIdentifier module, String version, String asPath, String asString, boolean single, Provider<Directory> eclipseOutputDir) {
+    static TaskProvider<SlimeLauncherExec> register(Project project, SourceSet sourceSet, SlimeLauncherOptionsImpl options, ModuleIdentifier module, String version, String asPath, String asString, boolean single) {
         TaskProvider<SlimeLauncherMetadata> metadata;
         {
             TaskProvider<SlimeLauncherMetadata> t;
@@ -70,18 +79,50 @@ abstract class SlimeLauncherExec extends JavaExec implements ForgeGradleTask, Ha
         var runTaskName = sourceSet.getTaskName("run", options.getName()) + taskNameSuffix;
         var generateEclipseRunTaskName = sourceSet.getTaskName("genEclipseRun", options.getName()) + taskNameSuffix;
 
-        var sourceSetOutputs = project.getObjects().fileCollection().from(sourceSet.getOutput().getResourcesDir(), sourceSet.getJava().getDestinationDirectory());
-        var eclipseOutputs = project.getObjects().fileCollection().from(eclipseOutputDir);
         var genEclipseRun = project.getTasks().register(generateEclipseRunTaskName, SlimeLauncherEclipseConfiguration.class, task -> {
             task.getRunName().set(options.getName());
             task.setDescription("Generates the '%s' Slime Launcher run configuration for Eclipse.".formatted(options.getName()));
             task.getOutputFile().set(task.getProjectLayout().getProjectDirectory().file(runTaskName + ".launch"));
 
-            task.getClasspath()
-                .from(task.getObjects().fileCollection().from(task.getProviders().provider(sourceSet::getRuntimeClasspath)))
-                .minus(sourceSetOutputs)
-                .plus(eclipseOutputs);
+            var runtimeClasspath = task.getObjects().fileCollection().from(
+                task.getProviders().provider(() -> {
+                    var runtime = sourceSet.getRuntimeClasspath();
+                    var eclipseModel = project.getExtensions().findByType(EclipseModel.class);
+                    if (eclipseModel == null)
+                        return runtime.getFiles();
 
+                    // We need to build a map of sourcesets to real output paths like Eclipse's plugin does.
+                    // There is no known exposure of this stuff, so have to do it ourselves.
+                    // https://github.com/gradle/gradle/blob/master/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java#L220
+                    var classpath = eclipseModel.getClasspath();
+                    var sortedSourceSets = sortSourceSets(classpath.getSourceSets());
+                    var replacements = new HashMap<File, File>();
+                    var base = classpath.getBaseSourceOutputDir().getAsFile().get();
+                    var claimed = new HashSet<File>();
+                    claimed.add(classpath.getDefaultOutputDir());
+
+                    // Gather the output name eclipse will use, and all outputs gradle expects
+                    for (var sources : sortedSourceSets) {
+                        var name =  sources.getName();
+                        var path = new File(base, name);
+                        while (claimed.contains(path)) {
+                            name += '_';
+                            path = new File(base, name);
+                        }
+                        claimed.add(path);
+                        if (sources.getOutput().getResourcesDir() != null)
+                            replacements.put(sources.getOutput().getResourcesDir(), path);
+                        for (var dir : sources.getOutput().getClassesDirs().getFiles())
+                            replacements.put(dir, path);
+                    }
+
+                    // Now replace the existing classpath with the ones eclipse will use
+                    var ret = new LinkedHashSet<File>(runtime.getFiles().size());
+                    for (var file : runtime.getFiles())
+                        ret.add(replacements.getOrDefault(file, file));
+                    return ret;
+                }));
+            task.getClasspath().from(runtimeClasspath);
             task.getSourceSetName().set(sourceSet.getName());
 
             task.getCacheDir().set(task.getObjects().directoryProperty().value(task.globalCaches().dir("slime-launcher/cache/%s".formatted(asPath)).map(task.problems.ensureFileLocation())));
@@ -204,6 +245,27 @@ abstract class SlimeLauncherExec extends JavaExec implements ForgeGradleTask, Ha
             this.getLogger().error("Args: {}", this.getArgs());
             this.getLogger().error("Options: {}", options);
             throw e;
+        }
+    }
+
+    private static List<SourceSet> sortSourceSets(@Nullable Iterable<SourceSet> sourceSets) {
+        if (sourceSets == null)
+            return new ArrayList<>(0);
+        var ret = new ArrayList<SourceSet>();
+        for (var item : sourceSets)
+            ret.add(item);
+        ret.sort(Comparator.comparing(SlimeLauncherExec::toComparable));
+        return ret;
+    }
+
+    private static Integer toComparable(SourceSet sourceSet) {
+        String name = sourceSet.getName();
+        if (SourceSet.MAIN_SOURCE_SET_NAME.equals(name)) {
+            return 0;
+        } else if (SourceSet.TEST_SOURCE_SET_NAME.equals(name)) {
+            return 1;
+        } else {
+            return 2;
         }
     }
 }


### PR DESCRIPTION
This is to address https://github.com/MinecraftForge/ForgeGradle/issues/1038
The eclipse runs were not using the correct directories.

Basically, because I didn't want to figure out how to pass in the eclipseModel to a task. I do all the work at configuration time.
But also this is called during afterEvalute because thats when MinecraftDependency.handle is called.
That needs to be fixed, as only validation should be happening in afterEvaluate, but thats a bigger thing for later.

I deleted getEclipseOutputDir because it is part of the internal api, and thus not what I consider a breaking change.
In its place, i grab the EclipseModel as needed.
From the EclipseModel I use:
 - sourceSets
 - baseSourceOutputDir
 - defaultOutputDir
 
From SourceSet I use:
  - name
  - output.resourcesDir
  - output.classesDirs

This works for now, if this looks sane enough to you @Jonathing pull.

Copy pasting some relevant details form discord:
Okay so The EclipseClasspath task uses the EclipseModel. Which includes [SourceFolder](https://github.com/gradle/gradle/blob/master/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/SourceFolder.java) entries.
These entries have a 'output' value which is set via [SourceFoldersCreator](https://github.com/gradle/gradle/blob/master/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java#L123)
Who [collectSourceSetoutputPaths](https://github.com/gradle/gradle/blob/master/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java#L220) function basically just does: 
```java
path = base + '/' + sourceSet.name
while (claimed.contains(path)) path += '_'
return path
```
Easy enough to mimic. Except for the base part. That is gotten from [EclipseClasspath.getBaseSourceOutputDir](https://github.com/gradle/gradle/blob/master/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/EclipseClasspath.java#L245), relativzed to the [project directory](https://github.com/gradle/gradle/blob/540b81b4fb2d312a8009fe3b7e6c5c014236b724/platforms/ide/ide/src/main/java/org/gradle/plugins/ide/eclipse/model/internal/SourceFoldersCreator.java#L60). 
Which for completeness sake, defaults to [project.dir("bin")](https://github.com/gradle/gradle/blob/master/platforms/ide/ide-plugins/src/main/java/org/gradle/plugins/ide/eclipse/EclipsePlugin.java#L219)

This is all simple enough if we can figure out how to pass in the EclispeModel and sourceSets into the task.