### PR TITLE
Add helper methods to access files inside zip files

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation libs.maven.artifact
     implementation libs.bundles.utils
     implementation libs.srgutils
+    implementation libs.toml
 }
 
 license {

--- a/settings.gradle
+++ b/settings.gradle
@@ -56,5 +56,8 @@ dependencyResolutionManagement.versionCatalogs.register('libs') {
 
     // Used to compare Minecraft Versions
     library 'srgutils', 'net.minecraftforge', 'srgutils' version '0.6.5'
+
+    // Used to parse mods.toml to locate access transformer locations
+    library 'toml', 'com.github.jezza', 'toml' version '1.2'
 }
 //@formatter:on

--- a/src/main/java/net/minecraftforge/gradle/ForgeGradleExtensionForProject.java
+++ b/src/main/java/net/minecraftforge/gradle/ForgeGradleExtensionForProject.java
@@ -11,10 +11,47 @@ import org.gradle.api.file.FileCollection;
 ///
 /// @see ForgeGradleExtension
 public interface ForgeGradleExtensionForProject extends ForgeGradleExtension {
-    FileCollection mapZip(Object files, String name);
-    FileCollection mapZip(FileCollection files, String name);
-    FileCollection mapAccessTransformer(Object files);
-    FileCollection mapAccessTransformer(FileCollection files);
-    FileCollection mapFacades(Object files);
-    FileCollection mapFacades(FileCollection files);
+    /// Attempts to locate and extract a file inside archives.
+    /// @param files The files to search, accepts anything that can be passed to {@link org.gradle.api.Project#files(Object...)}
+    /// @param name The exact name to search for in archives
+    FileCollection findFiles(Object files, String name);
+
+    /// Attempts to locate and extract a file inside archives.
+    /// @param files The files to search, any non-archives (zip, or jar) will be ignored
+    /// @param name The exact name to search for in archives
+    FileCollection findFiles(FileCollection files, String name);
+
+    /// Attempts to locate and extract any Access Transformer configurations from archives.
+    /// Configurations will be located via:
+    ///   - A Space Separated list in the Manifest entry `FMLAT`
+    ///   - The `mods.accessTransformers` entry in mods.toml a configuration file
+    ///   - The default location of META-INF/accesstransformer.cfg
+    ///
+    /// @param files The files to search, accepts anything that can be passed to {@link org.gradle.api.Project#files(Object...)}
+    FileCollection findAccessTransformers(Object files);
+
+    /// Attempts to locate and extract any Access Transformer configurations from archives.
+    /// Configurations will be located via:
+    ///   - A Space Separated list in the Manifest entry `FMLAT`
+    ///   - The `mods.accessTransformers` entry in mods.toml a configuration file
+    ///   - The default location of META-INF/accesstransformer.cfg
+    ///
+    /// @param files The files to search, any non-archives (zip, or jar) will be ignored
+    FileCollection findAccessTransformers(FileCollection files);
+
+    /// Attempts to locate and extract any Facade configurations from archives.
+    /// Configurations will be located via:
+    ///   - A Space Separated list in the Manifest entry `FORGE_FACADE`
+    ///   - The default location of META-INF/facades.cfg
+    ///
+    /// @param files The files to search, accepts anything that can be passed to {@link org.gradle.api.Project#files(Object...)}
+    FileCollection findFacades(Object files);
+
+    /// Attempts to locate and extract any Facade configurations from archives.
+    /// Configurations will be located via:
+    ///   - A Space Separated list in the Manifest entry `FORGE_FACADE`
+    ///   - The default location of META-INF/facades.cfg
+    ///
+    /// @param files The files to search, any non-archives (zip, or jar) will be ignored
+    FileCollection findFacades(FileCollection files);
 }

--- a/src/main/java/net/minecraftforge/gradle/ForgeGradleExtensionForProject.java
+++ b/src/main/java/net/minecraftforge/gradle/ForgeGradleExtensionForProject.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) Forge Development LLC and contributors
+ * SPDX-License-Identifier: LGPL-2.1-only
+ */
+package net.minecraftforge.gradle;
+
+import org.gradle.api.file.FileCollection;
+
+/// [Project][org.gradle.api.Project]-specific additions for the ForgeGradle extension. These will be accessible from the
+/// `fg` DSL object within your project's buildscript.
+///
+/// @see ForgeGradleExtension
+public interface ForgeGradleExtensionForProject extends ForgeGradleExtension {
+    FileCollection mapZip(Object files, String name);
+    FileCollection mapZip(FileCollection files, String name);
+    FileCollection mapAccessTransformer(Object files);
+    FileCollection mapAccessTransformer(FileCollection files);
+    FileCollection mapFacades(Object files);
+    FileCollection mapFacades(FileCollection files);
+}

--- a/src/main/java/net/minecraftforge/gradle/internal/ForgeGradleExtensionImpl.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/ForgeGradleExtensionImpl.java
@@ -68,7 +68,7 @@ abstract class ForgeGradleExtensionImpl implements ForgeGradleExtensionInternal 
 
         @Override
         public FileCollection findFiles(FileCollection files, String name) {
-            return mapJar(files, (file, jar) -> List.of(jar.getEntry(name)));
+            return findFilesInArchives(files, (file, jar) -> List.of(jar.getEntry(name)));
         }
 
         @Override
@@ -78,7 +78,7 @@ abstract class ForgeGradleExtensionImpl implements ForgeGradleExtensionInternal 
 
         @Override
         public FileCollection findAccessTransformers(FileCollection files) {
-            return mapJar(files, this::findAccessTransformer);
+            return findFilesInArchives(files, this::findAccessTransformer);
         }
 
         @Override
@@ -88,10 +88,10 @@ abstract class ForgeGradleExtensionImpl implements ForgeGradleExtensionInternal 
 
         @Override
         public FileCollection findFacades(FileCollection files) {
-            return mapJar(files, this::findFacades);
+            return findFilesInArchives(files, this::findFacades);
         }
 
-        private FileCollection mapJar(FileCollection files, BiFunction<File, JarFile, List<? extends ZipEntry>> filter) {
+        private FileCollection findFilesInArchives(FileCollection files, BiFunction<File, JarFile, List<? extends ZipEntry>> filter) {
             var root = this.plugin.localCaches().dir("zip_data");
             return this.project.files(this.project.provider(() -> {
                 var ret = new ArrayList<File>();

--- a/src/main/java/net/minecraftforge/gradle/internal/ForgeGradleExtensionImpl.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/ForgeGradleExtensionImpl.java
@@ -5,10 +5,28 @@
 package net.minecraftforge.gradle.internal;
 
 import net.minecraftforge.gradle.ForgeGradleExtension;
+import net.minecraftforge.gradle.ForgeGradleExtensionForProject;
+import net.minecraftforge.util.hash.HashFunction;
+import org.gradle.api.Project;
+import org.gradle.api.file.FileCollection;
 import org.gradle.api.plugins.ExtensionAware;
 import org.gradle.api.reflect.TypeOf;
 
 import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.BiFunction;
+import java.util.jar.JarFile;
+import java.util.zip.ZipEntry;
+
+import com.github.jezza.Toml;
+import com.github.jezza.TomlArray;
+import com.github.jezza.TomlTable;
+import org.jspecify.annotations.Nullable;
 
 abstract class ForgeGradleExtensionImpl implements ForgeGradleExtensionInternal {
     static void register(
@@ -16,8 +34,14 @@ abstract class ForgeGradleExtensionImpl implements ForgeGradleExtensionInternal 
         ExtensionAware target
     ) {
         var extensions = target.getExtensions();
-        extensions.create(ForgeGradleExtension.class, ForgeGradleExtension.NAME, ForgeGradleExtensionImpl.class);
+        if (target instanceof Project project) {
+            extensions.create(ForgeGradleExtensionForProject.class, ForgeGradleExtension.NAME, ForgeGradleExtensionImpl.ForProjectImpl.class, plugin, project);
+        } else {
+            extensions.create(ForgeGradleExtension.class, ForgeGradleExtension.NAME, ForgeGradleExtensionImpl.class);
+        }
     }
+
+
 
     @Inject
     public ForgeGradleExtensionImpl() { }
@@ -25,5 +49,172 @@ abstract class ForgeGradleExtensionImpl implements ForgeGradleExtensionInternal 
     @Override
     public TypeOf<?> getPublicType() {
         return ForgeGradleExtensionInternal.super.getPublicType();
+    }
+
+    static abstract class ForProjectImpl extends ForgeGradleExtensionImpl implements ForgeGradleExtensionForProject {
+        private final ForgeGradlePlugin plugin;
+        private final Project project;
+
+        @Inject
+        public ForProjectImpl(ForgeGradlePlugin plugin, Project project) {
+            this.plugin = plugin;
+            this.project = project;
+        }
+
+        @Override
+        public FileCollection mapZip(Object files, String name) {
+            return mapZip(this.project.files(files), name);
+        }
+
+        @Override
+        public FileCollection mapZip(FileCollection files, String name) {
+            return mapJar(files, (file, jar) -> List.of(jar.getEntry(name)));
+        }
+
+        @Override
+        public FileCollection mapAccessTransformer(Object files) {
+            return mapAccessTransformer(this.project.files(files));
+        }
+
+        @Override
+        public FileCollection mapAccessTransformer(FileCollection files) {
+            return mapJar(files, this::findAccessTransformer);
+        }
+
+        @Override
+        public FileCollection mapFacades(Object files) {
+            return mapFacades(this.project.files(files));
+        }
+
+        @Override
+        public FileCollection mapFacades(FileCollection files) {
+            return mapJar(files, this::findFacades);
+        }
+
+        private FileCollection mapJar(FileCollection files, BiFunction<File, JarFile, List<? extends ZipEntry>> filter) {
+            var root = this.plugin.localCaches().dir("zip_data");
+            return this.project.files(this.project.provider(() -> {
+                var ret = new ArrayList<File>();
+                for (var file : files) {
+                    var fileName = file.getName().toLowerCase(Locale.ENGLISH);
+                    if (!fileName.endsWith(".zip") && !fileName.endsWith(".jar"))
+                        continue;
+
+                    // We use jar file so that we can grab the manifest, for zip files it'll just be an empty manifest
+                    try (var jar = new JarFile(file)) {
+                        var entries = filter.apply(file, jar);
+                        if (entries == null || entries.isEmpty())
+                            continue;
+
+                        var hash = HashFunction.SHA1.hash(file);
+                        var prefix = file.getName().substring(0, file.getName().length() - 4);
+                        var dir = root.map(d -> d.dir(hash).dir(prefix)).get().getAsFile().getAbsoluteFile();
+
+                        for (var entry : entries) {
+                            var name = entry.getName();
+                            var target = new File(dir, name.replace('/', File.separatorChar)).getAbsoluteFile();
+                            //this.project.getLogger().lifecycle("Root: " + dir.toString() + File.separatorChar);
+                            //this.project.getLogger().lifecycle("      " + target.toString());
+                            if (!target.toString().startsWith(dir.toString() + File.separatorChar))
+                                throw new IllegalArgumentException("Invalid file " + name);
+
+                            // We've already extracted, assume it's correct. Could check hash, but we do for the input file, so should be fine.
+                            // This is also not thread safe, but that's more work than I think we need.
+                            if (!target.exists()) {
+                                var parent = target.getParentFile();
+                                if (!parent.exists() && !parent.mkdirs())
+                                    throw new IllegalStateException("Could not create directory " + parent.getAbsolutePath());
+                                try (var input = jar.getInputStream(entry)) {
+                                    Files.copy(input, target.toPath());
+                                }
+                            }
+                            ret.add(target);
+                        }
+                    }
+                }
+                return ret;
+            }));
+        }
+
+
+        private static final String MODS_TOML = "META-INF/mods.toml";
+        private static final String ACCESS_TRANSFORMER = "META-INF/accesstransformer.cfg";
+        private static final java.util.jar.Attributes.Name FMLAT = new java.util.jar.Attributes.Name("FMLAT");
+
+        private List<ZipEntry> findAccessTransformer(File file, JarFile jar) {
+            var ret = new ArrayList<ZipEntry>();
+
+            boolean hasCustom = false;
+            var configs = manifest(file, jar, FMLAT);
+            if (configs != null) {
+                for (var cfg : configs)
+                    add(ret, jar, "META-INF/" + cfg);
+                hasCustom = true;
+            }
+
+            var tomlEntry = jar.getEntry(MODS_TOML);
+            if (tomlEntry != null) {
+                try (var input = jar.getInputStream(tomlEntry)) {
+                    TomlTable toml = Toml.from(input);
+                    if (toml.get("mods") instanceof TomlArray mods) {
+                        for (Object mod : mods) {
+                            if (mod instanceof TomlTable table) {
+                                Object ats = table.get("accessTransformers");
+                                if (ats instanceof String string) {
+                                    for (var at : string.split(","))
+                                        add(ret, jar, at);
+                                    hasCustom = true;
+                                } else if (ats instanceof TomlArray array) {
+                                    for (Object at : array)
+                                        add(ret, jar, (String)at);
+                                    hasCustom = true;
+                                }
+                            }
+                        }
+                    }
+                } catch (IOException | ClassCastException e) {
+                    this.project.getLogger().info("Failed to parse mods.toml from {}", file.getAbsolutePath(), e);
+                }
+            }
+
+            if (!hasCustom)
+                add(ret, jar, ACCESS_TRANSFORMER);
+
+            return ret;
+        }
+
+        private static final java.util.jar.Attributes.Name FORGE_FACADE = new java.util.jar.Attributes.Name("FORGE_FACADE");
+        private static final String FACADES = "META-INF/facades.cfg";
+        private List<ZipEntry> findFacades(File file, JarFile jar) {
+            var ret = new ArrayList<ZipEntry>();
+
+            var configs = manifest(file, jar, FORGE_FACADE);
+            if (configs != null) {
+                for (var cfg : configs)
+                    add(ret, jar, "META-INF/" + cfg);
+            } else {
+                add(ret, jar, FACADES);
+            }
+
+            return ret;
+        }
+
+        private String @Nullable[] manifest(File file, JarFile jar, java.util.jar.Attributes.Name name) {
+            try {
+                var configs = (String)jar.getManifest().getMainAttributes().get(name);
+                if (configs == null)
+                    return null;
+                return configs.split(" ");
+            } catch (IOException e) {
+                this.project.getLogger().warn("Unable to read MANIFEST.MF file: {}", file.getAbsolutePath(), e);
+                return null;
+            }
+        }
+
+        private static void add(List<ZipEntry> ret, JarFile jar, String path) {
+            var entry = jar.getEntry(path);
+            if (entry != null)
+                ret.add(entry);
+        }
     }
 }

--- a/src/main/java/net/minecraftforge/gradle/internal/ForgeGradleExtensionImpl.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/ForgeGradleExtensionImpl.java
@@ -62,32 +62,32 @@ abstract class ForgeGradleExtensionImpl implements ForgeGradleExtensionInternal 
         }
 
         @Override
-        public FileCollection mapZip(Object files, String name) {
-            return mapZip(this.project.files(files), name);
+        public FileCollection findFiles(Object files, String name) {
+            return findFiles(this.project.files(files), name);
         }
 
         @Override
-        public FileCollection mapZip(FileCollection files, String name) {
+        public FileCollection findFiles(FileCollection files, String name) {
             return mapJar(files, (file, jar) -> List.of(jar.getEntry(name)));
         }
 
         @Override
-        public FileCollection mapAccessTransformer(Object files) {
-            return mapAccessTransformer(this.project.files(files));
+        public FileCollection findAccessTransformers(Object files) {
+            return findAccessTransformers(this.project.files(files));
         }
 
         @Override
-        public FileCollection mapAccessTransformer(FileCollection files) {
+        public FileCollection findAccessTransformers(FileCollection files) {
             return mapJar(files, this::findAccessTransformer);
         }
 
         @Override
-        public FileCollection mapFacades(Object files) {
-            return mapFacades(this.project.files(files));
+        public FileCollection findFacades(Object files) {
+            return findFacades(this.project.files(files));
         }
 
         @Override
-        public FileCollection mapFacades(FileCollection files) {
+        public FileCollection findFacades(FileCollection files) {
             return mapJar(files, this::findFacades);
         }
 

--- a/src/main/java/net/minecraftforge/gradle/internal/ForgeGradleExtensionImpl.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/ForgeGradleExtensionImpl.java
@@ -161,8 +161,10 @@ abstract class ForgeGradleExtensionImpl implements ForgeGradleExtensionInternal 
                             if (mod instanceof TomlTable table) {
                                 Object ats = table.get("accessTransformers");
                                 if (ats instanceof String string) {
-                                    for (var at : string.split(","))
-                                        add(ret, jar, at);
+                                    if (!string.isEmpty()) {
+                                        for (var at : string.split(","))
+                                            add(ret, jar, at);
+                                    }
                                     hasCustom = true;
                                 } else if (ats instanceof TomlArray array) {
                                     for (Object at : array)
@@ -204,7 +206,7 @@ abstract class ForgeGradleExtensionImpl implements ForgeGradleExtensionInternal 
                 var configs = (String)jar.getManifest().getMainAttributes().get(name);
                 if (configs == null)
                     return null;
-                return configs.split(" ");
+                return configs.isEmpty() ? new String[0] : configs.split(" ");
             } catch (IOException e) {
                 this.project.getLogger().warn("Unable to read MANIFEST.MF file: {}", file.getAbsolutePath(), e);
                 return null;

--- a/src/main/java/net/minecraftforge/gradle/internal/ForgeGradleProblems.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/ForgeGradleProblems.java
@@ -317,6 +317,18 @@ abstract class ForgeGradleProblems extends EnhancedProblems {
             .solution(HELP_MESSAGE)
         );
     }
+    void reportInvalidAccessTransformerConfig(String path) {
+        this.report("invalid-at-config", "Invalid Access Transformer config file", spec -> spec
+            .details("""
+            Attempted to use a jar or zip as a facade config, which must be text files. 
+            You most likely are trying to use a config from a dependency.
+            Use fg.findAccessTransformers() to map FileCollections to their configs.
+            Config Path:\s""" + path)
+            .severity(Severity.ERROR)
+            .solution("Extract the Access Transformer config from the dependency using fg.findAccessTransformer().")
+            .solution("Remove Access Transformer config if not needed.")
+            .solution(HELP_MESSAGE));
+    }
     //endregion
 
     //region Facades
@@ -329,6 +341,18 @@ abstract class ForgeGradleProblems extends EnhancedProblems {
             Configured Version:\s""" + dependency)
             .severity(Severity.ERROR)
             .solution("Update mavenizer to >=" + Constants.Mavenizer.SUPPORTS_FACADES + " or remove manual override.")
+            .solution("Remove Facade config if not needed.")
+            .solution(HELP_MESSAGE));
+    }
+    void reportInvalidFacadeConfig(String path) {
+        this.report("invalid-facade-config", "Invalid Facade config file", spec -> spec
+            .details("""
+            Attempted to use a jar or zip as a facade config, which must be text files. 
+            You most likely are trying to use a config from a dependency.
+            Use fg.findFacades() to map FileCollections to their configs.
+            Config Path:\s""" + path)
+            .severity(Severity.ERROR)
+            .solution("Extract the facade config from the dependency using fg.findFacades().")
             .solution("Remove Facade config if not needed.")
             .solution(HELP_MESSAGE));
     }

--- a/src/main/java/net/minecraftforge/gradle/internal/MinecraftExtensionImpl.java
+++ b/src/main/java/net/minecraftforge/gradle/internal/MinecraftExtensionImpl.java
@@ -451,9 +451,14 @@ abstract class MinecraftExtensionImpl implements MinecraftExtensionInternal {
                         minecraftDependency.finalizeAccessTransformers(sourceSets);
 
                         for (var at : minecraftDependency.getAccessTransformer()) {
+                            var path = at.getAbsolutePath();
                             //System.out.println("Access Transformer: " + at);
-                            ret.add("--access-transformer");
-                            ret.add(at.getAbsolutePath());
+                            if (path.endsWith(".zip") || path.endsWith(".jar"))
+                                this.problems.reportInvalidAccessTransformerConfig(path);
+                            else {
+                                ret.add("--access-transformer");
+                                ret.add(at.getAbsolutePath());
+                            }
                         }
 
                         var mappings = minecraftDependency.getMappings();
@@ -482,8 +487,13 @@ abstract class MinecraftExtensionImpl implements MinecraftExtensionInternal {
                                 problems.reportFacadesNotSupported(tool.getModule().toString());
                             } else {
                                 for (var cfg : minecraftDependency.getFacade()) {
-                                    ret.add("--facade-config");
-                                    ret.add(cfg.getAbsolutePath());
+                                    var path = cfg.getAbsolutePath();
+                                    if (path.endsWith(".zip") || path.endsWith(".jar"))
+                                        this.problems.reportInvalidFacadeConfig(path);
+                                    else {
+                                        ret.add("--facade-config");
+                                        ret.add(cfg.getAbsolutePath());
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
This is a first draft of what I had in mind for addressing #1080
This just adds helper methods for converting a FileCollection of archives, to a FileCollection of files from those archives.

Example usages (untested, but should work):

```groovy
configurations {
  mods
  implementation.extendsFrom mods
}

dependencies {
  mods renamer.dependency(libs.modA)
  mods renamer.dependency(libs.modB)

  implementation minecraft.dependency(forge) {
    facades.setFrom(files(
        'src/main/resources/META-INF/facades.cfg',
        fg.findFacades(configurations.mods)
    ))
    accessTransformers.setFrom(files(
        'src/main/resources/META-INF/at.cfg',
        fg.findAccessTransformers(configurations.mods)
    ))
  }
}
```

Its fairly generic, so you can do something like this:
```groovy
configurations {
    sharedLibs
}

dependencies {
    sharedLibs 'org.json:json:20260719'
}
fg.findFiles(configurations.sharedLibs, 'META-INF/MANIFEST.MF').forEach { 
  file -> logger.lifecycle('File: ' + file.absolutePath) 
}
```
Outputs a nice:
`File: Z:\test\_test\build\minecraftforge\forgegradle\zip_data\82390308e0b67205bf0d0d507dc48e0d71410bf7\json-20260719\META-INF\MANIFEST.MF`


In addition this defacto standardizes the Facade files in deps to:
A space separated list in the `FORGE_FACADE` manifest attribute OR `META-INF/facades.cfg`

Javadocs need to be written.
Do you think I should promote the `BiFunction<File, JarFile, List<ZipEntry>>` to a proper `EntryFinder` interface and expose a `mapZip(FileCollection, EntryFinder)`?

Adding support for the access transformer helper requires parsing the mods.toml, as such I have to add a TOML dependency, so I add [Jezza Toml](https://github.com/Jezza/toml) which adds ~30kb to the jar. Same library I use for Renamer.


The functions that take Object instead of FileCollection just pass it directly to `project.files` as a small helper to make cleaner build files.

`findFiles(files, name)` just grabs the explicit file from any archive that has it
`findAccessTransformers(files)` tries to find ATs from the manifest, toml, and default location
`findFacace(files)` tries to find the facade config from the manifest, or default location