### PR TITLE
Fix getAssetsIndex task for ForgeGradle 1.0

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/FileUtils.java
+++ b/src/main/java/net/minecraftforge/gradle/FileUtils.java
@@ -1,0 +1,31 @@
+package net.minecraftforge.gradle;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Objects;
+
+public class FileUtils {
+    public static String readString(File file) throws IOException {
+        return readString(file, StandardCharsets.UTF_8);
+    }
+
+    public static String readString(File file, Charset charset) throws IOException {
+        return new String(Files.readAllBytes(file.toPath()), charset);
+    }
+
+    public static void updateDate(File file) throws IOException {
+        if (!file.createNewFile() && !file.setLastModified(System.currentTimeMillis())) {
+            throw new IOException("Unable to update modification time of " + file);
+        }
+    }
+
+    public static String getFileExtension(String fullName) {
+        Objects.requireNonNull(fullName);
+        String fileName = new File(fullName).getName();
+        int dotIndex = fileName.lastIndexOf('.');
+        return (dotIndex == -1) ? "" : fileName.substring(dotIndex + 1);
+    }
+}

--- a/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
@@ -4,7 +4,11 @@ import groovy.lang.Closure;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.HashMap;
+import java.util.List;
+import java.util.function.Function;
 
 import net.minecraftforge.gradle.FileLogListenner;
 import net.minecraftforge.gradle.common.version.AssetIndex;
@@ -14,10 +18,13 @@ import net.minecraftforge.gradle.delayed.DelayedBase.IDelayedResolver;
 import net.minecraftforge.gradle.delayed.DelayedFile;
 import net.minecraftforge.gradle.delayed.DelayedFileTree;
 import net.minecraftforge.gradle.delayed.DelayedString;
+import net.minecraftforge.gradle.json.MCVersionManifest;
+import net.minecraftforge.gradle.json.version.VersionToString;
 import net.minecraftforge.gradle.tasks.DownloadAssetsTask;
 import net.minecraftforge.gradle.tasks.ObtainFernFlowerTask;
 import net.minecraftforge.gradle.tasks.abstractutil.DownloadTask;
 
+import net.minecraftforge.gradle.tasks.abstractutil.EtagDownloadTask;
 import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Plugin;
@@ -63,7 +70,7 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
             @Override
             public void execute(Project proj)
             {
-                addMavenRepo(proj, "forge", "http://files.minecraftforge.net/maven");
+                addMavenRepo(proj, "forge", "https://files.minecraftforge.net/maven");
                 proj.getRepositories().mavenCentral();
                 addMavenRepo(proj, "minecraft", Constants.LIBRARY_URL);
             }
@@ -129,16 +136,108 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
         // download tasks
         DownloadTask task;
 
+        EtagDownloadTask etagDlTask;
+        etagDlTask = makeTask("getVersionJsonIndex", EtagDownloadTask.class);
+        {
+            etagDlTask.setUri(delayedString(Constants.MC_JSON_INDEX_URL));
+            etagDlTask.setFile(delayedFile(Constants.VERSION_JSON_INDEX));
+            etagDlTask.setDieWithError(false);
+        }
+
+        etagDlTask = makeTask("getVersionJson", EtagDownloadTask.class);
+        {
+            class GetVersionJsonUrl extends DelayedString {
+                public GetVersionJsonUrl() {
+                    super(BasePlugin.this.project, "");
+                }
+
+                @Override
+                public String call() {
+                    try {
+                        MCVersionManifest manifest = JsonFactory.loadMCVersionManifest(delayedFile(Constants.VERSION_JSON_INDEX).call());
+                        MCVersionManifest.Version version = manifest.findVersion(delayedString("{MC_VERSION}").call());
+                        return version.url;
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            }
+            etagDlTask.dependsOn("getVersionJsonIndex");
+            etagDlTask.getInputs().file(delayedFile(Constants.VERSION_JSON_INDEX));
+            etagDlTask.setUri(new GetVersionJsonUrl());
+            etagDlTask.setFile(delayedFile(Constants.VERSION_JSON_INDEX));
+            etagDlTask.setDieWithError(false);
+            //TODO: this is not necessary?
+            etagDlTask.doLast(new Action<Task>() { // normalizes to linux endings
+                @Override
+                public void execute(Task task) {
+                    try {
+                        File json = delayedFile(Constants.VERSION_JSON_INDEX).call();
+                        if (!json.exists())
+                            return;
+
+                        List<String> lines = Files.readAllLines(json.toPath());
+                        StringBuilder buf = new StringBuilder();
+                        for (String line : lines) {
+                            buf.append(line).append('\n');
+                        }
+                        Files.write(json.toPath(), buf.toString().getBytes(StandardCharsets.UTF_8));
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+            });
+        }
+
+        class GetDataFromJson extends DelayedString {
+            private final VersionToString function;
+
+            public GetDataFromJson(VersionToString function) {
+                super(BasePlugin.this.project, "");
+                this.function = function;
+            }
+
+            @Override
+            public String call() {
+                try {
+                    Version manifest = JsonFactory.loadVersion(delayedFile(Constants.VERSION_JSON_INDEX).call());
+                    return function.apply(manifest);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
         task = makeTask("downloadClient", DownloadTask.class);
         {
+            task.getInputs().file(delayedFile(Constants.VERSION_JSON_INDEX));
+            task.dependsOn("getVersionJson");
+
             task.setOutput(delayedFile(Constants.JAR_CLIENT_FRESH));
-            task.setUrl(delayedString(Constants.MC_JAR_URL));
+            task.setUrl(new GetDataFromJson(new VersionToString() {
+                @Override
+                public String apply(Version json) {
+                    return json.downloads.client.url;
+                }
+            }));
+
+
         }
 
         task = makeTask("downloadServer", DownloadTask.class);
         {
+            task.getInputs().file(delayedFile(Constants.VERSION_JSON_INDEX));
+            task.dependsOn("getVersionJson");
+
             task.setOutput(delayedFile(Constants.JAR_SERVER_FRESH));
-            task.setUrl(delayedString(Constants.MC_SERVER_URL));
+            task.setUrl(new GetDataFromJson(new VersionToString() {
+                @Override
+                public String apply(Version json) {
+                    return json.downloads.server.url;
+                }
+            }));
+
+
         }
 
         ObtainFernFlowerTask mcpTask = makeTask("downloadMcpTools", ObtainFernFlowerTask.class);
@@ -146,31 +245,35 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
             mcpTask.setMcpUrl(delayedString(Constants.MCP_URL));
             mcpTask.setFfJar(delayedFile(Constants.FERNFLOWER));
         }
-        
-        DownloadTask getAssetsIndex = makeTask("getAssetsIndex", DownloadTask.class);
-        {
-            getAssetsIndex.setUrl(delayedString(Constants.ASSETS_INDEX_URL));
-            getAssetsIndex.setOutput(delayedFile(Constants.ASSETS + "/indexes/{ASSET_INDEX}.json"));
-            getAssetsIndex.setDoesCache(false);
 
-            getAssetsIndex.doLast(new Action<Task>() {
-                public void execute(Task task)
-                {
-                    try
-                    {
-                        parseAssetIndex();
-                    }
-                    catch (Exception e)
-                    {
-                        Throwables.propagate(e);
-                    }
+        etagDlTask = makeTask("getAssetsIndex", EtagDownloadTask.class);
+        {
+            task.getInputs().file(delayedFile(Constants.VERSION_JSON_INDEX));
+            task.dependsOn("getVersionJson");
+
+            etagDlTask.setUrl(new GetDataFromJson(new VersionToString() {
+                @Override
+                public String apply(Version json) {
+                    return json.assetIndex.url;
                 }
-            });
-            
-            getAssetsIndex.getOutputs().upToDateWhen(new Closure<Boolean>(this, null)  {
-                public Boolean call(Object... obj)
-                {
-                    return false;
+            }));
+
+
+            etagDlTask.setFile(delayedFile(Constants.ASSETS + "/indexes/{ASSET_INDEX}.json"));
+            etagDlTask.setDieWithError(false);
+
+            etagDlTask.doLast(new Action<Task>() {
+                @Override
+                public void execute(Task task1) {
+                    try {
+                        parseAssetIndex();
+                    } catch (JsonSyntaxException e) {
+                        throw new RuntimeException(e);
+                    } catch (JsonIOException e) {
+                        throw new RuntimeException(e);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
             });
         }

--- a/src/main/java/net/minecraftforge/gradle/common/Constants.java
+++ b/src/main/java/net/minecraftforge/gradle/common/Constants.java
@@ -22,137 +22,123 @@ import argo.jdom.JdomParser;
 
 import com.google.common.base.Joiner;
 
-public class Constants
-{
+public class Constants {
     // OS
-    public static enum OperatingSystem
-    {
+    public static enum OperatingSystem {
         WINDOWS, OSX, LINUX;
 
-        public String toString()
-        {
+        public String toString() {
             return StringUtils.lower(name());
         }
     }
 
     // OS
-    public static enum SystemArch
-    {
+    public static enum SystemArch {
         BIT_32, BIT_64;
 
-        public String toString()
-        {
+        public String toString() {
             return StringUtils.lower(name()).replace("bit_", "");
         }
     }
 
-    public static final OperatingSystem  OPERATING_SYSTEM = getOs();
-    public static final SystemArch       SYSTEM_ARCH      = getArch();
+    public static final OperatingSystem OPERATING_SYSTEM = getOs();
+    public static final SystemArch SYSTEM_ARCH = getArch();
+    public static final String HASH_FUNC = "MD5";
+    public static final String USER_AGENT = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.95 Safari/537.11";
 
     // extension nam
-    public static final String EXT_NAME_MC      = "minecraft";
+    public static final String EXT_NAME_MC = "minecraft";
     public static final String EXT_NAME_JENKINS = "jenkins";
 
     // json parser
     public static final JdomParser PARSER = new JdomParser();
 
     @SuppressWarnings("serial")
-    public static final Closure<Boolean> CALL_FALSE = new Closure<Boolean>(null){ public Boolean call(Object o){ return false; }};
+    public static final Closure<Boolean> CALL_FALSE = new Closure<Boolean>(null) {
+        public Boolean call(Object o) {
+            return false;
+        }
+    };
 
     // urls
-    public static final String MC_JAR_URL       = "http://s3.amazonaws.com/Minecraft.Download/versions/{MC_VERSION}/{MC_VERSION}.jar";
-    public static final String MC_SERVER_URL    = "http://s3.amazonaws.com/Minecraft.Download/versions/{MC_VERSION}/minecraft_server.{MC_VERSION}.jar";
-    public static final String MCP_URL          = "http://files.minecraftforge.net/fernflower_temporary.zip";
-    public static final String ASSETS_URL       = "http://resources.download.minecraft.net";
-    public static final String LIBRARY_URL      = "https://libraries.minecraft.net/";
-    public static final String ASSETS_INDEX_URL = "https://s3.amazonaws.com/Minecraft.Download/indexes/{ASSET_INDEX}.json";
+    public static final String MC_JSON_INDEX_URL = "https://piston-meta.mojang.com/mc/game/version_manifest.json";
+    public static final String MCP_URL = "https://files.minecraftforge.net/fernflower_temporary.zip";
+    public static final String ASSETS_URL = "https://resources.download.minecraft.net";
+    public static final String LIBRARY_URL = "https://libraries.minecraft.net/";
 
-    public static final String LOG              = ".gradle/gradle.log";
-    public static final String ASSETS_INDEX     =  "legacy";
+    public static final String LOG = ".gradle/gradle.log";
+    public static final String ASSETS_INDEX = "legacy";
 
     // things in the cache dir.
     public static final String JAR_CLIENT_FRESH = "{CACHE_DIR}/minecraft/net/minecraft/minecraft/{MC_VERSION}/minecraft-{MC_VERSION}.jar";
     public static final String JAR_SERVER_FRESH = "{CACHE_DIR}/minecraft/net/minecraft/minecraft_server/{MC_VERSION}/minecraft_server-{MC_VERSION}.jar";
-    public static final String JAR_MERGED       = "{CACHE_DIR}/minecraft/net/minecraft/minecraft_merged/{MC_VERSION}/minecraft_merged-{MC_VERSION}.jar";
-    public static final String FERNFLOWER       = "{CACHE_DIR}/minecraft/fernflower.jar";
-    public static final String EXCEPTOR         = "{CACHE_DIR}/minecraft/exceptor.jar";
-    public static final String ASSETS           = "{CACHE_DIR}/minecraft/assets";
+    public static final String JAR_MERGED = "{CACHE_DIR}/minecraft/net/minecraft/minecraft_merged/{MC_VERSION}/minecraft_merged-{MC_VERSION}.jar";
+    public static final String FERNFLOWER = "{CACHE_DIR}/minecraft/fernflower.jar";
+    public static final String EXCEPTOR = "{CACHE_DIR}/minecraft/exceptor.jar";
+    public static final String ASSETS = "{CACHE_DIR}/minecraft/assets";
+    public static final String JSONS_DIR = ASSETS + "/indexes";
+    public static final String VERSION_JSON_INDEX = JSONS_DIR + "/{ASSET_INDEX}.json";
 
-    public static final String DEOBF_JAR              = "{BUILD_DIR}/deobfuscated.jar";
-    public static final String DEOBF_BIN_JAR          = "{BUILD_DIR}/deobfuscated-bin.jar";
-    public static final String DECOMP_JAR             = "{BUILD_DIR}/decompiled.jar";
-    public static final String DECOMP_FMLED           = "{BUILD_DIR}/decompiled-fmled.jar";
-    public static final String DECOMP_FMLINJECTED     = "{BUILD_DIR}/decompiled-fmlinjected.jar";
+    public static final String DEOBF_JAR = "{BUILD_DIR}/deobfuscated.jar";
+    public static final String DEOBF_BIN_JAR = "{BUILD_DIR}/deobfuscated-bin.jar";
+    public static final String DECOMP_JAR = "{BUILD_DIR}/decompiled.jar";
+    public static final String DECOMP_FMLED = "{BUILD_DIR}/decompiled-fmled.jar";
+    public static final String DECOMP_FMLINJECTED = "{BUILD_DIR}/decompiled-fmlinjected.jar";
     public static final String DECOMP_FORGEJAVADOCCED = "{BUILD_DIR}/decompiled-forged.jar";
-    public static final String DECOMP_FORGED          = "{BUILD_DIR}/decompiled-forged-nojd.jar";
-    public static final String DECOMP_FORGEINJECTED   = "{BUILD_DIR}/decompiled-forgeinjected.jar";
-    public static final String DECOMP_REMAPPED        = "{BUILD_DIR}/decompiled-remapped.jar";
+    public static final String DECOMP_FORGED = "{BUILD_DIR}/decompiled-forged-nojd.jar";
+    public static final String DECOMP_FORGEINJECTED = "{BUILD_DIR}/decompiled-forgeinjected.jar";
+    public static final String DECOMP_REMAPPED = "{BUILD_DIR}/decompiled-remapped.jar";
 
     // util
     public static final String NEWLINE = System.getProperty("line.separator");
-    private static final OutputStream NULL_OUT = new OutputStream()
-    {
-        public void write(int b) throws IOException{}
+    private static final OutputStream NULL_OUT = new OutputStream() {
+        public void write(int b) throws IOException {
+        }
     };
 
 
     // helper methods
-    public static File cacheFile(Project project, String... otherFiles)
-    {
+    public static File cacheFile(Project project, String... otherFiles) {
         return Constants.file(project.getGradle().getGradleUserHomeDir(), otherFiles);
     }
 
-    public static File file(File file, String... otherFiles)
-    {
+    public static File file(File file, String... otherFiles) {
         String othersJoined = Joiner.on('/').join(otherFiles);
         return new File(file, othersJoined);
     }
 
-    public static File file(String... otherFiles)
-    {
+    public static File file(String... otherFiles) {
         String othersJoined = Joiner.on('/').join(otherFiles);
         return new File(othersJoined);
     }
 
-    public static List<String> getClassPath()
-    {
+    public static List<String> getClassPath() {
         URL[] urls = ((URLClassLoader) DevExtension.class.getClassLoader()).getURLs();
 
         ArrayList<String> list = new ArrayList<String>();
-        for (URL url : urls)
-        {
+        for (URL url : urls) {
             list.add(url.getPath());
         }
         return list;
     }
 
-    private static OperatingSystem getOs()
-    {
+    private static OperatingSystem getOs() {
         String name = StringUtils.lower(System.getProperty("os.name"));
-        if (name.contains("windows"))
-        {
+        if (name.contains("windows")) {
             return OperatingSystem.WINDOWS;
-        }
-        else if (name.contains("mac") || name.contains("osx"))
-        {
+        } else if (name.contains("mac") || name.contains("osx")) {
             return OperatingSystem.OSX;
-        }
-        else if (name.contains("linux") || name.contains("unix"))
-        {
+        } else if (name.contains("linux") || name.contains("unix")) {
             return OperatingSystem.LINUX;
-        }
-        else
-        {
+        } else {
             return null;
         }
     }
 
-    public static File getMinecraftDirectory()
-    {
+    public static File getMinecraftDirectory() {
         String userDir = System.getProperty("user.home");
 
-        switch (OPERATING_SYSTEM)
-        {
+        switch (OPERATING_SYSTEM) {
             case LINUX:
                 return new File(userDir, ".minecraft/");
             case WINDOWS:
@@ -164,30 +150,23 @@ public class Constants
             default:
                 return new File(userDir, "minecraft/");
         }
-      }
+    }
 
-    private static SystemArch getArch()
-    {
+    private static SystemArch getArch() {
         String name = StringUtils.lower(System.getProperty("os.arch"));
-        if (name.contains("64"))
-        {
+        if (name.contains("64")) {
             return SystemArch.BIT_64;
-        }
-        else
-        {
+        } else {
             return SystemArch.BIT_32;
         }
     }
 
-    public static String hash(File file)
-    {
+    public static String hash(File file) {
         return hash(file, "MD5");
     }
 
-    public static String hash(File file, String function)
-    {
-        try
-        {
+    public static String hash(File file, String function) {
+        try {
 
             InputStream fis = new FileInputStream(file);
 
@@ -195,11 +174,9 @@ public class Constants
             MessageDigest complete = MessageDigest.getInstance(function);
             int numRead;
 
-            do
-            {
+            do {
                 numRead = fis.read(buffer);
-                if (numRead > 0)
-                {
+                if (numRead > 0) {
                     complete.update(buffer, 0, numRead);
                 }
             } while (numRead != -1);
@@ -209,37 +186,29 @@ public class Constants
 
             String result = "";
 
-            for (int i = 0; i < hash.length; i++)
-            {
+            for (int i = 0; i < hash.length; i++) {
                 result += Integer.toString((hash[i] & 0xff) + 0x100, 16).substring(1);
             }
             return result;
-        }
-        catch (Exception e)
-        {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
         return null;
     }
 
-    public static String hash(String str)
-    {
-        try
-        {
+    public static String hash(String str) {
+        try {
             MessageDigest complete = MessageDigest.getInstance("MD5");
             byte[] hash = complete.digest(str.getBytes());
 
             String result = "";
 
-            for (int i = 0; i < hash.length; i++)
-            {
+            for (int i = 0; i < hash.length; i++) {
                 result += Integer.toString((hash[i] & 0xff) + 0x100, 16).substring(1);
             }
             return result;
-        }
-        catch (Exception e)
-        {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 
@@ -249,8 +218,7 @@ public class Constants
     /**
      * DON'T FORGET TO CLOSE
      */
-    public static OutputStream getNullStream()
-    {
+    public static OutputStream getNullStream() {
         return NULL_OUT;
     }
 }

--- a/src/main/java/net/minecraftforge/gradle/common/version/Version.java
+++ b/src/main/java/net/minecraftforge/gradle/common/version/Version.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import java.util.List;
 
 import net.minecraftforge.gradle.common.Constants;
+import net.minecraftforge.gradle.json.version.Downloads;
 
 public class Version
 {
@@ -19,6 +20,8 @@ public class Version
     public String incompatibilityReason;
     private String assets;
     public List<OSRule> rules;
+    public Downloads downloads;
+    public Downloads.DownloadFileInfo assetIndex;
     
     private List<Library> _libraries;
 

--- a/src/main/java/net/minecraftforge/gradle/common/version/json/JsonFactory.java
+++ b/src/main/java/net/minecraftforge/gradle/common/version/json/JsonFactory.java
@@ -13,6 +13,7 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonIOException;
 import com.google.gson.JsonSyntaxException;
+import net.minecraftforge.gradle.json.MCVersionManifest;
 
 public class JsonFactory
 {
@@ -40,6 +41,13 @@ public class JsonFactory
     {
         FileReader reader = new FileReader(json);
         AssetIndex a =  GSON.fromJson(reader, AssetIndex.class);
+        reader.close();
+        return a;
+    }
+
+    public static MCVersionManifest loadMCVersionManifest(File json) throws JsonSyntaxException, JsonIOException, IOException {
+        FileReader reader = new FileReader(json);
+        MCVersionManifest a = GSON.fromJson(reader, MCVersionManifest.class);
         reader.close();
         return a;
     }

--- a/src/main/java/net/minecraftforge/gradle/json/MCVersionManifest.java
+++ b/src/main/java/net/minecraftforge/gradle/json/MCVersionManifest.java
@@ -1,0 +1,32 @@
+package net.minecraftforge.gradle.json;
+
+import java.util.Date;
+import java.util.List;
+
+// format of https://piston-meta.mojang.com/mc/game/version_manifest.json
+public class MCVersionManifest {
+    public LatestInfo latest;
+    public List<Version> versions;
+
+    public Version findVersion(String versionId) {
+        for (Version v : versions) {
+            if (versionId.equals(v.id)) {
+                return v;
+            }
+        }
+        throw new IllegalArgumentException(versionId + " not found");
+    }
+
+    public static class LatestInfo {
+        public String release;
+        public String snapshot;
+    }
+
+    public static class Version {
+        public String id;
+        public String type;
+        public String url;
+        public Date time;
+        public Date releaseTime;
+    }
+}

--- a/src/main/java/net/minecraftforge/gradle/json/version/Downloads.java
+++ b/src/main/java/net/minecraftforge/gradle/json/version/Downloads.java
@@ -1,0 +1,14 @@
+package net.minecraftforge.gradle.json.version;
+
+
+public class Downloads {
+    public DownloadFileInfo client;
+    public DownloadFileInfo server;
+    public DownloadFileInfo windows_server;
+
+    public static class DownloadFileInfo {
+        public String sha1;
+        public long size;
+        public String url;
+    }
+}

--- a/src/main/java/net/minecraftforge/gradle/json/version/VersionToString.java
+++ b/src/main/java/net/minecraftforge/gradle/json/version/VersionToString.java
@@ -1,0 +1,7 @@
+package net.minecraftforge.gradle.json.version;
+
+import net.minecraftforge.gradle.common.version.Version;
+
+public interface VersionToString {
+    String apply(Version version);
+}

--- a/src/main/java/net/minecraftforge/gradle/tasks/GenSrgTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/GenSrgTask.java
@@ -62,6 +62,7 @@ public class GenSrgTask extends DefaultTask
         
         File deobfFile = getNotchToMcpSrg();
         File reobfFile = getMcpToSrgSrg();
+        File notchFile = getMcpToNotchSrg();
 
         // verify files...
         if (!deobfFile.exists())
@@ -73,6 +74,11 @@ public class GenSrgTask extends DefaultTask
         {
             reobfFile.getParentFile().mkdirs();
             reobfFile.createNewFile();
+        }
+        if (!notchFile.exists())
+        {
+            notchFile.getParentFile().mkdirs();
+            notchFile.createNewFile();
         }
         
         // create streams

--- a/src/main/java/net/minecraftforge/gradle/tasks/abstractutil/EtagDownloadTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/abstractutil/EtagDownloadTask.java
@@ -1,0 +1,135 @@
+package net.minecraftforge.gradle.tasks.abstractutil;
+
+import com.google.common.base.Strings;
+import com.google.common.io.ByteStreams;
+import groovy.lang.Closure;
+import net.minecraftforge.gradle.FileUtils;
+import net.minecraftforge.gradle.common.Constants;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.OutputFile;
+import org.gradle.api.tasks.TaskAction;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.*;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public class EtagDownloadTask extends DefaultTask {
+    Object uri;
+    Object file;
+    boolean dieWithError;
+
+    @TaskAction
+    public void doTask() throws IOException, URISyntaxException {
+        URI uri = getUri();
+        File outFile = getFile();
+        File etagFile = getProject().file(getFile().getPath() + ".etag");
+
+        // ensure folder exists
+        outFile.getParentFile().mkdirs();
+
+        String etag;
+        if (etagFile.exists()) {
+            etag = FileUtils.readString(etagFile);
+        } else {
+            etag = "";
+        }
+
+        try {
+            HttpURLConnection con = (HttpURLConnection) uri.toURL().openConnection();
+            con.setInstanceFollowRedirects(true);
+            con.setRequestProperty("User-Agent", Constants.USER_AGENT);
+            con.setRequestProperty("If-None-Match", etag);
+
+            con.connect();
+
+            switch (con.getResponseCode()) {
+                case 404: // file not found.... duh...
+                    error(uri + "  404'ed!");
+                    break;
+                case 304: // content is the same.
+                    this.setDidWork(false);
+                    break;
+                case 200: // worked
+
+                    // write file
+                    InputStream stream = con.getInputStream();
+                    Files.write(outFile.toPath(), ByteStreams.toByteArray(stream));
+                    stream.close();
+
+                    // write etag
+                    etag = con.getHeaderField("ETag");
+                    if (!Strings.isNullOrEmpty(etag)) {
+                        Files.write(etagFile.toPath(), etag.getBytes(StandardCharsets.UTF_8));
+                    }
+
+                    break;
+                default: // another code?? uh..
+                    error("Unexpected reponse " + con.getResponseCode() + " from " + uri);
+                    break;
+            }
+
+            con.disconnect();
+        } catch (Throwable e) {
+            // just in case people dont have internet at the moment.
+            error(e.getLocalizedMessage());
+        }
+    }
+
+    private void error(String error) {
+        if (dieWithError) {
+            throw new RuntimeException(error);
+        } else {
+            getLogger().error(error);
+        }
+    }
+
+    @Deprecated
+    public URL getUrl() throws MalformedURLException {
+        try {
+            return getUri().toURL();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Deprecated
+    public void setUrl(Object url) {
+        this.setUri(url);
+    }
+
+    @Input
+    public URI getUri() throws URISyntaxException {
+        while (uri instanceof Closure<?>) {
+            uri = ((Closure<?>) uri).call();
+        }
+
+        return new URI(uri.toString());
+    }
+
+    public void setUri(Object url) {
+        this.uri = url;
+    }
+
+    @OutputFile
+    public File getFile() {
+        return getProject().file(file);
+    }
+
+    public void setFile(Object file) {
+        this.file = file;
+    }
+
+    @Input
+    public boolean isDieWithError() {
+        return dieWithError;
+    }
+
+    public void setDieWithError(boolean dieWithError) {
+        this.dieWithError = dieWithError;
+    }
+}
+

--- a/src/main/java/net/minecraftforge/gradle/tasks/dev/ObfuscateTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/dev/ObfuscateTask.java
@@ -89,7 +89,8 @@ public class ObfuscateTask extends DefaultTask
     {
         for (Object dep : task.getTaskDependencies().getDependencies(task))
         {
-            executeTask((AbstractTask) dep);
+            if (dep instanceof AbstractTask)
+                executeTask((AbstractTask) dep);
         }
 
         if (!task.getState().getExecuted())


### PR DESCRIPTION
## Changes
- **Asset Download Fix**:
    - Replaced the legacy asset downloading logic with the current **Mojang API** implementation.
    - This fix is backported and adapted from [anatawa12/ForgeGradle-1.2](https://github.com/anatawa12/ForgeGradle-1.2).
    
## Testing Performed
- [x] Executed `./gradlew build and successfully